### PR TITLE
Fix remaining reward example spelling

### DIFF
--- a/AdvancedCore/src/main/resources/Rewards/ExampleAdvanced.yml
+++ b/AdvancedCore/src/main/resources/Rewards/ExampleAdvanced.yml
@@ -41,7 +41,7 @@ Chance: 40
 # Item conditional example
 Items:
   Item1:
-    # Javacript for conditional
+    # Javascript for conditional
     # Uses return value to get item info (can be anything, like numbers)
     ConditionalJavascript: 'User.canVoteAll()'
     Conditional:
@@ -188,7 +188,7 @@ AdvancedWorld:
 #    - say test
       
 # Special chance
-# percentage is caculated with all numbers added up
+# Percentage is calculated with all numbers added up
 # E.g. below:
 # Total is 100, so 5 is 5 out of 100, and so on
 # The number represents a weight value essentially
@@ -323,7 +323,7 @@ BossBar:
   # Bar Styles:
   # https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarStyle.html
   Style: 'SOLID'
-  # Precentage for bar
+  # Percentage for bar
   Progress: 0.50
   # Delay until bar goes away (in ticks)
   Delay: 30
@@ -348,7 +348,7 @@ Sound:
 Effect:
   Enabled: false
   Effect: 'EXPLOSION_NORMAL'
-  # Ususally speed
+  # Usually speed
   Data: 1
   Particles: 10
   Radius: 5

--- a/AdvancedCore/src/main/resources/Rewards/ExampleBasic.yml
+++ b/AdvancedCore/src/main/resources/Rewards/ExampleBasic.yml
@@ -21,7 +21,7 @@
 
 # If true:
 # Only allow one item with chance to go through (from items below)
-# If no chance specificied it will only give the first item
+# If no chance is specified it will only give the first item
 OnlyOneItemChance: false
 
 # Items to give to user


### PR DESCRIPTION
## Summary

- correct the remaining spelling errors in `ExampleBasic.yml` and `ExampleAdvanced.yml`
- improve the grammar of the affected `OnlyOneItemChance` comment
- preserve all reward keys, values, formatting, and behavior

## Why

PR #282 corrected several documentation spelling errors but did not include these five remaining occurrences. These example files are the authoritative source for generated Wiki reward examples, so the corrections belong here first.

## Impact

Documentation comments only. There is no runtime or configuration behavior change.

## Validation

- verified the commit contains exactly five comment corrections across the two reward-example files
- confirmed no reward keys or values changed
- reviewed the published remote commit diff

AI disclosure: This content was written with assistance from ChatGPT.