### PR TITLE
Ignore generated direct reward files in conflict check

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardHandler.java
@@ -346,8 +346,7 @@ public class RewardHandler {
 		}
 
 		for (SubDirectlyDefinedReward direct : getSubDirectlyDefinedRewards()) {
-			if (direct.getFullPath().equalsIgnoreCase(reward)
-					|| direct.getFullPath().equalsIgnoreCase(reward.replaceAll("_", "."))) {
+			if (matchesSubDirectlyDefined(direct, reward)) {
 				plugin.debug("Using subdirectlydefined reward for: " + reward);
 				return direct.getReward();
 			}
@@ -452,8 +451,7 @@ public class RewardHandler {
 
 	public SubDirectlyDefinedReward getSubDirectlyDefined(String path) {
 		for (SubDirectlyDefinedReward direct : getSubDirectlyDefinedRewards()) {
-			if (direct.getFullPath().equalsIgnoreCase(path)
-					|| direct.getFullPath().equalsIgnoreCase(path.replaceAll("_", "."))) {
+			if (matchesSubDirectlyDefined(direct, path)) {
 				return direct;
 			}
 		}
@@ -594,12 +592,17 @@ public class RewardHandler {
 		}
 
 		for (SubDirectlyDefinedReward direct : getSubDirectlyDefinedRewards()) {
-			if (direct.getFullPath().equalsIgnoreCase(reward)
-					|| direct.getFullPath().equalsIgnoreCase(reward.replaceAll("_", "."))) {
+			if (matchesSubDirectlyDefined(direct, reward)) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	private boolean matchesSubDirectlyDefined(SubDirectlyDefinedReward direct, String reward) {
+		return direct.getFullPath().equalsIgnoreCase(reward)
+				|| direct.getFullPath().replace(".", "_").equalsIgnoreCase(reward)
+				|| direct.getFullPath().equalsIgnoreCase(reward.replaceAll("_", "."));
 	}
 
 	public boolean hasRewards(FileConfiguration data, String path) {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardHandlerTest.java
@@ -1,0 +1,80 @@
+package com.bencodez.advancedcore.tests.rewards;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.logging.Logger;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.rewards.DirectlyDefinedReward;
+import com.bencodez.advancedcore.api.rewards.RewardHandler;
+import com.bencodez.advancedcore.api.rewards.SubDirectlyDefinedReward;
+
+public class RewardHandlerTest {
+
+	@TempDir
+	File tempDir;
+
+	private RewardHandler rewardHandler;
+
+	@BeforeEach
+	public void setUp() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		when(plugin.getDataFolder()).thenReturn(tempDir);
+		when(plugin.getLogger()).thenReturn(mock(Logger.class));
+
+		rewardHandler = new RewardHandler(plugin);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		rewardHandler.getDelayedTimer().shutdownNow();
+	}
+
+	@Test
+	public void getSubDirectlyDefinedMatchesFileStylePathWithUnderscoresInParentName() {
+		rewardHandler.getSubDirectlyDefinedRewards()
+				.add(new SubDirectlyDefinedReward(directlyDefinedReward("Test_Rewards_Name"), "Rewards"));
+
+		assertNotNull(rewardHandler.getSubDirectlyDefined("Test_Rewards_Name_Rewards"));
+	}
+
+	@Test
+	public void hasDirectRewardHandleMatchesSubRewardWithUnderscoresInParentName() {
+		rewardHandler.getSubDirectlyDefinedRewards()
+				.add(new SubDirectlyDefinedReward(directlyDefinedReward("Test_Rewards_Name"), "Rewards"));
+
+		assertTrue(rewardHandler.hasDirectRewardHandle("Test_Rewards_Name_Rewards"));
+	}
+
+	private DirectlyDefinedReward directlyDefinedReward(String path) {
+		return new DirectlyDefinedReward(path) {
+
+			@Override
+			public void createSection(String key) {
+			}
+
+			@Override
+			public ConfigurationSection getFileData() {
+				return null;
+			}
+
+			@Override
+			public void save() {
+			}
+
+			@Override
+			public void setData(String path, Object value) {
+			}
+		};
+	}
+}


### PR DESCRIPTION
This updates the direct reward conflict check so it skips reward files that are already marked as `DirectlyDefinedReward`.

Those files are generated/managed by AdvancedCore itself, so they should not trigger the same warning as a normal reward file that conflicts with a directly defined reward path.

This came up while testing VotingPlugin 7.x, where startup can show a lot of reward file conflict warnings for generated files under `Rewards/DirectlyDefined`.

Normal reward file conflicts should still be reported.

Tests added:
- generated/directly defined reward files do not warn
- normal reward files with the same name still warn