### PR TITLE
Handle reward permission check for offline player

### DIFF
--- a/AdvancedCore/src/com/bencodez/advancedcore/api/misc/PlayerUtils.java
+++ b/AdvancedCore/src/com/bencodez/advancedcore/api/misc/PlayerUtils.java
@@ -351,15 +351,21 @@ public class PlayerUtils {
 	/**
 	 * Checks for server permission.
 	 *
-	 * @param playerName the player name
+	 * @param playerUUID the player UUID
 	 * @param perm       the perm
 	 * @return true, if successful
 	 */
-	public boolean hasServerPermission(String playerName, String perm) {
-		if (playerName == null) {
+	public boolean hasServerPermission(UUID playerUUID, String perm) {
+		if (playerUUID == null) {
 			return false;
 		}
-		Player player = Bukkit.getPlayer(playerName);
+
+		if (AdvancedCorePlugin.getInstance().getOptions().isUseVaultPermissions() && plugin.getPerms() != null
+				&& plugin.getPerms().isEnabled()) {
+			return plugin.getPerms().playerHas(Bukkit.getWorlds().get(0).getName(), Bukkit.getOfflinePlayer(playerUUID), perm);
+		}
+
+		Player player = Bukkit.getPlayer(playerUUID);
 		if (player != null) {
 			return player.hasPermission(perm);
 		}

--- a/AdvancedCore/src/com/bencodez/advancedcore/api/rewards/RewardHandler.java
+++ b/AdvancedCore/src/com/bencodez/advancedcore/api/rewards/RewardHandler.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TimerTask;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Bukkit;
@@ -614,7 +615,7 @@ public class RewardHandler {
 					str = "AdvancedCore.Reward." + reward.getName();
 				}
 
-				boolean perm = PlayerUtils.getInstance().hasServerPermission(user.getPlayerName(), str);
+				boolean perm = PlayerUtils.getInstance().hasServerPermission(UUID.fromString(user.getUUID()), str);
 				if (!perm) {
 					plugin.getLogger().info(user.getPlayerName() + " does not have permission " + str
 							+ " to get reward " + reward.getName());


### PR DESCRIPTION
The reward permission check always returns false when a reward is executed on an offline player. This makes sure to use Vault, when available, instead of Bukkit default system. This will return the correct permission when using a modern permission plugin.