### PR TITLE
Reduce unnecessary Maven repository lookups

### DIFF
--- a/AdvancedCore/pom.xml
+++ b/AdvancedCore/pom.xml
@@ -131,21 +131,33 @@
     </build>
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
         <repository>
             <id>placeholderapi</id>
             <url>
                 https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
-        </repository>
-        <repository>
-            <id>bungeecord-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>papermc</id>
@@ -161,6 +173,9 @@
         <repository>
             <id>codemc-repo</id>
             <url>https://repo.codemc.org/repository/maven-public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>bencodez repo</id>
@@ -173,10 +188,16 @@
         <repository>
             <id>opencollab-snapshot</id>
             <url>https://repo.opencollab.dev/main/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>nickuc-repo</id>
             <url>https://repo.nickuc.com/maven-releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <dependencies>


### PR DESCRIPTION
## Summary
- add real Maven Central explicitly for normal release dependencies
- remove the legacy `oss.sonatype.org` BungeeCord snapshot repository
- make the Spigot repository snapshot-only
- disable snapshot resolution on PlaceholderAPI, JitPack, CodeMC, OpenCollab, and NickUC repositories
- keep BenCodez snapshot resolution enabled with `updatePolicy=always` for `simpleapi`

## Why
VotingPlugin builds stalled in both Jenkins and GitHub Actions while Maven waited on legacy/unrelated repositories. The fix in VotingPlugin showed that normal release dependencies resolve reliably when Maven Central is used first and custom repositories are restricted to the artifact types they actually serve.

AdvancedCore is especially important because its published POM is consumed transitively by downstream plugins. Its current POM still exports the old `oss.sonatype.org` snapshot repository and permits unrelated repositories to participate in snapshot resolution. This change removes that legacy path and narrows repository participation without changing dependency versions or runtime behavior.