### PR TITLE
Make commands compatible with the help map

### DIFF
--- a/AdvancedCore/src/com/bencodez/advancedcore/command/executor/ValueRequestInputCommand.java
+++ b/AdvancedCore/src/com/bencodez/advancedcore/command/executor/ValueRequestInputCommand.java
@@ -3,19 +3,25 @@ package com.bencodez.advancedcore.command.executor;
 import java.util.ArrayList;
 
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.defaults.BukkitCommand;
+import org.bukkit.command.Command;
+import org.bukkit.command.PluginIdentifiableCommand;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.command.CommandHandler;
 
-public class ValueRequestInputCommand extends BukkitCommand {
-	private AdvancedCorePlugin plugin;
+public class ValueRequestInputCommand extends Command implements PluginIdentifiableCommand {
+	private final AdvancedCorePlugin plugin;
 
 	public ValueRequestInputCommand(AdvancedCorePlugin plugin, String name) {
 		super(name);
 		this.plugin = plugin;
 		description = "ValueRequestInput";
 		setAliases(new ArrayList<String>());
+	}
+
+	@Override
+	public Plugin getPlugin() {
+		return plugin;
 	}
 
 	@Override


### PR DESCRIPTION
I've made 2 changes to improve compatibility with the help map:
1. Extend Command instead of BukkitCommand. Bukkit only expects itself to use `BukkitCommand`.
2. Implement PluginIdentifiableCommand

For context, the HelpMap display it does this:

```java
    private String getCommandPluginName(Command command) {
        if (command instanceof VanillaCommandWrapper) {
            return "Minecraft";
        }
        if (command instanceof BukkitCommand) {
            return "Bukkit";
        }
        if (command instanceof PluginIdentifiableCommand) {
            return ((PluginIdentifiableCommand)command).getPlugin().getName();
        }
        return null;
    }
```

Excuse the line breaks - that always happens to myself and my colleagues.