### PR TITLE
Refactor EditGUI value handling

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/EditGUI.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/EditGUI.java
@@ -3,7 +3,7 @@ package com.bencodez.advancedcore.api.inventory.editgui;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.bencodez.advancedcore.api.inventory.BInventory;
@@ -13,40 +13,38 @@ import com.bencodez.advancedcore.api.inventory.BInventoryButton;
  * Edit GUI for sorting and organizing edit buttons.
  */
 public class EditGUI extends BInventory {
-
-	/**
-	 * Constructor for EditGUI.
-	 *
-	 * @param name the inventory name
-	 */
 	public EditGUI(String name) {
 		super(name);
 	}
 
 	/**
-	 * Sorts the edit buttons alphabetically by key.
+	 * Sorts edit buttons alphabetically by editor key while retaining non-editor
+	 * buttons and duplicate editor keys.
 	 */
 	public void sort() {
-		Map<Integer, BInventoryButton> map = getButtons();
-		setButtons(new HashMap<>());
-		LinkedHashMap<String, EditGUIButton> buttons = new LinkedHashMap<>();
-		ArrayList<String> sortedList = new ArrayList<>();
-		for (BInventoryButton button : map.values()) {
+		Map<Integer, BInventoryButton> current = getButtons();
+		List<BInventoryButton> fixedButtons = new ArrayList<>();
+		List<EditGUIButton> editButtons = new ArrayList<>();
+
+		for (BInventoryButton button : current.values()) {
 			if (button instanceof EditGUIButton) {
-				EditGUIButton b = (EditGUIButton) button;
-				String key = b.getEditor().getKey();
-				sortedList.add(key);
-				b.setSlot(-1);
-				buttons.put(key, b);
+				EditGUIButton editButton = (EditGUIButton) button;
+				editButton.setSlot(-1);
+				editButtons.add(editButton);
 			} else {
-				addButton(button);
+				fixedButtons.add(button);
 			}
 		}
-		sortedList.sort(Comparator.naturalOrder());
 
-		for (String key : sortedList) {
-			addButton(buttons.get(key));
+		editButtons.sort(Comparator.comparing(button -> button.getEditor().getKey(),
+				Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+
+		setButtons(new HashMap<>());
+		for (BInventoryButton button : fixedButtons) {
+			addButton(button);
+		}
+		for (EditGUIButton button : editButtons) {
+			addButton(button);
 		}
 	}
-
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/EditGUIButton.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/EditGUIButton.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.api.inventory.editgui;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -11,9 +12,7 @@ import com.bencodez.advancedcore.api.inventory.BInventory.ClickEvent;
 import com.bencodez.advancedcore.api.inventory.BInventoryButton;
 import com.bencodez.advancedcore.api.inventory.editgui.valuetypes.EditGUIValue;
 import com.bencodez.advancedcore.api.inventory.editgui.valuetypes.EditGUIValueInventory;
-import com.bencodez.advancedcore.api.inventory.editgui.valuetypes.EditGUIValueList;
 import com.bencodez.advancedcore.api.item.ItemBuilder;
-import com.bencodez.simpleapi.array.ArrayUtils;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -22,89 +21,49 @@ import lombok.Setter;
  * Button for editing GUI values.
  */
 public class EditGUIButton extends BInventoryButton {
-
-	/**
-	 * The editor for this button.
-	 * 
-	 * @return the editor
-	 * @param editor the editor
-	 */
 	@Getter
 	@Setter
 	private EditGUIValue editor;
 
-	/**
-	 * Constructor for EditGUIButton.
-	 *
-	 * @param editer the GUI value editor
-	 */
-	public EditGUIButton(EditGUIValue editer) {
+	public EditGUIButton(EditGUIValue editor) {
 		super(new ItemBuilder(Material.PAPER));
-		this.editor = editer;
+		this.editor = editor;
 	}
 
-	/**
-	 * Constructor for EditGUIButton with custom item.
-	 *
-	 * @param item the item builder
-	 * @param editer the GUI value editor
-	 */
-	public EditGUIButton(ItemBuilder item, EditGUIValue editer) {
+	public EditGUIButton(ItemBuilder item, EditGUIValue editor) {
 		super(item);
-		this.editor = editer;
+		this.editor = editor;
 	}
 
-	/**
-	 * Adds a lore line to the button.
-	 *
-	 * @param lore the lore line
-	 * @return this instance
-	 */
 	public EditGUIButton addLore(String lore) {
 		getEditor().addLore(lore);
 		return this;
 	}
 
-	/**
-	 * Adds options to the button.
-	 *
-	 * @param str the options
-	 * @return this instance
-	 */
-	public EditGUIButton addOptions(String... str) {
-		getEditor().addOptions(str);
+	public EditGUIButton addOptions(String... values) {
+		getEditor().addOptions(values);
 		return this;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public ItemStack getItem(Player player, HashMap<String, String> placeholders) {
 		ItemBuilder builder = getBuilder();
 		builder.addPlaceholder(placeholders);
-		if ((getEditor() instanceof EditGUIValueInventory)) {
-			if (!builder.hasCustomDisplayName()) {
-				builder.setName("&cSet " + getEditor().getKey());
-			}
-			builder.setLore("&cClick to open");
-		} else if (!(getEditor() instanceof EditGUIValueList)) {
-			if (!builder.hasCustomDisplayName()) {
-				builder.setName("&cSet " + getEditor().getType() + " for " + getEditor().getKey());
-			}
-			builder.setLore("&cCurrent value: " + getEditor().getCurrentValue());
+
+		if (getEditor() instanceof EditGUIValueInventory) {
+			applyInventoryDisplay(builder);
 		} else {
 			if (!builder.hasCustomDisplayName()) {
-				builder.setName("&cEdit list for " + getEditor().getKey());
+				builder.setName(getEditor().getButtonName());
 			}
-			if (getEditor().getCurrentValue() instanceof ArrayList<?>) {
-				builder.setLore(ArrayUtils.makeStringList((ArrayList<String>) getEditor().getCurrentValue()));
-			} else {
-				builder.setLore("&cCurrent value: null");
-			}
+			List<String> lore = getEditor().getButtonLore();
+			builder.setLore(lore == null ? new String[0] : lore.toArray(new String[0]));
 		}
-		ArrayList<String> lores = getEditor().getLores();
-		if (lores != null) {
-			for (String t : lores) {
-				builder.addLoreLine("&3" + t);
+
+		ArrayList<String> customLore = getEditor().getLores();
+		if (customLore != null) {
+			for (String line : customLore) {
+				builder.addLoreLine("&3" + line);
 			}
 		}
 		return builder.toItemStack(player);
@@ -116,14 +75,15 @@ public class EditGUIButton extends BInventoryButton {
 		getEditor().onClick(clickEvent);
 	}
 
-	/**
-	 * Sets the name of the button.
-	 *
-	 * @param name the name
-	 * @return this instance
-	 */
 	public EditGUIButton setName(String name) {
-		this.getBuilder().setName(name);
+		getBuilder().setName(name);
 		return this;
+	}
+
+	private void applyInventoryDisplay(ItemBuilder builder) {
+		if (!builder.hasCustomDisplayName()) {
+			builder.setName("&cSet " + getEditor().getKey());
+		}
+		builder.setLore("&cClick to open");
 	}
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValue.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValue.java
@@ -1,11 +1,19 @@
 package com.bencodez.advancedcore.api.inventory.editgui.valuetypes;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
 
+import org.bukkit.entity.Player;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.inventory.BInventory;
 import com.bencodez.advancedcore.api.inventory.BInventory.ClickEvent;
 import com.bencodez.advancedcore.api.rewards.RewardEditData;
+import com.bencodez.simpleapi.messages.MessageAPI;
 import com.bencodez.simpleapi.valuerequest.InputMethod;
+import com.bencodez.simpleapi.valuerequest.ValueRequest;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -14,172 +22,172 @@ import lombok.Setter;
  * Abstract base class for GUI edit values.
  */
 public abstract class EditGUIValue {
-	/**
-	 * Whether the value can be retrieved.
-	 */
 	@Getter
 	@Setter
 	private boolean canGetValue = true;
 
-	/**
-	 * The current value.
-	 */
 	@Getter
 	@Setter
 	private Object currentValue;
 
-	/**
-	 * The input method.
-	 */
 	@Getter
 	@Setter
 	private InputMethod inputMethod = InputMethod.DIALOG;
 
-	/**
-	 * The inventory.
-	 */
 	@Getter
 	@Setter
 	private BInventory inv;
 
-	/**
-	 * The key.
-	 */
 	@Getter
 	@Setter
 	private String key;
 
-	/**
-	 * The lore lines.
-	 */
 	@Getter
 	@Setter
 	private ArrayList<String> lores;
 
-	/**
-	 * The options.
-	 */
 	@Getter
-	private ArrayList<String> options = new ArrayList<String>();
+	private final ArrayList<String> options = new ArrayList<>();
 
-	/**
-	 * Adds lore lines to this value.
-	 *
-	 * @param lore the lore lines to add
-	 * @return this instance
-	 */
+	protected EditGUIValue() {
+	}
+
+	protected EditGUIValue(String key, Object currentValue) {
+		this.key = key;
+		this.currentValue = currentValue;
+	}
+
 	public EditGUIValue addLore(ArrayList<String> lore) {
+		if (lore == null || lore.isEmpty()) {
+			return this;
+		}
 		if (lores == null) {
-			lores = new ArrayList<String>();
+			lores = new ArrayList<>();
 		}
 		lores.addAll(lore);
 		return this;
 	}
 
-	/**
-	 * Adds a lore line to this value.
-	 *
-	 * @param lore the lore line to add
-	 * @return this instance
-	 */
 	public EditGUIValue addLore(String lore) {
+		if (lore == null) {
+			return this;
+		}
 		if (lores == null) {
-			lores = new ArrayList<String>();
+			lores = new ArrayList<>();
 		}
 		lores.add(lore);
 		return this;
 	}
 
-	/**
-	 * Adds options to this value.
-	 *
-	 * @param str the options to add
-	 * @return this instance
-	 */
-	public EditGUIValue addOptions(String... str) {
-		for (String s : str) {
-			options.add(s);
+	public EditGUIValue addOptions(String... values) {
+		if (values == null) {
+			return this;
+		}
+		for (String value : values) {
+			if (value != null) {
+				options.add(value);
+			}
 		}
 		return this;
 	}
 
-	/**
-	 * Checks if the reward edit data contains this key.
-	 *
-	 * @param rewardEditData the reward edit data
-	 * @return true if key exists
-	 */
 	public boolean containsKey(RewardEditData rewardEditData) {
-		return rewardEditData.hasPath(getKey());
+		return rewardEditData != null && rewardEditData.hasPath(getKey());
 	}
 
-	/**
-	 * Uses the dialog input method.
-	 *
-	 * @return this instance
-	 */
 	public EditGUIValue dialog() {
 		return inputMethod(InputMethod.DIALOG);
 	}
 
-	/**
-	 * Uses the chat input method.
-	 *
-	 * @return this instance
-	 */
 	public EditGUIValue chat() {
 		return inputMethod(InputMethod.CHAT);
 	}
 
-	/**
-	 * Uses the inventory input method.
-	 *
-	 * @return this instance
-	 */
 	public EditGUIValue inventory() {
 		return inputMethod(InputMethod.INVENTORY);
 	}
 
-	/**
-	 * Uses the book input method.
-	 *
-	 * @return this instance
-	 */
 	public EditGUIValue book() {
 		return inputMethod(InputMethod.BOOK);
 	}
 
-	/**
-	 * Uses the sign input method.
-	 *
-	 * @return this instance
-	 */
 	public EditGUIValue sign() {
 		return inputMethod(InputMethod.SIGN);
 	}
 
-	/**
-	 * Gets the type of this value.
-	 *
-	 * @return the type
-	 */
 	public abstract String getType();
 
 	/**
-	 * Sets the input method for this value.
-	 *
-	 * @param inputMethod the input method
-	 * @return this instance
+	 * Default display name used by {@link com.bencodez.advancedcore.api.inventory.editgui.EditGUIButton}.
 	 */
-	public EditGUIValue inputMethod(InputMethod inputMethod) {
-		this.inputMethod = inputMethod;
-		return this;
+	public String getButtonName() {
+		return "&cSet " + getType() + " for " + getKey();
 	}
 
 	/**
-	 * Handles click events for this value.
-	 *
-	 * @param event the click event
+	 * Default display lore used by {@link com.bencodez.advancedcore.api.inventory.editgui.EditGUIButton}.
 	 */
+	public List<String> getButtonLore() {
+		return List.of("&cCurrent value: " + String.valueOf(getCurrentValue()));
+	}
+
+	public EditGUIValue inputMethod(InputMethod inputMethod) {
+		this.inputMethod = inputMethod == null ? InputMethod.DIALOG : inputMethod;
+		return this;
+	}
+
 	public abstract void onClick(ClickEvent event);
+
+	protected ValueRequest createValueRequest() {
+		return createValueRequest(getInputMethod());
+	}
+
+	protected ValueRequest createValueRequest(InputMethod method) {
+		AdvancedCorePlugin plugin = AdvancedCorePlugin.getInstance();
+		return new ValueRequest(plugin, plugin.getDialogService(), method == null ? InputMethod.DIALOG : method);
+	}
+
+	protected <T> void applyValue(Player player, T value, Consumer<T> saveAction) {
+		saveAction.accept(value);
+		setCurrentValue(value);
+		if (player != null) {
+			player.sendMessage(MessageAPI.colorize("&cSetting " + getKey() + " to " + String.valueOf(value)));
+		}
+	}
+
+	protected String currentString(String defaultValue) {
+		Object current = getCurrentValue();
+		return current == null ? defaultValue : String.valueOf(current);
+	}
+
+	protected Number currentNumber(Number defaultValue) {
+		Object current = getCurrentValue();
+		if (current instanceof Number) {
+			return (Number) current;
+		}
+		if (current != null) {
+			try {
+				return Double.valueOf(String.valueOf(current));
+			} catch (NumberFormatException ignored) {
+				// Fall through to the supplied default.
+			}
+		}
+		return defaultValue;
+	}
+
+	protected ArrayList<String> currentStringList() {
+		return toStringList(getCurrentValue());
+	}
+
+	protected ArrayList<String> toStringList(Object value) {
+		ArrayList<String> values = new ArrayList<>();
+		if (value instanceof Collection<?>) {
+			for (Object entry : (Collection<?>) value) {
+				if (entry != null) {
+					values.add(String.valueOf(entry));
+				}
+			}
+		}
+		return values;
+	}
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueBoolean.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueBoolean.java
@@ -2,24 +2,14 @@ package com.bencodez.advancedcore.api.inventory.editgui.valuetypes;
 
 import org.bukkit.entity.Player;
 
-import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.inventory.BInventory.ClickEvent;
-import com.bencodez.simpleapi.messages.MessageAPI;
-import com.bencodez.simpleapi.valuerequest.ValueRequest;
 
 /**
  * Abstract GUI value for boolean editing.
  */
 public abstract class EditGUIValueBoolean extends EditGUIValue {
-	/**
-	 * Constructor for EditGUIValueBoolean.
-	 *
-	 * @param key the key
-	 * @param value the initial value
-	 */
 	public EditGUIValueBoolean(String key, Object value) {
-		setKey(key);
-		setCurrentValue(value);
+		super(key, value);
 	}
 
 	@Override
@@ -29,23 +19,11 @@ public abstract class EditGUIValueBoolean extends EditGUIValue {
 
 	@Override
 	public void onClick(ClickEvent clickEvent) {
-		if (getCurrentValue() == null) {
-			setCurrentValue(Boolean.FALSE);
-		}
-		new ValueRequest(AdvancedCorePlugin.getInstance(), AdvancedCorePlugin.getInstance().getDialogService(),
-				getInputMethod()).requestBoolean(clickEvent.getPlayer(), Boolean.valueOf(String.valueOf(getCurrentValue())),
-				"Type cancel to cancel", (Player player, boolean value) -> {
-					setValue(player, value);
-					setCurrentValue(Boolean.valueOf(value));
-					player.sendMessage(MessageAPI.colorize("&cSetting " + getKey() + " to " + value));
-				});
+		boolean current = Boolean.parseBoolean(currentString("false"));
+		createValueRequest().requestBoolean(clickEvent.getPlayer(), current, "Type cancel to cancel",
+				(Player player, boolean value) -> applyValue(player, Boolean.valueOf(value),
+						newValue -> setValue(player, newValue.booleanValue())));
 	}
 
-	/**
-	 * Sets the boolean value.
-	 *
-	 * @param player the player
-	 * @param value the value to set
-	 */
 	public abstract void setValue(Player player, boolean value);
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueList.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueList.java
@@ -1,31 +1,23 @@
 package com.bencodez.advancedcore.api.inventory.editgui.valuetypes;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
-import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.inventory.BInventory;
 import com.bencodez.advancedcore.api.inventory.BInventory.ClickEvent;
 import com.bencodez.advancedcore.api.inventory.BInventoryButton;
 import com.bencodez.advancedcore.api.item.ItemBuilder;
 import com.bencodez.simpleapi.valuerequest.InputMethod;
-import com.bencodez.simpleapi.valuerequest.ValueRequest;
 
 /**
  * Abstract GUI value for list editing.
  */
 public abstract class EditGUIValueList extends EditGUIValue {
-	/**
-	 * Constructor for EditGUIValueList.
-	 *
-	 * @param key the key
-	 * @param value the initial value
-	 */
 	public EditGUIValueList(String key, Object value) {
-		setKey(key);
-		setCurrentValue(value);
+		super(key, value);
 	}
 
 	@Override
@@ -34,59 +26,66 @@ public abstract class EditGUIValueList extends EditGUIValue {
 	}
 
 	@Override
+	public String getButtonName() {
+		return "&cEdit list for " + getKey();
+	}
+
+	@Override
+	public List<String> getButtonLore() {
+		ArrayList<String> current = currentStringList();
+		return current.isEmpty() && getCurrentValue() == null ? List.of("&cCurrent value: null") : current;
+	}
+
+	@Override
 	public void onClick(ClickEvent clickEvent) {
-		if (getCurrentValue() == null) {
-			setCurrentValue(new ArrayList<String>());
-		}
-		BInventory inv = new BInventory("Edit list: " + getKey());
-		inv.setMeta(clickEvent.getPlayer(), "Value", getCurrentValue());
-		inv.addButton(new BInventoryButton(new ItemBuilder(Material.EMERALD_BLOCK).setName("&cAdd value")) {
+		ArrayList<String> initial = currentStringList();
+		setCurrentValue(initial);
+
+		BInventory inventory = new BInventory("Edit list: " + getKey());
+		inventory.setMeta(clickEvent.getPlayer(), "Value", new ArrayList<>(initial));
+		inventory.addButton(createAddButton());
+		inventory.addButton(createRemoveButton());
+		inventory.openInventory(clickEvent.getPlayer());
+	}
+
+	private BInventoryButton createAddButton() {
+		return new BInventoryButton(new ItemBuilder(Material.EMERALD_BLOCK).setName("&cAdd value")) {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				new ValueRequest(AdvancedCorePlugin.getInstance(), AdvancedCorePlugin.getInstance().getDialogService(),
-						getInputMethod()).requestString(clickEvent.getPlayer(), (String) null, null, true,
+				createValueRequest().requestString(clickEvent.getPlayer(), (String) null, null, true,
 						"Type cancel to cancel", (Player player, String add) -> {
-							@SuppressWarnings("unchecked")
-							ArrayList<String> list = (ArrayList<String>) getMeta(player, "Value");
-							if (list == null) {
-								list = new ArrayList<String>();
-							}
+							ArrayList<String> list = EditGUIValueList.this.toStringList(getMeta(player, "Value"));
 							list.add(add);
-							setCurrentValue(list);
-							setValue(player, list);
+							setMeta(player, "Value", list);
+							applyValue(player, list, newValue -> setValue(player, new ArrayList<>(newValue)));
 							sendMessage(player, "&cAdded " + add + " to " + getKey());
 						});
 			}
-		});
-		inv.addButton(new BInventoryButton(new ItemBuilder(Material.BARRIER).setName("&cRemove value")) {
-			@SuppressWarnings("unchecked")
-			@Override
-			public void onClick(ClickEvent clickEvent) {
-				ArrayList<String> list = (ArrayList<String>) getMeta(clickEvent.getPlayer(), "Value");
-				if (!list.isEmpty()) {
-					InputMethod removeMethod = getInputMethod() == InputMethod.BOOK ? InputMethod.CHAT : getInputMethod();
-					new ValueRequest(AdvancedCorePlugin.getInstance(), AdvancedCorePlugin.getInstance().getDialogService(),
-							removeMethod).requestString(clickEvent.getPlayer(), (String) null, new ArrayList<String>(list), false,
-							"Type cancel to cancel", (Player player, String remove) -> {
-								ArrayList<String> currentList = (ArrayList<String>) getMeta(player, "Value");
-								currentList.remove(remove);
-								setCurrentValue(currentList);
-								setValue(player, currentList);
-								sendMessage(player, "&cRemoved " + remove + " from " + getKey());
-							});
-				} else {
-					clickEvent.getPlayer().sendMessage("No values to remove");
-				}
-			}
-		});
-		inv.openInventory(clickEvent.getPlayer());
+		};
 	}
 
-	/**
-	 * Sets the list value.
-	 *
-	 * @param player the player
-	 * @param value the list to set
-	 */
+	private BInventoryButton createRemoveButton() {
+		return new BInventoryButton(new ItemBuilder(Material.BARRIER).setName("&cRemove value")) {
+			@Override
+			public void onClick(ClickEvent clickEvent) {
+				ArrayList<String> list = EditGUIValueList.this.toStringList(getMeta(clickEvent.getPlayer(), "Value"));
+				if (list.isEmpty()) {
+					clickEvent.getPlayer().sendMessage("No values to remove");
+					return;
+				}
+
+				InputMethod removeMethod = getInputMethod() == InputMethod.BOOK ? InputMethod.CHAT : getInputMethod();
+				createValueRequest(removeMethod).requestString(clickEvent.getPlayer(), (String) null, new ArrayList<>(list),
+						false, "Type cancel to cancel", (Player player, String remove) -> {
+							ArrayList<String> current = EditGUIValueList.this.toStringList(getMeta(player, "Value"));
+							current.remove(remove);
+							setMeta(player, "Value", current);
+							applyValue(player, current, newValue -> setValue(player, new ArrayList<>(newValue)));
+							sendMessage(player, "&cRemoved " + remove + " from " + getKey());
+						});
+			}
+		};
+	}
+
 	public abstract void setValue(Player player, ArrayList<String> value);
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueNumber.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueNumber.java
@@ -6,24 +6,14 @@ import java.util.List;
 
 import org.bukkit.entity.Player;
 
-import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.inventory.BInventory.ClickEvent;
-import com.bencodez.simpleapi.messages.MessageAPI;
-import com.bencodez.simpleapi.valuerequest.ValueRequest;
 
 /**
  * Abstract GUI value for number editing.
  */
 public abstract class EditGUIValueNumber extends EditGUIValue {
-	/**
-	 * Constructor for EditGUIValueNumber.
-	 *
-	 * @param key the key
-	 * @param value the initial value
-	 */
 	public EditGUIValueNumber(String key, Object value) {
-		setKey(key);
-		setCurrentValue(value);
+		super(key, value);
 	}
 
 	@Override
@@ -33,42 +23,14 @@ public abstract class EditGUIValueNumber extends EditGUIValue {
 
 	@Override
 	public void onClick(ClickEvent clickEvent) {
-		if (getCurrentValue() == null) {
-			setCurrentValue(Integer.valueOf(0));
-		}
-		new ValueRequest(AdvancedCorePlugin.getInstance(), AdvancedCorePlugin.getInstance().getDialogService(),
-				getInputMethod()).requestNumber(clickEvent.getPlayer(), getCurrentNumber(), getDefaultOptions(), true,
-				"Type cancel to cancel", (Player player, Number number) -> {
-					setValue(player, number);
-					setCurrentValue(number);
-					player.sendMessage(MessageAPI.colorize("&cSetting " + getKey() + " to " + number.doubleValue()));
-				});
+		Number current = currentNumber(Integer.valueOf(0));
+		createValueRequest().requestNumber(clickEvent.getPlayer(), current, getDefaultOptions(current), true,
+				"Type cancel to cancel", (Player player, Number number) -> applyValue(player, number,
+						newValue -> setValue(player, newValue)));
 	}
 
-	/**
-	 * Gets the current value as a number.
-	 *
-	 * @return the current number value
-	 */
-	private Number getCurrentNumber() {
-		Object current = getCurrentValue();
-		if (current instanceof Number) {
-			return (Number) current;
-		}
-		try {
-			return Double.valueOf(String.valueOf(current));
-		} catch (NumberFormatException ex) {
-			return Integer.valueOf(0);
-		}
-	}
-
-	/**
-	 * Builds the default number options including the current value.
-	 *
-	 * @return the list of default number options
-	 */
-	private List<Number> getDefaultOptions() {
-		LinkedHashSet<Number> values = new LinkedHashSet<Number>();
+	private List<Number> getDefaultOptions(Number current) {
+		LinkedHashSet<Number> values = new LinkedHashSet<>();
 		values.add(Integer.valueOf(0));
 		values.add(Integer.valueOf(10));
 		values.add(Integer.valueOf(25));
@@ -76,15 +38,9 @@ public abstract class EditGUIValueNumber extends EditGUIValue {
 		values.add(Integer.valueOf(100));
 		values.add(Integer.valueOf(500));
 		values.add(Integer.valueOf(1000));
-		values.add(getCurrentNumber());
-		return new ArrayList<Number>(values);
+		values.add(current);
+		return new ArrayList<>(values);
 	}
 
-	/**
-	 * Sets the number value.
-	 *
-	 * @param player the player
-	 * @param num the number to set
-	 */
 	public abstract void setValue(Player player, Number num);
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueString.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/inventory/editgui/valuetypes/EditGUIValueString.java
@@ -2,24 +2,14 @@ package com.bencodez.advancedcore.api.inventory.editgui.valuetypes;
 
 import org.bukkit.entity.Player;
 
-import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.inventory.BInventory.ClickEvent;
-import com.bencodez.simpleapi.messages.MessageAPI;
-import com.bencodez.simpleapi.valuerequest.ValueRequest;
 
 /**
  * Abstract GUI value for string editing.
  */
 public abstract class EditGUIValueString extends EditGUIValue {
-	/**
-	 * Constructor for EditGUIValueString.
-	 *
-	 * @param key   the key
-	 * @param value the initial value
-	 */
 	public EditGUIValueString(String key, Object value) {
-		setKey(key);
-		setCurrentValue(value);
+		super(key, value);
 	}
 
 	@Override
@@ -29,23 +19,10 @@ public abstract class EditGUIValueString extends EditGUIValue {
 
 	@Override
 	public void onClick(ClickEvent clickEvent) {
-		if (getCurrentValue() == null) {
-			setCurrentValue("");
-		}
-		new ValueRequest(AdvancedCorePlugin.getInstance(), AdvancedCorePlugin.getInstance().getDialogService(),
-				getInputMethod()).requestString(clickEvent.getPlayer(), String.valueOf(getCurrentValue()), getOptions(),
-						true, "Type cancel to cancel", (Player player, String value) -> {
-							setValue(player, value);
-							setCurrentValue(value);
-							player.sendMessage(MessageAPI.colorize("&cSetting " + getKey() + " to " + value));
-						});
+		createValueRequest().requestString(clickEvent.getPlayer(), currentString(""), getOptions(), true,
+				"Type cancel to cancel", (Player player, String value) -> applyValue(player, value,
+						newValue -> setValue(player, newValue)));
 	}
 
-	/**
-	 * Sets the string value.
-	 *
-	 * @param player the player
-	 * @param value  the value to set
-	 */
 	public abstract void setValue(Player player, String value);
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/inventory/EditGUIValueBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/inventory/EditGUIValueBehaviorTest.java
@@ -1,0 +1,122 @@
+package com.bencodez.advancedcore.tests.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.api.inventory.BInventory.ClickEvent;
+import com.bencodez.advancedcore.api.inventory.editgui.valuetypes.EditGUIValue;
+import com.bencodez.advancedcore.api.inventory.editgui.valuetypes.EditGUIValueList;
+import com.bencodez.simpleapi.valuerequest.InputMethod;
+
+public class EditGUIValueBehaviorTest {
+
+	@Test
+	public void commonValueNormalizationHandlesNullsAndStringNumbers() {
+		TestValue value = new TestValue("Example", null);
+
+		assertEquals("fallback", value.stringValue("fallback"));
+		assertEquals(Integer.valueOf(5), value.numberValue(Integer.valueOf(5)));
+
+		value.setCurrentValue("12.5");
+		assertEquals(12.5D, value.numberValue(Integer.valueOf(0)).doubleValue());
+
+		value.setCurrentValue("not-a-number");
+		assertEquals(Integer.valueOf(7), value.numberValue(Integer.valueOf(7)));
+	}
+
+	@Test
+	public void stringListNormalizationAcceptsAnyCollectionAndIgnoresNulls() {
+		TestValue value = new TestValue("List", List.of());
+		ArrayList<Object> input = new ArrayList<>();
+		input.add("one");
+		input.add(Integer.valueOf(2));
+		input.add(null);
+		value.setCurrentValue(input);
+
+		assertEquals(List.of("one", "2"), value.stringListValue());
+	}
+
+	@Test
+	public void applyValueUpdatesCurrentValueAndInvokesPersistenceHook() {
+		TestValue value = new TestValue("Example", "old");
+		AtomicReference<String> saved = new AtomicReference<>();
+
+		value.apply(null, "new", saved::set);
+
+		assertEquals("new", saved.get());
+		assertEquals("new", value.getCurrentValue());
+	}
+
+	@Test
+	public void nullInputMethodFallsBackToDialog() {
+		TestValue value = new TestValue("Example", null);
+		value.inputMethod(null);
+		assertEquals(InputMethod.DIALOG, value.getInputMethod());
+	}
+
+	@Test
+	public void defaultAndListDisplayMetadataAreCentralized() {
+		TestValue value = new TestValue("Example", "value");
+		assertEquals("&cSet test for Example", value.getButtonName());
+		assertEquals(List.of("&cCurrent value: value"), value.getButtonLore());
+
+		EditGUIValueList list = new EditGUIValueList("Entries", new ArrayList<>(List.of("a", "b"))) {
+			@Override
+			public void setValue(Player player, ArrayList<String> value) {
+			}
+		};
+		assertEquals("&cEdit list for Entries", list.getButtonName());
+		assertEquals(List.of("a", "b"), list.getButtonLore());
+
+		EditGUIValueList nullList = new EditGUIValueList("Entries", null) {
+			@Override
+			public void setValue(Player player, ArrayList<String> value) {
+			}
+		};
+		assertEquals(List.of("&cCurrent value: null"), nullList.getButtonLore());
+	}
+
+	@Test
+	public void containsKeyHandlesMissingEditData() {
+		TestValue value = new TestValue("Example", null);
+		assertFalse(value.containsKey(null));
+	}
+
+	private static final class TestValue extends EditGUIValue {
+		private TestValue(String key, Object value) {
+			super(key, value);
+		}
+
+		@Override
+		public String getType() {
+			return "test";
+		}
+
+		@Override
+		public void onClick(ClickEvent event) {
+		}
+
+		private String stringValue(String fallback) {
+			return currentString(fallback);
+		}
+
+		private Number numberValue(Number fallback) {
+			return currentNumber(fallback);
+		}
+
+		private ArrayList<String> stringListValue() {
+			return currentStringList();
+		}
+
+		private <T> void apply(Player player, T value, java.util.function.Consumer<T> consumer) {
+			applyValue(player, value, consumer);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Clean up the EditGUI/value-type subsystem while preserving the existing abstract editor classes and downstream `setValue(...)` extension pattern.

### Shared value behavior

- centralize common editor construction in `EditGUIValue`
- centralize `ValueRequest` creation and input-method fallback
- centralize value apply/current-value/message behavior
- centralize string, numeric, and string-list normalization
- make lore/options helpers null-safe
- make `containsKey(...)` null-safe
- expose default editor button name/lore metadata from the value type

### Built-in value editors

- simplify Boolean, Number, and String editors to use the shared request/apply helpers
- make number parsing consistently fall back instead of duplicating parsing logic
- make list values accept generic collections instead of unchecked `ArrayList<String>` casts
- keep list editor metadata synchronized after add/remove operations
- handle empty/missing remove-list metadata safely
- preserve BOOK -> CHAT fallback for list removal

### EditGUI / EditGUIButton

- simplify `EditGUIButton` rendering by using editor-provided display metadata for ordinary/list editors
- retain the existing specialized inventory-editor presentation for compatibility
- simplify EditGUI sorting
- retain duplicate editor keys instead of collapsing them through a temporary key map
- sort editor keys case-insensitively with null keys last

### Tests

Adds focused value behavior tests for:

- null/default string and number handling
- numeric string parsing and invalid-number fallback
- collection-to-string-list normalization
- shared apply/persist/current-value behavior
- input-method fallback
- default/list button display metadata
- null-safe edit-data checks
