### PR TITLE
Add compatibility with older versions of bungeechat

### DIFF
--- a/AdvancedCore/.gitignore
+++ b/AdvancedCore/.gitignore
@@ -1,2 +1,4 @@
 /bin/
 /target/
+/.idea/
+/*.iml

--- a/AdvancedCore/pom.xml
+++ b/AdvancedCore/pom.xml
@@ -193,7 +193,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.2</version>
+			<version>1.18.20</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/AdvancedCore/src/com/bencodez/advancedcore/api/messages/HoverEventSupport.java
+++ b/AdvancedCore/src/com/bencodez/advancedcore/api/messages/HoverEventSupport.java
@@ -1,0 +1,18 @@
+package com.bencodez.advancedcore.api.messages;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.HoverEvent;
+
+interface HoverEventSupport {
+
+    HoverEvent createHoverEvent(BaseComponent[] value);
+
+    static HoverEventSupport findInstance() {
+        try {
+            Class.forName("net.md_5.bungee.api.chat.hover.content.Content");
+            return new HoverEventSupport16();
+        } catch (ClassNotFoundException ignored) {
+            return new HoverEventSupport15();
+        }
+    }
+}

--- a/AdvancedCore/src/com/bencodez/advancedcore/api/messages/HoverEventSupport15.java
+++ b/AdvancedCore/src/com/bencodez/advancedcore/api/messages/HoverEventSupport15.java
@@ -1,0 +1,14 @@
+package com.bencodez.advancedcore.api.messages;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.HoverEvent;
+
+final class HoverEventSupport15 implements HoverEventSupport {
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public HoverEvent createHoverEvent(BaseComponent[] value) {
+        return new HoverEvent(HoverEvent.Action.SHOW_TEXT, value);
+    }
+
+}

--- a/AdvancedCore/src/com/bencodez/advancedcore/api/messages/HoverEventSupport16.java
+++ b/AdvancedCore/src/com/bencodez/advancedcore/api/messages/HoverEventSupport16.java
@@ -1,0 +1,14 @@
+package com.bencodez.advancedcore.api.messages;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+
+final class HoverEventSupport16 implements HoverEventSupport {
+
+    @Override
+    public HoverEvent createHoverEvent(BaseComponent[] value) {
+        return new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(value));
+    }
+
+}

--- a/AdvancedCore/src/com/bencodez/advancedcore/api/messages/StringParser.java
+++ b/AdvancedCore/src/com/bencodez/advancedcore/api/messages/StringParser.java
@@ -17,20 +17,21 @@ import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.api.chat.hover.content.Text;
+import net.md_5.bungee.api.chat.BaseComponent;
 
 public class StringParser {
-	private static StringParser instance = new StringParser();
+	private static final StringParser instance = new StringParser();
 
-	public static StringParser getInstance() {
-		return instance;
-	}
+	private static final HoverEventSupport hoverEventSupport = HoverEventSupport.findInstance();
 
 	public final char COLOR_CHAR = ChatColor.COLOR_CHAR;
 
 	private StringParser() {
+	}
+
+	public static StringParser getInstance() {
+		return instance;
 	}
 
 	/**
@@ -175,7 +176,8 @@ public class StringParser {
 				}
 
 				if (type.equalsIgnoreCase("hover")) {
-					t.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(typeData)));
+					BaseComponent[] hoverContent = TextComponent.fromLegacyText(typeData);
+					t.setHoverEvent(hoverEventSupport.createHoverEvent(hoverContent));
 				} else if (type.equalsIgnoreCase("command")) {
 					t.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, typeData));
 				} else if (type.equalsIgnoreCase("url")) {


### PR DESCRIPTION
This fixes support for versions below 1.15, where net.md_5.bungee.api.chat.hover.content.Content does not exist.

Some points of note:
* If you don't mind, I've bumped the version of lombok so I can develop with JDK 16.
* I've followed the surrounding code convention in making hoverEventSupport lowerCamelCase, even though SNAKE_CASE is usually used for constants.
* I modified the .gitignore to exclude Intellij project files. I suggest you remove the Eclipse project files at some point. IDE-specific files don't belong in the source repo.


---------------------------------------------------------

Explanation behind this PR:

AdvancedCore depends on `net.md_5.bungee.api.chat.hover.content.Text` which was introduced in the 1.16 version of bungee-chat. Previously, VotingPlugin shaded bungee-chat, which meant that this class would always exist. Shading net.md_5.bungee.api.chat has its own associated bugs, though, so for good reason, that is no longer happening.

What has to be done is AdvancedCore has to use a different approach on pre-1.16 versions in order to maintain compatibility, using the other HoverEvent constructor. The 1.16 API uses net.md_5.bungee.api.chat.hover.content.Content whereas the 1.15 API, which is now deprecated, uses BaseComponent[] directly.

There are two solutions, really:
1. Use the 1.16 hover event API on 1.16+ and the old hover event API on 1.15-
2. Use the old hover event API always, and hope it isn't removed in a future release.

This PR chooses solution 1 because it is the most resilient with respect to future versions of the bungeechat API.