### PR TITLE
Fix core scheduling, command, and thread correctness issues

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/BInventory.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/BInventory.java
@@ -394,7 +394,7 @@ public class BInventory {
 		if (futures == null) {
 			futures = new ArrayList<>();
 		}
-		futures.add(plugin.getInventoryTimer().scheduleWithFixedDelay(runnable, delay, delay, TimeUnit.MILLISECONDS));
+		futures.add(plugin.getInventoryTimer().scheduleWithFixedDelay(runnable, delay, interval, TimeUnit.MILLISECONDS));
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
@@ -72,7 +72,7 @@ public class MiscUtils {
 	 */
 	public Date addSeconds(Date date, int seconds) {
 		Calendar c = Calendar.getInstance();
-		c.setTime(new Date());
+		c.setTime(date);
 		c.add(Calendar.SECOND, seconds);
 		return c.getTime();
 	}
@@ -165,6 +165,7 @@ public class MiscUtils {
 			for (final String cmd : commands) {
 				plugin.debug("Executing console command: " + cmd);
 				runConsoleCommand(cmd, tick, stagger);
+				tick++;
 			}
 
 		}
@@ -181,6 +182,7 @@ public class MiscUtils {
 			for (final String cmd : commands) {
 				plugin.debug("Executing console command: " + cmd);
 				runConsoleCommand(cmd, tick, stagger);
+				tick++;
 			}
 
 		}
@@ -191,7 +193,7 @@ public class MiscUtils {
 			String cmd = PlaceholderUtils.replaceJavascriptOnly(player, command);
 			cmd = PlaceholderUtils.replacePlaceHolder(cmd, placeholders);
 			cmd = PlaceholderUtils.replacePlaceHolders(player, cmd);
-			final String finalCommand = cmd;
+			final String finalCommand = stripLeadingSlash(cmd);
 
 			plugin.debug("Executing console command: " + command);
 			plugin.getBukkitScheduler().executeOrScheduleSync(plugin, new Runnable() {
@@ -224,6 +226,7 @@ public class MiscUtils {
 			for (final String cmd : commands) {
 				plugin.debug("Executing console command: " + cmd);
 				runConsoleCommand(cmd, tick, stagger);
+				tick++;
 			}
 		}
 	}
@@ -238,10 +241,7 @@ public class MiscUtils {
 			if (p != null) {
 				command = PlaceholderUtils.replacePlaceHolders(p, command);
 			}
-			if (command.startsWith("/")) {
-				command.replaceFirst("/", "");
-			}
-			final String cmd = command;
+			final String cmd = stripLeadingSlash(command);
 
 			plugin.debug("Executing console command: " + command);
 			plugin.getBukkitScheduler().executeOrScheduleSync(plugin, new Runnable() {
@@ -458,12 +458,13 @@ public class MiscUtils {
 	}
 
 	private void runConsoleCommand(String command, int delay, boolean hasDelay) {
+		final String commandToRun = stripLeadingSlash(command);
 		if (hasDelay && delay > 0) {
 			plugin.getBukkitScheduler().runTaskLater(plugin, new Runnable() {
 
 				@Override
 				public void run() {
-					Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), command);
+					Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), commandToRun);
 				}
 			}, delay);
 
@@ -472,10 +473,17 @@ public class MiscUtils {
 
 				@Override
 				public void run() {
-					Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), command);
+					Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), commandToRun);
 				}
 			});
 		}
+	}
+
+	private String stripLeadingSlash(String command) {
+		if (command != null && command.startsWith("/")) {
+			return command.substring(1);
+		}
+		return command;
 	}
 
 	public void setBlockMeta(Block block, String str, Object value) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/thread/FileThread.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/thread/FileThread.java
@@ -115,12 +115,12 @@ public class FileThread {
 
 		@Override
 		public void run() {
-			while (!thread.isInterrupted()) {
+			while (!isInterrupted()) {
 				try {
 					sleep(50);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
-					System.exit(0);
+					interrupt();
+					break;
 				}
 			}
 		}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/thread/Thread.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/thread/Thread.java
@@ -29,12 +29,12 @@ public class Thread {
 
 		@Override
 		public void run() {
-			while (!thread.isInterrupted()) {
+			while (!isInterrupted()) {
 				try {
 					sleep(50);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
-					System.exit(0);
+					interrupt();
+					break;
 				}
 			}
 		}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/inventory/BInventoryTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/inventory/BInventoryTest.java
@@ -1,6 +1,7 @@
 package com.bencodez.advancedcore.tests.inventory;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,15 +18,15 @@ import com.bencodez.advancedcore.api.inventory.BInventory;
 public class BInventoryTest {
 
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void updatingButtonUsesConfiguredIntervalAndCancelsFuture() {
 		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
 		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
-		@SuppressWarnings("unchecked")
-		ScheduledFuture<Object> future = mock(ScheduledFuture.class);
+		ScheduledFuture future = mock(ScheduledFuture.class);
 		Runnable runnable = mock(Runnable.class);
 		when(plugin.getInventoryTimer()).thenReturn(timer);
-		when(timer.scheduleWithFixedDelay(eq(runnable), eq(100L), eq(250L), eq(TimeUnit.MILLISECONDS)))
-				.thenReturn(future);
+		doReturn(future).when(timer).scheduleWithFixedDelay(eq(runnable), eq(100L), eq(250L),
+				eq(TimeUnit.MILLISECONDS));
 
 		BInventory inventory = new BInventory("Test");
 		inventory.addUpdatingButton(plugin, 100L, 250L, runnable);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/inventory/BInventoryTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/inventory/BInventoryTest.java
@@ -1,0 +1,37 @@
+package com.bencodez.advancedcore.tests.inventory;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.inventory.BInventory;
+
+public class BInventoryTest {
+
+	@Test
+	public void updatingButtonUsesConfiguredIntervalAndCancelsFuture() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		@SuppressWarnings("unchecked")
+		ScheduledFuture<Object> future = mock(ScheduledFuture.class);
+		Runnable runnable = mock(Runnable.class);
+		when(plugin.getInventoryTimer()).thenReturn(timer);
+		when(timer.scheduleWithFixedDelay(eq(runnable), eq(100L), eq(250L), eq(TimeUnit.MILLISECONDS)))
+				.thenReturn(future);
+
+		BInventory inventory = new BInventory("Test");
+		inventory.addUpdatingButton(plugin, 100L, 250L, runnable);
+		inventory.cancelTimer();
+
+		verify(timer).scheduleWithFixedDelay(runnable, 100L, 250L, TimeUnit.MILLISECONDS);
+		verify(future).cancel(true);
+	}
+}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
@@ -1,0 +1,86 @@
+package com.bencodez.advancedcore.tests.misc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.command.ConsoleCommandSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.misc.MiscUtils;
+import com.bencodez.advancedcore.tests.BaseTest;
+import com.bencodez.simpleapi.scheduler.BukkitScheduler;
+
+public class MiscUtilsTest {
+
+	private AdvancedCorePlugin plugin;
+	private BukkitScheduler scheduler;
+	private MiscUtils miscUtils;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		plugin = BaseTest.getInstance().plugin;
+		scheduler = mock(BukkitScheduler.class);
+		when(plugin.getBukkitScheduler()).thenReturn(scheduler);
+		miscUtils = MiscUtils.getInstance();
+
+		Field pluginField = MiscUtils.class.getDeclaredField("plugin");
+		pluginField.setAccessible(true);
+		pluginField.set(miscUtils, plugin);
+	}
+
+	@Test
+	public void addSecondsUsesProvidedDate() {
+		Date base = new Date(1_000_000L);
+
+		Date result = miscUtils.addSeconds(base, 30);
+
+		assertEquals(1_030_000L, result.getTime());
+	}
+
+	@Test
+	public void staggeredCommandsIncrementDelayForEachCommand() {
+		ArrayList<String> commands = new ArrayList<>(List.of("first", "second", "third"));
+
+		miscUtils.executeConsoleCommands(commands, new HashMap<>(), true);
+
+		verify(scheduler).runTask(eq(plugin), any(Runnable.class));
+		verify(scheduler).runTaskLater(eq(plugin), any(Runnable.class), eq(1L));
+		verify(scheduler).runTaskLater(eq(plugin), any(Runnable.class), eq(2L));
+	}
+
+	@Test
+	public void consoleCommandsStripLeadingSlashBeforeDispatch() {
+		Server server = mock(Server.class);
+		ConsoleCommandSender console = mock(ConsoleCommandSender.class);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(Bukkit::getServer).thenReturn(server);
+			bukkit.when(Bukkit::getConsoleSender).thenReturn(console);
+			bukkit.when(() -> Bukkit.getOfflinePlayer("Ben")).thenReturn(null);
+
+			miscUtils.executeConsoleCommands("Ben", "/say hi", new HashMap<>());
+
+			verify(scheduler).executeOrScheduleSync(eq(plugin), task.capture());
+			task.getValue().run();
+			verify(server).dispatchCommand(console, "say hi");
+		}
+	}
+}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/thread/ThreadInterruptionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/thread/ThreadInterruptionTest.java
@@ -1,0 +1,34 @@
+package com.bencodez.advancedcore.tests.thread;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.thread.FileThread;
+
+public class ThreadInterruptionTest {
+
+	@Test
+	public void fileReadThreadStopsWhenInterrupted() throws InterruptedException {
+		FileThread.ReadThread readThread = FileThread.getInstance().new ReadThread();
+
+		readThread.start();
+		readThread.interrupt();
+		readThread.join(1_000L);
+
+		assertFalse(readThread.isAlive());
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void legacyReadThreadStopsWhenInterrupted() throws InterruptedException {
+		com.bencodez.advancedcore.thread.Thread.ReadThread readThread = com.bencodez.advancedcore.thread.Thread
+				.getInstance().new ReadThread();
+
+		readThread.start();
+		readThread.interrupt();
+		readThread.join(1_000L);
+
+		assertFalse(readThread.isAlive());
+	}
+}


### PR DESCRIPTION
## Summary

Fix several deterministic AdvancedCore correctness issues outside the reward subsystem.

### Thread safety

- remove `System.exit(0)` from `FileThread.ReadThread` interruption handling
- remove `System.exit(0)` from the deprecated `Thread.ReadThread` helper
- treat interruption as normal shutdown: restore the interrupt flag and exit the loop
- use each worker thread's own interruption state instead of the outer thread reference

### Inventory scheduling

- fix `BInventory.addUpdatingButton(...)` to use its `interval` argument as the fixed-delay period instead of incorrectly reusing the initial `delay`
- retain existing timer cancellation behavior

### MiscUtils correctness

- make `addSeconds(Date, int)` add to the supplied date instead of the current time
- increment stagger delay for each list command so staggered commands actually run on successive ticks
- normalize leading `/` consistently before Bukkit console command dispatch, including list/staggered and single-command paths

### Tests

- add `MiscUtilsTest` for supplied-date arithmetic, stagger delay progression, and slash stripping
- add `BInventoryTest` for initial delay/update interval and future cancellation
- add `ThreadInterruptionTest` verifying both legacy worker threads terminate normally when interrupted

This PR is intentionally focused on deterministic correctness fixes and does not change reward behavior or configuration.