### PR TITLE
Prevent PlaceholderAPI output from being evaluated as AdvancedCore JavaScript in reward commands

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/messages/PlaceholderUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/messages/PlaceholderUtils.java
@@ -181,6 +181,25 @@ public class PlaceholderUtils {
 		return text;
 	}
 
+	public static ArrayList<String> replaceJavascriptOnly(OfflinePlayer player, ArrayList<String> list) {
+		ArrayList<String> msg = new ArrayList<>();
+		for (String str : list) {
+			msg.add(replaceJavascriptOnly(player, str));
+		}
+		return msg;
+	}
+
+	public static String replaceJavascriptOnly(OfflinePlayer player, String text) {
+		if (AdvancedCorePlugin.getInstance().getOptions().isJavascriptEngineEnabled()) {
+			if (player.isOnline()) {
+				return replaceJavascriptOnly(player.getPlayer(), text);
+			}
+			JavascriptEngine engine = new JavascriptEngine().addPlayer(player);
+			return replaceJavascript(text, engine);
+		}
+		return text;
+	}
+
 	public static ArrayList<String> replaceJavascript(Player player, ArrayList<String> list) {
 		ArrayList<String> msg = new ArrayList<>();
 		for (String str : list) {
@@ -196,6 +215,22 @@ public class PlaceholderUtils {
 			return replaceJavascript(msg, engine);
 		}
 		return msg;
+	}
+
+	public static ArrayList<String> replaceJavascriptOnly(Player player, ArrayList<String> list) {
+		ArrayList<String> msg = new ArrayList<>();
+		for (String str : list) {
+			msg.add(replaceJavascriptOnly(player, str));
+		}
+		return msg;
+	}
+
+	public static String replaceJavascriptOnly(Player player, String text) {
+		if (AdvancedCorePlugin.getInstance().getOptions().isJavascriptEngineEnabled()) {
+			JavascriptEngine engine = new JavascriptEngine().addPlayer(player);
+			return replaceJavascript(text, engine);
+		}
+		return text;
 	}
 
 	public static String replaceJavascript(String text) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
@@ -174,11 +174,11 @@ public class MiscUtils {
 			final HashMap<String, String> placeholders, boolean stagger) {
 		if (cmds != null && !cmds.isEmpty()) {
 			placeholders.put("player", player.getName());
-			ArrayList<String> commands = PlaceholderUtils.replacePlaceHolder(cmds, placeholders);
+			ArrayList<String> commands = PlaceholderUtils.replaceJavascriptOnly(player, cmds);
+			commands = PlaceholderUtils.replacePlaceHolder(commands, placeholders);
 			commands = PlaceholderUtils.replacePlaceHolders(commands, player);
-			final ArrayList<String> finalCommands = PlaceholderUtils.replaceJavascript(player, commands);
 			int tick = 0;
-			for (final String cmd : finalCommands) {
+			for (final String cmd : commands) {
 				plugin.debug("Executing console command: " + cmd);
 				runConsoleCommand(cmd, tick, stagger);
 			}
@@ -188,9 +188,10 @@ public class MiscUtils {
 
 	public void executeConsoleCommands(Player player, String command, HashMap<String, String> placeholders) {
 		if (command != null && !command.isEmpty()) {
-			String cmd = PlaceholderUtils.replacePlaceHolder(command, placeholders);
+			String cmd = PlaceholderUtils.replaceJavascriptOnly(player, command);
+			cmd = PlaceholderUtils.replacePlaceHolder(cmd, placeholders);
 			cmd = PlaceholderUtils.replacePlaceHolders(player, cmd);
-			final String finalCommand = PlaceholderUtils.replaceJavascript(player, cmd);
+			final String finalCommand = cmd;
 
 			plugin.debug("Executing console command: " + command);
 			plugin.getBukkitScheduler().executeOrScheduleSync(plugin, new Runnable() {
@@ -211,10 +212,13 @@ public class MiscUtils {
 		if (cmds != null && !cmds.isEmpty()) {
 			placeholders.put("player", playerName);
 			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
-			ArrayList<String> commands = PlaceholderUtils.replacePlaceHolder(cmds, placeholders);
+			ArrayList<String> commands = cmds;
+			if (p != null) {
+				commands = PlaceholderUtils.replaceJavascriptOnly(p, commands);
+			}
+			commands = PlaceholderUtils.replacePlaceHolder(commands, placeholders);
 			if (p != null) {
 				commands = PlaceholderUtils.replacePlaceHolders(p, commands);
-				commands = PlaceholderUtils.replaceJavascript(p, commands);
 			}
 			int tick = 0;
 			for (final String cmd : commands) {
@@ -227,10 +231,12 @@ public class MiscUtils {
 	public void executeConsoleCommands(String playerName, String command, HashMap<String, String> placeholders) {
 		if (command != null && !command.isEmpty()) {
 			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
+			if (p != null) {
+				command = PlaceholderUtils.replaceJavascriptOnly(p, command);
+			}
 			command = PlaceholderUtils.replacePlaceHolder(command, placeholders);
 			if (p != null) {
 				command = PlaceholderUtils.replacePlaceHolders(p, command);
-				command = PlaceholderUtils.replaceJavascript(p, command);
 			}
 			if (command.startsWith("/")) {
 				command.replaceFirst("/", "");

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/messages/PlaceholderUtilsTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/messages/PlaceholderUtilsTest.java
@@ -1,0 +1,38 @@
+package com.bencodez.advancedcore.tests.messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.messages.PlaceholderUtils;
+
+import me.clip.placeholderapi.PlaceholderAPI;
+
+public class PlaceholderUtilsTest {
+
+	@Test
+	public void replaceJavascriptOnlyDoesNotExpandPlaceholderApiOutput() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		AdvancedCoreConfigOptions options = mock(AdvancedCoreConfigOptions.class);
+		Player player = mock(Player.class);
+		String command = "say %untrusted%";
+
+		when(plugin.getOptions()).thenReturn(options);
+		when(options.isJavascriptEngineEnabled()).thenReturn(false);
+
+		try (MockedStatic<AdvancedCorePlugin> pluginStatic = mockStatic(AdvancedCorePlugin.class);
+				MockedStatic<PlaceholderAPI> placeholderApiStatic = mockStatic(PlaceholderAPI.class)) {
+			pluginStatic.when(AdvancedCorePlugin::getInstance).thenReturn(plugin);
+
+			assertEquals(command, PlaceholderUtils.replaceJavascriptOnly(player, command));
+			placeholderApiStatic.verifyNoInteractions();
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Reward console-command processing expanded internal placeholders and PlaceholderAPI output before scanning for AdvancedCore `[Javascript=...]` expressions, which allowed attacker-influenced placeholder output to become executable script when the JavaScript engine was enabled.

### Description
- Add `replaceJavascriptOnly` helpers for `Player` and `OfflinePlayer` in `PlaceholderUtils` that evaluate configured `[Javascript=...]` expressions without invoking `PlaceholderAPI` expansion. 
- Update `MiscUtils.executeConsoleCommands(...)` paths to call the new `replaceJavascriptOnly` first, then substitute internal reward placeholders with `replacePlaceHolder(...)`, and finally apply `PlaceholderUtils.replacePlaceHolders(...)` (PlaceholderAPI), ensuring placeholder output is not reinterpreted as script. 
- Add a focused unit test `PlaceholderUtilsTest` that asserts `replaceJavascriptOnly` does not invoke `PlaceholderAPI`. 
- AI disclosure: This pull request was created with assistance from OpenAI Codex and reviewed by BenCodez.

### Testing
- Ran repository checks `git diff --check` and staged/commit validations which passed. 
- Added `AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/messages/PlaceholderUtilsTest.java` to assert that `PlaceholderUtils.replaceJavascriptOnly(...)` does not call `PlaceholderAPI`. 
- Attempted to run `mvn -Dtest=PlaceholderUtilsTest test` but the build could not complete because Maven failed to resolve `maven-resources-plugin:3.3.1` from Maven Central (HTTP 403), so the unit test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7692f934008327ac7a90310bb22ac8)