### PR TITLE
Correct command and reward-example spelling

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/command/CommandLoader.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/command/CommandLoader.java
@@ -657,7 +657,7 @@ public class CommandLoader {
 		if (plugin.isLoadUserData()) {
 			cmds.add(new CommandHandler(plugin, new String[] { "ConvertToData", "(UserStorage)" },
 					permPrefix + ".Commands.AdminVote.ConvertToData",
-					"Convert user storage from current storage type the one specificed", true, true) {
+					"Convert user storage from current storage type to the one specified", true, true) {
 
 				@Override
 				public void execute(CommandSender sender, String[] args) {
@@ -670,7 +670,7 @@ public class CommandLoader {
 
 			cmds.add(new CommandHandler(plugin, new String[] { "ConvertFromData", "(UserStorage)" },
 					permPrefix + ".Commands.AdminVote.ConvertFromData",
-					"Convert user storage from current storage type from the one specificed", true, true) {
+					"Convert user storage from the specified storage type to the current one", true, true) {
 
 				@Override
 				public void execute(CommandSender sender, String[] args) {

--- a/AdvancedCore/src/main/resources/Rewards/ExampleAdvanced.yml
+++ b/AdvancedCore/src/main/resources/Rewards/ExampleAdvanced.yml
@@ -1,6 +1,6 @@
 # This is a reward file
 # Define rewards in here (Items, commands, etc)
-# File name is the reward name, without file extention
+# File name is the reward name, without file extension
 # This reward is named "ExampleAdvanced"
 # That is what you put as a reward for other plugins, like VotingPlugin
 # DO NOT HAVE DUPLICATE NAMES!!
@@ -11,7 +11,7 @@
 # https://github.com/BenCodez/AdvancedCore/wiki/Reward-files
 
 # You can just remove values you don't want (just delete it)
-# If you just want money just have a reward file containg only "Money: 100", for example
+# If you just want money just have a reward file containing only "Money: 100", for example
 # Don't use this file as a reward, example only
 
 # This is the advanced example, if you only want an item or command then look

--- a/AdvancedCore/src/main/resources/Rewards/ExampleBasic.yml
+++ b/AdvancedCore/src/main/resources/Rewards/ExampleBasic.yml
@@ -1,6 +1,6 @@
 # This is a reward file
 # Define rewards in here (Items, commands, etc)
-# File name is the reward name, without file extention
+# File name is the reward name, without file extension
 # This reward is named "ExampleBasic"
 # That is what you put as a reward for other plugins, like VotingPlugin
 # DO NOT HAVE DUPLICATE NAMES!!
@@ -15,7 +15,7 @@
 # Below are some basic things you can have, see the advanced example for more
 
 # You can just remove values you don't want (just delete it)
-# If you just want money just have a reward file containg only "Money: 100", for example
+# If you just want money just have a reward file containing only "Money: 100", for example
 # You can simply copy and paste from here what you want
 # in other reward files, that is the way they are designed
 


### PR DESCRIPTION
## What changed

- correct the descriptions for the two data-conversion commands
- correct spelling in the bundled `ExampleBasic.yml` and `ExampleAdvanced.yml` comments
- clarify the conversion direction in each command description

## Why

Wiki pull request BenCodez/Wiki#8 corrects copies of these source strings. Updating AdvancedCore keeps generated command documentation and reward examples aligned with their authoritative source.

## Impact

This is a text-only change. It does not rename commands, configuration keys, reward options, or Java identifiers and does not change conversion behavior.

## Validation

- compared the branch against `master`
- confirmed only one Java file and two YAML resource files changed
- verified every change is limited to command-description or comment text
- verified the branch is based on the current `master` commit

> **AI disclosure:** This pull request was created by ChatGPT/Codex at the maintainer's request. It should receive normal maintainer review before merge.