### PR TITLE
Use prepared statements for database operations

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/userstorage/mysql/MySQL.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/userstorage/mysql/MySQL.java
@@ -894,7 +894,7 @@ public class MySQL extends AbstractSqlTable {
 			return value.getString();
 		}
 		if (value.isBoolean()) {
-			return value.getBoolean();
+			return String.valueOf(value.getBoolean());
 		}
 		if (value.isInt()) {
 			return value.getInt();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/userstorage/mysql/MySQL.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/userstorage/mysql/MySQL.java
@@ -395,24 +395,25 @@ public class MySQL extends AbstractSqlTable {
 	}
 
 	public String getUUID(String playerName) {
-		String query = "SELECT " + qi("uuid") + " FROM " + qi(tableName) + " WHERE " + qi("PlayerName") + "='"
-				+ playerName + "';";
+		String query = "SELECT " + qi("uuid") + " FROM " + qi(tableName) + " WHERE " + qi("PlayerName") + "=?;";
 		plugin.devDebug("DB QUERY: " + query);
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
-				PreparedStatement sql = conn.prepareStatement(query);
-				ResultSet rs = sql.executeQuery()) {
+				PreparedStatement sql = conn.prepareStatement(query)) {
+			sql.setString(1, playerName);
+			try (ResultSet rs = sql.executeQuery()) {
 
-			if (rs.next()) {
-				if (dbType == DbType.POSTGRESQL) {
-					Object obj = rs.getObject(1);
-					if (obj instanceof java.util.UUID) {
-						return ((java.util.UUID) obj).toString();
+				if (rs.next()) {
+					if (dbType == DbType.POSTGRESQL) {
+						Object obj = rs.getObject(1);
+						if (obj instanceof java.util.UUID) {
+							return ((java.util.UUID) obj).toString();
+						}
 					}
-				}
-				String uuid = rs.getString(1);
-				if (uuid != null && !uuid.isEmpty()) {
-					return uuid;
+					String uuid = rs.getString(1);
+					if (uuid != null && !uuid.isEmpty()) {
+						return uuid;
+					}
 				}
 			}
 		} catch (SQLException e) {
@@ -537,17 +538,14 @@ public class MySQL extends AbstractSqlTable {
 	// -------------------------
 
 	public void deletePlayer(String uuid) {
-		String q;
-		if (dbType == DbType.POSTGRESQL) {
-			q = "DELETE FROM " + qi(tableName) + " WHERE " + qi("uuid") + "='" + uuid + "'::uuid;";
-		} else {
-			q = "DELETE FROM " + qi(tableName) + " WHERE " + qi("uuid") + "='" + uuid + "';";
-		}
+		String q = "DELETE FROM " + qi(tableName) + " WHERE " + qi("uuid") + "=?;";
 		plugin.devDebug("DB QUERY: " + q);
 
-		try {
-			new Query(mysql, q).executeUpdate();
-		} catch (SQLException e) {
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement statement = conn.prepareStatement(q)) {
+			bindUuid(statement, 1, uuid);
+			statement.executeUpdate();
+		} catch (SQLException | IllegalArgumentException e) {
 			debug(e);
 		}
 
@@ -650,53 +648,52 @@ public class MySQL extends AbstractSqlTable {
 	public ArrayList<Column> getExactQuery(Column column) {
 		ArrayList<Column> result = new ArrayList<>();
 
-		String query;
-		if (dbType == DbType.POSTGRESQL && "uuid".equalsIgnoreCase(column.getName())) {
-			query = "SELECT * FROM " + qi(tableName) + " WHERE " + qi("uuid") + "='" + column.getValue().getString()
-					+ "'::uuid;";
-		} else {
-			query = "SELECT * FROM " + qi(tableName) + " WHERE " + qi(column.getName()) + "='"
-					+ column.getValue().getString() + "';";
-		}
+		String query = "SELECT * FROM " + qi(tableName) + " WHERE " + qi(column.getName()) + "=?;";
 
 		plugin.devDebug("DB QUERY: " + query);
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
-				PreparedStatement sql = conn.prepareStatement(query);
-				ResultSet rs = sql.executeQuery()) {
+				PreparedStatement sql = conn.prepareStatement(query)) {
+			if (dbType == DbType.POSTGRESQL && "uuid".equalsIgnoreCase(column.getName())) {
+				bindUuid(sql, 1, column.getValue().getString());
+			} else {
+				bindValue(sql, 1, column.getValue());
+			}
+			try (ResultSet rs = sql.executeQuery()) {
 
-			if (rs.next()) {
-				for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
-					String columnName = rs.getMetaData().getColumnLabel(i);
-					Column rCol;
+				if (rs.next()) {
+					for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
+						String columnName = rs.getMetaData().getColumnLabel(i);
+						Column rCol;
 
-					if (plugin.getUserManager().getDataManager().isInt(columnName)) {
-						rCol = new Column(columnName, DataType.INTEGER);
-						try {
-							rCol.setValue(new DataValueInt(rs.getInt(i)));
-						} catch (Exception e) {
-							String data = rs.getString(i);
-							if (data != null) {
-								try {
-									rCol.setValue(new DataValueInt(Integer.parseInt(data)));
-								} catch (NumberFormatException ex) {
+						if (plugin.getUserManager().getDataManager().isInt(columnName)) {
+							rCol = new Column(columnName, DataType.INTEGER);
+							try {
+								rCol.setValue(new DataValueInt(rs.getInt(i)));
+							} catch (Exception e) {
+								String data = rs.getString(i);
+								if (data != null) {
+									try {
+										rCol.setValue(new DataValueInt(Integer.parseInt(data)));
+									} catch (NumberFormatException ex) {
+										rCol.setValue(new DataValueInt(0));
+									}
+								} else {
 									rCol.setValue(new DataValueInt(0));
 								}
-							} else {
-								rCol.setValue(new DataValueInt(0));
 							}
+						} else if (plugin.getUserManager().getDataManager().isBoolean(columnName)) {
+							rCol = new Column(columnName, DataType.BOOLEAN);
+							rCol.setValue(new DataValueBoolean(Boolean.valueOf(rs.getString(i))));
+						} else {
+							rCol = new Column(columnName, DataType.STRING);
+							rCol.setValue(new DataValueString(rs.getString(i)));
 						}
-					} else if (plugin.getUserManager().getDataManager().isBoolean(columnName)) {
-						rCol = new Column(columnName, DataType.BOOLEAN);
-						rCol.setValue(new DataValueBoolean(Boolean.valueOf(rs.getString(i))));
-					} else {
-						rCol = new Column(columnName, DataType.STRING);
-						rCol.setValue(new DataValueString(rs.getString(i)));
+						result.add(rCol);
 					}
-					result.add(rCol);
 				}
+				return result;
 			}
-			return result;
 		} catch (SQLException | ArrayIndexOutOfBoundsException e) {
 			debug(e);
 		}
@@ -728,10 +725,10 @@ public class MySQL extends AbstractSqlTable {
 				sb.append(", ").append(qi(col.getName()));
 			}
 
-			sb.append(") VALUES ('").append(index).append("'::uuid");
+			sb.append(") VALUES (?");
 
 			for (Column col : cols) {
-				sb.append(", '").append(col.getValue().toString()).append("'");
+				sb.append(", ?");
 			}
 
 			sb.append(") ON CONFLICT (").append(qi("uuid")).append(") DO UPDATE SET ");
@@ -749,32 +746,37 @@ public class MySQL extends AbstractSqlTable {
 			plugin.devDebug("DB QUERY: " + query);
 
 			try {
-				new Query(mysql, query).executeUpdate();
+				Query prepared = new Query(mysql, query);
+				prepared.setParameter(1, UUID.fromString(index));
+				for (int i = 0; i < cols.size(); i++) {
+					prepared.setParameter(i + 2, toSqlValue(cols.get(i).getValue()));
+				}
+				prepared.executeUpdate();
 			} catch (Exception e) {
 				debug(e);
 				plugin.debug("Failed to insert/upsert player " + index);
 			}
 		} else {
-			// MySQL/MariaDB: keep original INSERT IGNORE ... SET ...
-			String query = "INSERT IGNORE " + qi(tableName) + " set " + qi("uuid") + "='" + index + "', ";
-
-			for (int i = 0; i < cols.size(); i++) {
-				Column col = cols.get(i);
-				boolean last = (i == cols.size() - 1);
-
-				if (col.getValue().isString()) {
-					query += qi(col.getName()) + "='" + col.getValue().getString() + "'" + (last ? ";" : ", ");
-				} else if (col.getValue().isBoolean()) {
-					query += qi(col.getName()) + "='" + col.getValue().getBoolean() + "'" + (last ? ";" : ", ");
-				} else if (col.getValue().isInt()) {
-					query += qi(col.getName()) + "='" + col.getValue().getInt() + "'" + (last ? ";" : ", ");
-				}
+			StringBuilder query = new StringBuilder("INSERT IGNORE INTO ").append(qi(tableName)).append(" (")
+					.append(qi("uuid"));
+			for (Column col : cols) {
+				query.append(", ").append(qi(col.getName()));
 			}
+			query.append(") VALUES (?");
+			for (int i = 0; i < cols.size(); i++) {
+				query.append(", ?");
+			}
+			query.append(");");
 
-			plugin.devDebug("DB QUERY: " + query);
+			plugin.devDebug("DB QUERY: " + query.toString());
 
 			try {
-				new Query(mysql, query).executeUpdate();
+				Query prepared = new Query(mysql, query.toString());
+				prepared.setParameter(1, index);
+				for (int i = 0; i < cols.size(); i++) {
+					prepared.setParameter(i + 2, toSqlValue(cols.get(i).getValue()));
+				}
+				prepared.executeUpdate();
 			} catch (Exception e) {
 				debug(e);
 				plugin.debug("Failed to insert player " + index);
@@ -803,6 +805,9 @@ public class MySQL extends AbstractSqlTable {
 		for (Column col : cols) {
 			checkColumn(col.getName(), col.getDataType());
 		}
+		if (cols.isEmpty()) {
+			return;
+		}
 
 		synchronized (updateLock) {
 			if (getUuids().contains(index) || containsKeyQuery(index)) {
@@ -810,33 +815,23 @@ public class MySQL extends AbstractSqlTable {
 				sb.append("UPDATE ").append(qi(tableName)).append(" SET ");
 
 				for (int i = 0; i < cols.size(); i++) {
-					Column col = cols.get(i);
-					boolean last = (i == cols.size() - 1);
-
-					if (col.getValue().isString()) {
-						sb.append(qi(col.getName())).append("='").append(col.getValue().getString()).append("'");
-					} else if (col.getValue().isBoolean()) {
-						sb.append(qi(col.getName())).append("='").append(col.getValue().getBoolean()).append("'");
-					} else if (col.getValue().isInt()) {
-						sb.append(qi(col.getName())).append("='").append(col.getValue().getInt()).append("'");
-					}
-
-					if (!last) {
+					sb.append(qi(cols.get(i).getName())).append("=?");
+					if (i != cols.size() - 1) {
 						sb.append(", ");
 					}
 				}
 
-				if (dbType == DbType.POSTGRESQL) {
-					sb.append(" WHERE ").append(qi("uuid")).append("='").append(index).append("'::uuid;");
-				} else {
-					sb.append(" WHERE ").append(qi("uuid")).append("='").append(index).append("';");
-				}
+				sb.append(" WHERE ").append(qi("uuid")).append("=?;");
 
 				String query = sb.toString();
 				plugin.devDebug("DB QUERY: " + query);
 
 				try {
 					Query q = new Query(mysql, query);
+					for (int i = 0; i < cols.size(); i++) {
+						q.setParameter(i + 1, toSqlValue(cols.get(i).getValue()));
+					}
+					q.setParameter(cols.size() + 1, toUuidValue(index));
 					if (runAsync) {
 						q.executeUpdateAsync();
 					} else {
@@ -861,26 +856,15 @@ public class MySQL extends AbstractSqlTable {
 
 		synchronized (updateLock) {
 			if (getUuids().contains(index) || containsKeyQuery(index)) {
-				String query = "UPDATE " + qi(tableName) + " SET ";
-
-				if (value.isString()) {
-					query += qi(column) + "='" + value.getString() + "'";
-				} else if (value.isBoolean()) {
-					query += qi(column) + "='" + value.getBoolean() + "'";
-				} else if (value.isInt()) {
-					query += qi(column) + "='" + value.getInt() + "'";
-				}
-
-				if (dbType == DbType.POSTGRESQL) {
-					query += " WHERE " + qi("uuid") + "='" + index + "'::uuid;";
-				} else {
-					query += " WHERE " + qi("uuid") + "='" + index + "';";
-				}
+				String query = "UPDATE " + qi(tableName) + " SET " + qi(column) + "=? WHERE " + qi("uuid") + "=?;";
 
 				plugin.devDebug("DB QUERY: " + query);
 
 				try {
-					new Query(mysql, query).executeUpdate();
+					Query prepared = new Query(mysql, query);
+					prepared.setParameter(1, toSqlValue(value));
+					prepared.setParameter(2, toUuidValue(index));
+					prepared.executeUpdate();
 				} catch (SQLException e) {
 					debug(e);
 				}
@@ -888,6 +872,34 @@ public class MySQL extends AbstractSqlTable {
 				insert(index, column, value);
 			}
 		}
+	}
+
+	private void bindUuid(PreparedStatement statement, int parameter, String uuid) throws SQLException {
+		statement.setObject(parameter, toUuidValue(uuid));
+	}
+
+	private void bindValue(PreparedStatement statement, int parameter, DataValue value) throws SQLException {
+		statement.setObject(parameter, toSqlValue(value));
+	}
+
+	private Object toUuidValue(String uuid) {
+		return dbType == DbType.POSTGRESQL ? UUID.fromString(uuid) : uuid;
+	}
+
+	private Object toSqlValue(DataValue value) {
+		if (value == null) {
+			return null;
+		}
+		if (value.isString()) {
+			return value.getString();
+		}
+		if (value.isBoolean()) {
+			return value.getBoolean();
+		}
+		if (value.isInt()) {
+			return value.getInt();
+		}
+		return value.toString();
 	}
 
 	public void wipeColumnData(String columnName, DataType dataType) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/userstorage/sql/UserTable.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/userstorage/sql/UserTable.java
@@ -597,9 +597,10 @@ public class UserTable extends com.bencodez.simpleapi.sql.sqlite.Table {
 	}
 
 	public String getUUID(String playerName) {
-		String query = "SELECT uuid FROM " + getName() + " WHERE " + "PlayerName" + "='" + playerName + "';";
+		String query = "SELECT uuid FROM " + getName() + " WHERE PlayerName=?;";
 
 		try (PreparedStatement sql = sqLite.getSQLConnection().prepareStatement(query)) {
+			sql.setString(1, playerName);
 			ResultSet rs = sql.executeQuery();
 			/*
 			 * Query sql = new Query(mysql, query); ResultSet rs = sql.executeQuery();
@@ -729,29 +730,26 @@ public class UserTable extends com.bencodez.simpleapi.sql.sqlite.Table {
 		for (Column c : columns) {
 			checkColumn(c);
 		}
+		if (columns.isEmpty()) {
+			return;
+		}
 		if (containsKey(primaryKey.getValue().toString())) {
 			synchronized (object) {
-				String query = "UPDATE " + getName() + " SET ";
-				for (Column column : columns) {
-					if (column.getValue().isString()) {
-						query += "`" + column.getName() + "`='" + column.getValue().getString() + "'";
-					} else if (column.getValue().isBoolean()) {
-						query += "`" + column.getName() + "`=" + column.getValue().getBoolean();
-					} else if (column.getValue().isInt()) {
-						query += "`" + column.getName() + "`=" + column.getValue().getInt();
-					}
-					if (columns.indexOf(column) == columns.size() - 1) {
-						query += " ";
-					} else {
-						query += ", ";
+				StringBuilder query = new StringBuilder("UPDATE ").append(getName()).append(" SET ");
+				for (int i = 0; i < columns.size(); i++) {
+					query.append("`").append(columns.get(i).getName()).append("`=?");
+					if (i != columns.size() - 1) {
+						query.append(", ");
 					}
 				}
-				query += "WHERE `" + primaryKey.getName() + "`=";
-				query += "'" + primaryKey.getValue().getString() + "'";
-				try {
-					PreparedStatement s = sqLite.getSQLConnection().prepareStatement(query);
+				query.append(" WHERE `").append(primaryKey.getName()).append("`=?");
+				try (PreparedStatement s = sqLite.getSQLConnection().prepareStatement(query.toString())) {
+					int parameter = 1;
+					for (Column column : columns) {
+						bindValue(s, parameter++, column);
+					}
+					bindValue(s, parameter, primaryKey);
 					s.executeUpdate();
-					s.close();
 				} catch (SQLException e) {
 					e.printStackTrace();
 				}
@@ -767,6 +765,20 @@ public class UserTable extends com.bencodez.simpleapi.sql.sqlite.Table {
 				columns.add(primaryKey);
 			}
 			insert(columns);
+		}
+	}
+
+	private void bindValue(PreparedStatement statement, int parameter, Column column) throws SQLException {
+		if (column.getValue() == null) {
+			statement.setObject(parameter, null);
+		} else if (column.getValue().isString()) {
+			statement.setString(parameter, column.getValue().getString());
+		} else if (column.getValue().isBoolean()) {
+			statement.setBoolean(parameter, column.getValue().getBoolean());
+		} else if (column.getValue().isInt()) {
+			statement.setInt(parameter, column.getValue().getInt());
+		} else {
+			statement.setObject(parameter, column.getValue().toString());
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
@@ -917,10 +917,10 @@ public abstract class GlobalMySQL {
 			return value.getString();
 		}
 		if (value.isBoolean()) {
-			return value.getBoolean();
+			return String.valueOf(value.getBoolean());
 		}
 		if (value.isInt()) {
-			return value.getInt();
+			return String.valueOf(value.getInt());
 		}
 		return value.toString();
 	}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
@@ -480,9 +480,11 @@ public abstract class GlobalMySQL {
 	 * @param server the server name to delete
 	 */
 	public void deleteServer(String server) {
-		String q = "DELETE FROM " + getName() + " WHERE server='" + server + "';";
+		String q = "DELETE FROM " + getName() + " WHERE " + qi("server") + "=?;";
 		try {
-			new Query(mysql, q).executeUpdate();
+			Query prepared = new Query(mysql, q);
+			prepared.setParameter(1, server);
+			prepared.executeUpdate();
 		} catch (SQLException e) {
 			e.printStackTrace();
 		}
@@ -576,27 +578,29 @@ public abstract class GlobalMySQL {
 		ArrayList<Column> result = new ArrayList<>();
 
 		String colName = (dbType() == DbType.POSTGRESQL) ? qi(column.getName().toLowerCase()) : qi(column.getName());
-		String query = "SELECT * FROM " + getName() + " WHERE " + colName + "='" + column.getValue().getString() + "';";
+		String query = "SELECT * FROM " + getName() + " WHERE " + colName + "=?;";
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
-				PreparedStatement sql = conn.prepareStatement(query);
-				ResultSet rs = sql.executeQuery()) {
+				PreparedStatement sql = conn.prepareStatement(query)) {
+			sql.setObject(1, toSqlValue(column.getValue()));
+			try (ResultSet rs = sql.executeQuery()) {
 
-			if (rs.next()) {
-				for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
-					String columnName = rs.getMetaData().getColumnLabel(i);
-					Column rCol;
-					if (intColumns.contains(columnName)) {
-						rCol = new Column(columnName, DataType.INTEGER);
-						rCol.setValue(new DataValueInt(rs.getInt(i)));
-					} else {
-						rCol = new Column(columnName, DataType.STRING);
-						rCol.setValue(new DataValueString(rs.getString(i)));
+				if (rs.next()) {
+					for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
+						String columnName = rs.getMetaData().getColumnLabel(i);
+						Column rCol;
+						if (intColumns.contains(columnName)) {
+							rCol = new Column(columnName, DataType.INTEGER);
+							rCol.setValue(new DataValueInt(rs.getInt(i)));
+						} else {
+							rCol = new Column(columnName, DataType.STRING);
+							rCol.setValue(new DataValueString(rs.getString(i)));
+						}
+						result.add(rCol);
 					}
-					result.add(rCol);
 				}
+				return result;
 			}
-			return result;
 		} catch (SQLException | ArrayIndexOutOfBoundsException e) {
 			e.printStackTrace();
 		}
@@ -714,9 +718,9 @@ public abstract class GlobalMySQL {
 			for (Column col : cols) {
 				sb.append(", ").append(quoteIdent(dbType, col.getName().toLowerCase()));
 			}
-			sb.append(") VALUES ('").append(index).append("'");
+			sb.append(") VALUES (?");
 			for (Column col : cols) {
-				sb.append(", '").append(col.getValue().toString()).append("'");
+				sb.append(", ?");
 			}
 			sb.append(") ON CONFLICT (server) DO UPDATE SET ");
 			for (int i = 0; i < cols.size(); i++) {
@@ -731,7 +735,12 @@ public abstract class GlobalMySQL {
 
 			String query = sb.toString();
 			try {
-				new Query(mysql, query).executeUpdate();
+				Query prepared = new Query(mysql, query);
+				prepared.setParameter(1, index);
+				for (int i = 0; i < cols.size(); i++) {
+					prepared.setParameter(i + 2, toSqlValue(cols.get(i).getValue()));
+				}
+				prepared.executeUpdate();
 				servers.add(index);
 				debugLog("Upserting " + index + " into database");
 			} catch (Exception e) {
@@ -741,25 +750,24 @@ public abstract class GlobalMySQL {
 			return;
 		}
 
-		// MySQL/MariaDB: keep original INSERT IGNORE ... SET ...
-		String query = "INSERT IGNORE " + getName() + " ";
-		query += "set server='" + index + "', ";
-
-		for (int i = 0; i < cols.size(); i++) {
-			Column col = cols.get(i);
-			boolean last = (i == cols.size() - 1);
-
-			if (col.getValue().isString()) {
-				query += col.getName() + "='" + col.getValue().getString() + "'" + (last ? ";" : ", ");
-			} else if (col.getValue().isBoolean()) {
-				query += col.getName() + "='" + col.getValue().getBoolean() + "'" + (last ? ";" : ", ");
-			} else if (col.getValue().isInt()) {
-				query += col.getName() + "='" + col.getValue().getInt() + "'" + (last ? ";" : ", ");
-			}
+		StringBuilder query = new StringBuilder("INSERT IGNORE INTO ").append(getName()).append(" (")
+				.append(qi("server"));
+		for (Column col : cols) {
+			query.append(", ").append(qi(col.getName()));
 		}
+		query.append(") VALUES (?");
+		for (int i = 0; i < cols.size(); i++) {
+			query.append(", ?");
+		}
+		query.append(");");
 
 		try {
-			new Query(mysql, query).executeUpdate();
+			Query prepared = new Query(mysql, query.toString());
+			prepared.setParameter(1, index);
+			for (int i = 0; i < cols.size(); i++) {
+				prepared.setParameter(i + 2, toSqlValue(cols.get(i).getValue()));
+			}
+			prepared.executeUpdate();
 			servers.add(index);
 			debugLog("Inserting " + index + " into database");
 		} catch (Exception e) {
@@ -818,6 +826,9 @@ public abstract class GlobalMySQL {
 		for (Column col : cols) {
 			checkColumn(col.getName(), col.getDataType());
 		}
+		if (cols.isEmpty()) {
+			return;
+		}
 
 		synchronized (object2) {
 			if (getServers().contains(index) || containsKeyQuery(index)) {
@@ -829,31 +840,25 @@ public abstract class GlobalMySQL {
 
 				for (int i = 0; i < cols.size(); i++) {
 					Column col = cols.get(i);
-					boolean last = (i == cols.size() - 1);
-
 					String colName = (dbType == DbType.POSTGRESQL) ? quoteIdent(dbType, col.getName().toLowerCase())
-							: "`" + col.getName() + "`";
-
-					if (col.getValue().isString()) {
-						sb.append(colName).append("='").append(col.getValue().getString()).append("'");
-					} else if (col.getValue().isBoolean()) {
-						sb.append(colName).append("='").append(col.getValue().getBoolean()).append("'");
-					} else if (col.getValue().isInt()) {
-						sb.append(colName).append("='").append(col.getValue().getInt()).append("'");
-					}
-
-					if (!last) {
+							: qi(col.getName());
+					sb.append(colName).append("=?");
+					if (i != cols.size() - 1) {
 						sb.append(", ");
 					}
 				}
 
-				sb.append(" WHERE server='").append(index).append("';");
+				sb.append(" WHERE ").append(qi("server")).append("=?;");
 
 				String query = sb.toString();
 				debugLog("Batch query: " + query);
 
 				try {
 					Query q = new Query(mysql, query);
+					for (int i = 0; i < cols.size(); i++) {
+						q.setParameter(i + 1, toSqlValue(cols.get(i).getValue()));
+					}
+					q.setParameter(cols.size() + 1, index);
 					if (runAsync) {
 						q.executeUpdateAsync();
 					} else {
@@ -886,22 +891,15 @@ public abstract class GlobalMySQL {
 			if (getServers().contains(index) || containsKeyQuery(index)) {
 				DbType dbType = dbType();
 
-				String colName = (dbType == DbType.POSTGRESQL) ? quoteIdent(dbType, column.toLowerCase()) : column;
+				String colName = (dbType == DbType.POSTGRESQL) ? quoteIdent(dbType, column.toLowerCase()) : qi(column);
 
-				String query = "UPDATE " + getName() + " SET ";
-
-				if (value.isString()) {
-					query += colName + "='" + value.getString() + "'";
-				} else if (value.isBoolean()) {
-					query += colName + "='" + value.getBoolean() + "'";
-				} else if (value.isInt()) {
-					query += colName + "='" + value.getInt() + "'";
-				}
-
-				query += " WHERE server='" + index + "';";
+				String query = "UPDATE " + getName() + " SET " + colName + "=? WHERE " + qi("server") + "=?;";
 
 				try {
-					new Query(mysql, query).executeUpdate();
+					Query prepared = new Query(mysql, query);
+					prepared.setParameter(1, toSqlValue(value));
+					prepared.setParameter(2, index);
+					prepared.executeUpdate();
 				} catch (SQLException e) {
 					e.printStackTrace();
 				}
@@ -909,6 +907,22 @@ public abstract class GlobalMySQL {
 				insert(index, column, value);
 			}
 		}
+	}
+
+	private Object toSqlValue(DataValue value) {
+		if (value == null) {
+			return null;
+		}
+		if (value.isString()) {
+			return value.getString();
+		}
+		if (value.isBoolean()) {
+			return value.getBoolean();
+		}
+		if (value.isInt()) {
+			return value.getInt();
+		}
+		return value.toString();
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
@@ -329,7 +329,7 @@ public abstract class GlobalMySQL {
 			if (!columnNeedsAlter(conn, dbType, column, normalized)) {
 				debugLog("GlobalDB: Column " + qi(dbType == DbType.POSTGRESQL ? column.toLowerCase() : column)
 						+ " already matches " + normalized + ", skipping ALTER");
-				if (normalized.toUpperCase().contains("INT") && !intColumns.contains(column)) {
+				if (normalized.toUpperCase().contains("INT") && !isIntColumn(column)) {
 					intColumns.add(column);
 				}
 				return;
@@ -372,7 +372,7 @@ public abstract class GlobalMySQL {
 			e.printStackTrace();
 		}
 
-		if (normalized.toUpperCase().contains("INT") && !intColumns.contains(column)) {
+		if (normalized.toUpperCase().contains("INT") && !isIntColumn(column)) {
 			intColumns.add(column);
 		}
 	}
@@ -582,14 +582,14 @@ public abstract class GlobalMySQL {
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement sql = conn.prepareStatement(query)) {
-			sql.setObject(1, toSqlValue(column.getValue()));
+			sql.setObject(1, toSqlValue(column.getName(), column.getValue()));
 			try (ResultSet rs = sql.executeQuery()) {
 
 				if (rs.next()) {
 					for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
 						String columnName = rs.getMetaData().getColumnLabel(i);
 						Column rCol;
-						if (intColumns.contains(columnName)) {
+						if (isIntColumn(columnName)) {
 							rCol = new Column(columnName, DataType.INTEGER);
 							rCol.setValue(new DataValueInt(rs.getInt(i)));
 						} else {
@@ -738,7 +738,8 @@ public abstract class GlobalMySQL {
 				Query prepared = new Query(mysql, query);
 				prepared.setParameter(1, index);
 				for (int i = 0; i < cols.size(); i++) {
-					prepared.setParameter(i + 2, toSqlValue(cols.get(i).getValue()));
+					Column column = cols.get(i);
+					prepared.setParameter(i + 2, toSqlValue(column.getName(), column.getValue()));
 				}
 				prepared.executeUpdate();
 				servers.add(index);
@@ -765,7 +766,8 @@ public abstract class GlobalMySQL {
 			Query prepared = new Query(mysql, query.toString());
 			prepared.setParameter(1, index);
 			for (int i = 0; i < cols.size(); i++) {
-				prepared.setParameter(i + 2, toSqlValue(cols.get(i).getValue()));
+				Column column = cols.get(i);
+				prepared.setParameter(i + 2, toSqlValue(column.getName(), column.getValue()));
 			}
 			prepared.executeUpdate();
 			servers.add(index);
@@ -783,7 +785,15 @@ public abstract class GlobalMySQL {
 	 * @return true if the column is an integer column, false otherwise
 	 */
 	public boolean isIntColumn(String key) {
-		return intColumns.contains(key);
+		if (key == null) {
+			return false;
+		}
+		for (String intColumn : intColumns) {
+			if (intColumn.equalsIgnoreCase(key)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -856,7 +866,8 @@ public abstract class GlobalMySQL {
 				try {
 					Query q = new Query(mysql, query);
 					for (int i = 0; i < cols.size(); i++) {
-						q.setParameter(i + 1, toSqlValue(cols.get(i).getValue()));
+						Column column = cols.get(i);
+						q.setParameter(i + 1, toSqlValue(column.getName(), column.getValue()));
 					}
 					q.setParameter(cols.size() + 1, index);
 					if (runAsync) {
@@ -897,7 +908,7 @@ public abstract class GlobalMySQL {
 
 				try {
 					Query prepared = new Query(mysql, query);
-					prepared.setParameter(1, toSqlValue(value));
+					prepared.setParameter(1, toSqlValue(column, value));
 					prepared.setParameter(2, index);
 					prepared.executeUpdate();
 				} catch (SQLException e) {
@@ -909,7 +920,7 @@ public abstract class GlobalMySQL {
 		}
 	}
 
-	private Object toSqlValue(DataValue value) {
+	private Object toSqlValue(String column, DataValue value) {
 		if (value == null) {
 			return null;
 		}
@@ -920,7 +931,7 @@ public abstract class GlobalMySQL {
 			return String.valueOf(value.getBoolean());
 		}
 		if (value.isInt()) {
-			return String.valueOf(value.getInt());
+			return isIntColumn(column) ? value.getInt() : String.valueOf(value.getInt());
 		}
 		return value.toString();
 	}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bungeeapi/globaldata/GlobalMySQL.java
@@ -323,15 +323,14 @@ public abstract class GlobalMySQL {
 
 		DbType dbType = dbType();
 		String normalized = normalizeColumnType(dbType, newType);
+		boolean integerType = normalized.toUpperCase().contains("INT");
 
 		// First inspect existing type; skip ALTER if it's already correct
 		try (Connection conn = mysql.getConnectionManager().getConnection()) {
 			if (!columnNeedsAlter(conn, dbType, column, normalized)) {
 				debugLog("GlobalDB: Column " + qi(dbType == DbType.POSTGRESQL ? column.toLowerCase() : column)
 						+ " already matches " + normalized + ", skipping ALTER");
-				if (normalized.toUpperCase().contains("INT") && !isIntColumn(column)) {
-					intColumns.add(column);
-				}
+				trackIntegerColumn(column, integerType);
 				return;
 			}
 		} catch (SQLException e) {
@@ -341,38 +340,54 @@ public abstract class GlobalMySQL {
 
 		debugLog("Altering column `" + column + "` to " + normalized);
 
-		// If going to INT, normalise empty strings to 0 first to avoid conversion issues.
-		if (normalized.toUpperCase().contains("INT")) {
+		// MySQL needs empty text values normalized before changing to an integer type.
+		if (integerType && dbType != DbType.POSTGRESQL) {
 			try {
-				if (dbType == DbType.POSTGRESQL) {
-					// Postgres: trim(coalesce(col::text,'')) = ''
-					String fix = "UPDATE " + getName() + " SET " + qi(column.toLowerCase()) + " = '0' "
-							+ "WHERE btrim(coalesce(" + qi(column.toLowerCase()) + "::text, '')) = '';";
-					new Query(mysql, fix).executeUpdateAsync();
-				} else {
-					String fix = "UPDATE " + getName() + " SET " + qi(column) + " = '0' "
-							+ "WHERE TRIM(COALESCE(" + column + ", '')) = '';";
-					new Query(mysql, fix).executeUpdateAsync();
-				}
+				String fix = "UPDATE " + getName() + " SET " + qi(column) + " = '0' "
+						+ "WHERE TRIM(COALESCE(" + qi(column) + ", '')) = '';";
+				new Query(mysql, fix).executeUpdate();
 			} catch (SQLException e) {
-				e.printStackTrace();
+				debugEx(e);
+				return;
 			}
 		}
 
 		try {
 			String alter;
 			if (dbType == DbType.POSTGRESQL) {
-				alter = "ALTER TABLE " + getName() + " ALTER COLUMN " + qi(column.toLowerCase()) + " TYPE " + normalized
-						+ ";";
+				String columnName = qi(column.toLowerCase());
+				alter = "ALTER TABLE " + getName() + " ALTER COLUMN " + columnName + " TYPE " + normalized;
+				if (integerType) {
+					alter += " USING CASE WHEN btrim(coalesce(" + columnName + "::text, '')) = '' THEN 0 ELSE "
+							+ columnName + "::" + normalized + " END";
+				}
+				alter += ";";
 			} else {
 				alter = "ALTER TABLE " + getName() + " MODIFY " + qi(column) + " " + normalized + ";";
 			}
-			new Query(mysql, alter).executeUpdateAsync();
+			new Query(mysql, alter).executeUpdate();
 		} catch (SQLException e) {
-			e.printStackTrace();
+			debugEx(e);
+			return;
 		}
 
-		if (normalized.toUpperCase().contains("INT") && !isIntColumn(column)) {
+		try (Connection conn = mysql.getConnectionManager().getConnection()) {
+			if (columnNeedsAlter(conn, dbType, column, normalized)) {
+				debugLog("GlobalDB: Column " + column + " did not change to " + normalized);
+				return;
+			}
+		} catch (SQLException e) {
+			debugLog("GlobalDB: Unable to verify column type for " + getName() + "." + column);
+			debugEx(e);
+			return;
+		}
+
+		trackIntegerColumn(column, integerType);
+	}
+
+	private void trackIntegerColumn(String column, boolean integerType) {
+		intColumns.removeIf(intColumn -> intColumn.equalsIgnoreCase(column));
+		if (integerType) {
 			intColumns.add(column);
 		}
 	}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserTablePreparedStatementTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserTablePreparedStatementTest.java
@@ -1,0 +1,85 @@
+package com.bencodez.advancedcore.tests.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.user.userstorage.sql.UserTable;
+import com.bencodez.simpleapi.sql.Column;
+import com.bencodez.simpleapi.sql.data.DataValueInt;
+import com.bencodez.simpleapi.sql.data.DataValueString;
+import com.bencodez.simpleapi.sql.sqlite.db.SQLite;
+
+class UserTablePreparedStatementTest {
+
+	private static final String UUID = "00000000-0000-0000-0000-000000000001";
+
+	private Connection connection;
+	private PreparedStatement statement;
+	private SQLite sqlite;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		connection = mock(Connection.class);
+		statement = mock(PreparedStatement.class);
+		sqlite = mock(SQLite.class);
+		when(sqlite.getSQLConnection()).thenReturn(connection);
+	}
+
+	@Test
+	void updateBindsValuesInsteadOfEmbeddingThemInSql() throws Exception {
+		Column primaryKey = new Column("uuid", new DataValueString(UUID));
+		UserTable table = spy(new UserTable(mock(AdvancedCorePlugin.class), "Users",
+				Collections.singletonList(primaryKey), primaryKey));
+		table.setSqLite(sqlite);
+		doNothing().when(table).checkColumn(any(Column.class));
+		doReturn(true).when(table).containsKey(anyString());
+
+		String sql = "UPDATE Users SET `LastVotes`=?, `Points`=? WHERE `uuid`=?";
+		when(connection.prepareStatement(sql)).thenReturn(statement);
+
+		String lastVotes = "Site's value with punctuation;//123";
+		table.update(primaryKey, Arrays.asList(new Column("LastVotes", new DataValueString(lastVotes)),
+				new Column("Points", new DataValueInt(25))));
+
+		verify(connection).prepareStatement(sql);
+		verify(statement).setString(1, lastVotes);
+		verify(statement).setInt(2, 25);
+		verify(statement).setString(3, UUID);
+		verify(statement).executeUpdate();
+	}
+
+	@Test
+	void getUuidBindsPlayerName() throws Exception {
+		Column primaryKey = new Column("uuid", new DataValueString(UUID));
+		UserTable table = new UserTable(mock(AdvancedCorePlugin.class), "Users",
+				Collections.singletonList(primaryKey), primaryKey);
+		table.setSqLite(sqlite);
+
+		ResultSet resultSet = mock(ResultSet.class);
+		String sql = "SELECT uuid FROM Users WHERE PlayerName=?;";
+		when(connection.prepareStatement(sql)).thenReturn(statement);
+		when(statement.executeQuery()).thenReturn(resultSet);
+		when(resultSet.next()).thenReturn(false);
+
+		table.getUUID("O'Brien");
+
+		verify(statement).setString(1, "O'Brien");
+		verify(statement).executeQuery();
+	}
+}


### PR DESCRIPTION
## Summary
- bind values in SQLite user lookups and updates
- bind values in MySQL, MariaDB, and PostgreSQL user inserts, lookups, updates, and deletes
- bind values in global-data database operations
- add regression coverage for quotes and punctuation in stored values

## Why
Building values directly into query strings makes ordinary names and stored values containing quotes or punctuation fail to round-trip correctly. Prepared statements keep SQL structure separate from values and make behavior consistent across supported database engines.

## Validation
- parsed all changed Java sources successfully
- added focused Mockito and JUnit coverage for SQLite binding
- full Maven validation will run in GitHub Actions because the local environment does not include Maven or a Java 21 compiler