### PR TITLE
Make user cache flushing race-safe

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
@@ -161,19 +161,40 @@ public class UserDataCache {
 			}
 		}
 
-		manager.getPlugin().extraDebug("Processing changes for " + currentUuid + ", Changes: " + changes.size());
-		AdvancedCoreUser user = manager.getPlugin().getUserManager().getUser(currentUuid, false);
-		HashMap<String, DataValue> values = new HashMap<>();
-		ArrayList<String> keys = new ArrayList<>();
-		for (UserDataChange change : changes) {
-			values.put(change.getKey(), change.toUserDataValue());
-			keys.add(change.getKey());
-			change.dump();
+		boolean persisted = false;
+		try {
+			manager.getPlugin().extraDebug("Processing changes for " + currentUuid + ", Changes: " + changes.size());
+			AdvancedCoreUser user = manager.getPlugin().getUserManager().getUser(currentUuid, false);
+			HashMap<String, DataValue> values = new HashMap<>();
+			ArrayList<String> keys = new ArrayList<>();
+			for (UserDataChange change : changes) {
+				values.put(change.getKey(), change.toUserDataValue());
+				keys.add(change.getKey());
+			}
+			if (!values.isEmpty()) {
+				user.getUserData().setValues(values);
+			}
+			persisted = true;
+			manager.getPlugin().getUserManager().onChange(user, ArrayUtils.convert(keys));
+			for (UserDataChange change : changes) {
+				change.dump();
+			}
+		} catch (RuntimeException | Error e) {
+			if (!persisted) {
+				requeueChanges(changes);
+			}
+			throw e;
 		}
-		if (!values.isEmpty()) {
-			user.getUserData().setValues(values);
+	}
+
+	private synchronized void requeueChanges(ArrayList<UserDataChange> changes) {
+		if (changes == null || changes.isEmpty() || cachedChanges == null) {
+			return;
 		}
-		manager.getPlugin().getUserManager().onChange(user, ArrayUtils.convert(keys));
+		Queue<UserDataChange> restored = new ConcurrentLinkedQueue<>();
+		restored.addAll(changes);
+		restored.addAll(cachedChanges);
+		cachedChanges = restored;
 	}
 
 	public void processChangesAsync() {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
@@ -25,6 +25,7 @@ public class UserDataCache {
 
 	private final UserDataManager manager;
 	private boolean scheduled = false;
+	private int inFlightBatches = 0;
 	@Getter
 	private UUID uuid;
 
@@ -121,14 +122,28 @@ public class UserDataCache {
 		return list;
 	}
 
-	public synchronized void dump() {
-		if (hasChangesToProcess()) {
+	public void dump() {
+		while (true) {
 			processChanges();
+			synchronized (this) {
+				while (inFlightBatches > 0) {
+					try {
+						wait();
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						return;
+					}
+				}
+				if (cachedChanges != null && !cachedChanges.isEmpty()) {
+					continue;
+				}
+				cache = null;
+				cachedChanges = null;
+				uuid = null;
+				scheduled = false;
+				return;
+			}
 		}
-		cache = null;
-		cachedChanges = null;
-		uuid = null;
-		scheduled = false;
 	}
 
 	public AdvancedCoreUser getUser() {
@@ -159,6 +174,7 @@ public class UserDataCache {
 			while ((change = cachedChanges.poll()) != null) {
 				changes.add(change);
 			}
+			inFlightBatches++;
 		}
 
 		boolean persisted = false;
@@ -184,6 +200,8 @@ public class UserDataCache {
 				requeueChanges(changes);
 			}
 			throw e;
+		} finally {
+			finishInFlightBatch();
 		}
 	}
 
@@ -195,6 +213,13 @@ public class UserDataCache {
 		restored.addAll(changes);
 		restored.addAll(cachedChanges);
 		cachedChanges = restored;
+	}
+
+	private synchronized void finishInFlightBatch() {
+		if (inFlightBatches > 0) {
+			inFlightBatches--;
+		}
+		notifyAll();
 	}
 
 	public void processChangesAsync() {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
@@ -6,6 +6,7 @@ import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
@@ -22,7 +23,7 @@ public class UserDataCache {
 
 	private Queue<UserDataChange> cachedChanges;
 
-	private UserDataManager manager;
+	private final UserDataManager manager;
 	private boolean scheduled = false;
 	@Getter
 	private UUID uuid;
@@ -35,6 +36,9 @@ public class UserDataCache {
 	}
 
 	public synchronized void addChange(UserDataChange change, boolean queue) {
+		if (change == null || cache == null || cachedChanges == null) {
+			return;
+		}
 		cache.put(change.getKey(), change.toUserDataValue());
 		if (queue) {
 			cachedChanges.add(change);
@@ -42,11 +46,10 @@ public class UserDataCache {
 				scheduleChanges();
 			}
 		}
-
 	}
 
-	public UserDataCache cache() {
-		if (uuid != null) {
+	public synchronized UserDataCache cache() {
+		if (uuid != null && cache != null) {
 			AdvancedCoreUser user = getUser();
 			ArrayList<String> keys = user.getUserData().getKeys();
 			HashMap<String, DataValue> data = user.getUserData().getValues();
@@ -58,22 +61,18 @@ public class UserDataCache {
 					DataValue dataValue = data.get(key);
 					manager.getPlugin().devDebug("Caching " + dataValue.getTypeName() + " " + key + " for "
 							+ uuid.toString() + ", value: " + dataValue.toString());
-					// temp try/catch to prevent plugin failures
 					try {
-						if (cache.containsKey(key)) {
-							if (!cache.get(key).toString().equals(dataValue.toString())) {
-								changedKeys.add(key);
-							}
+						if (cache.containsKey(key) && !cache.get(key).toString().equals(dataValue.toString())) {
+							changedKeys.add(key);
 						}
 					} catch (Exception e) {
-						e.printStackTrace();
+						manager.getPlugin().debug(e);
 					}
 					cache.put(key, dataValue);
 				} else {
 					manager.getPlugin().devDebug("Loading default cache value for " + key + " for " + uuid.toString());
 					cache.put(key, dataKey.getDefault());
 				}
-
 			}
 			if (!changedKeys.isEmpty()) {
 				manager.getPlugin().getUserManager().onChange(user, ArrayUtils.convert(changedKeys));
@@ -85,14 +84,16 @@ public class UserDataCache {
 		return this;
 	}
 
-	public void clearCache() {
+	public synchronized void clearCache() {
 		if (hasChangesToProcess()) {
 			processChanges();
 		}
-		cache.clear();
+		if (cache != null) {
+			cache.clear();
+		}
 	}
 
-	public void clearChanges() {
+	public synchronized void clearChanges() {
 		if (hasChangesToProcess()) {
 			processChanges();
 		}
@@ -102,9 +103,12 @@ public class UserDataCache {
 		manager.getPlugin().devDebug(displayCacheStringList().toString());
 	}
 
-	public ArrayList<String> displayCacheStringList() {
+	public synchronized ArrayList<String> displayCacheStringList() {
 		ArrayList<String> list = new ArrayList<>();
 		list.add("Current cache for " + uuid + ": ");
+		if (cache == null) {
+			return list;
+		}
 		for (Entry<String, DataValue> entry : getCache().entrySet()) {
 			if (entry.getValue().isBoolean()) {
 				list.add(entry.getKey() + "=" + entry.getValue().getBoolean());
@@ -117,88 +121,97 @@ public class UserDataCache {
 		return list;
 	}
 
-	public void dump() {
+	public synchronized void dump() {
 		if (hasChangesToProcess()) {
 			processChanges();
 		}
 		cache = null;
 		cachedChanges = null;
 		uuid = null;
+		scheduled = false;
 	}
 
 	public AdvancedCoreUser getUser() {
 		return manager.getPlugin().getUserManager().getUser(uuid, false);
 	}
 
-	public boolean hasCache() {
-		return !cache.isEmpty();
+	public synchronized boolean hasCache() {
+		return cache != null && !cache.isEmpty();
 	}
 
-	public boolean hasChangesToProcess() {
-		return !cachedChanges.isEmpty();
+	public synchronized boolean hasChangesToProcess() {
+		return cachedChanges != null && !cachedChanges.isEmpty();
 	}
 
-	public boolean isCached(String key) {
-		if (cache != null) {
-			return cache.containsKey(key);
-		}
-		return false;
+	public synchronized boolean isCached(String key) {
+		return cache != null && cache.containsKey(key);
 	}
 
 	public void processChanges() {
-		if (uuid != null) {
-			if (cachedChanges.size() > 0) {
-				manager.getPlugin()
-						.extraDebug("Processing changes for " + uuid.toString() + ", Changes: " + cachedChanges.size());
-				AdvancedCoreUser user = getUser();
-				HashMap<String, DataValue> values = new HashMap<>();
-				ArrayList<String> keys = new ArrayList<>();
-				while (!cachedChanges.isEmpty()) {
-					UserDataChange change = cachedChanges.poll();
-					values.put(change.getKey(), change.toUserDataValue());
-					keys.add(change.getKey());
-					change.dump();
-					// manager.getPlugin().extraDebug("Processing change for " + change.getKey());
-				}
-				if (!values.isEmpty()) {
-					user.getUserData().setValues(values);
-				}
-				manager.getPlugin().getUserManager().onChange(user, ArrayUtils.convert(keys));
+		UUID currentUuid;
+		ArrayList<UserDataChange> changes = new ArrayList<>();
+		synchronized (this) {
+			currentUuid = uuid;
+			if (currentUuid == null || cachedChanges == null || cachedChanges.isEmpty()) {
+				return;
+			}
+			UserDataChange change;
+			while ((change = cachedChanges.poll()) != null) {
+				changes.add(change);
 			}
 		}
+
+		manager.getPlugin().extraDebug("Processing changes for " + currentUuid + ", Changes: " + changes.size());
+		AdvancedCoreUser user = manager.getPlugin().getUserManager().getUser(currentUuid, false);
+		HashMap<String, DataValue> values = new HashMap<>();
+		ArrayList<String> keys = new ArrayList<>();
+		for (UserDataChange change : changes) {
+			values.put(change.getKey(), change.toUserDataValue());
+			keys.add(change.getKey());
+			change.dump();
+		}
+		if (!values.isEmpty()) {
+			user.getUserData().setValues(values);
+		}
+		manager.getPlugin().getUserManager().onChange(user, ArrayUtils.convert(keys));
 	}
 
 	public void processChangesAsync() {
-		if (uuid != null && cachedChanges.size() > 0) {
-			manager.getPlugin().getTimer().execute(new Runnable() {
-
-				@Override
-				public void run() {
-					processChanges();
-				}
-			});
+		if (uuid != null && hasChangesToProcess()) {
+			manager.getPlugin().getTimer().execute(this::processChanges);
 		}
 	}
 
-	private void scheduleChanges() {
+	private synchronized void scheduleChanges() {
+		if (scheduled || cachedChanges == null || cachedChanges.isEmpty()) {
+			return;
+		}
 		manager.getPlugin().debug("Schedule changes");
 		scheduled = true;
-
-		manager.getTimer().schedule(new Runnable() {
-
-			@Override
-			public void run() {
+		try {
+			manager.getTimer().schedule(() -> {
 				try {
 					processChanges();
-					scheduled = false;
 				} catch (Exception e) {
 					manager.getPlugin().debug(e);
+				} finally {
+					onScheduledFlushComplete();
 				}
-			}
-		}, 3, TimeUnit.SECONDS);
+			}, 3, TimeUnit.SECONDS);
+		} catch (RejectedExecutionException e) {
+			scheduled = false;
+			manager.getPlugin().debug(e);
+		}
 	}
 
-	public void updateCache(HashMap<String, DataValue> tempCache) {
-		cache = tempCache;
+	private synchronized void onScheduledFlushComplete() {
+		scheduled = false;
+		if (cachedChanges != null && !cachedChanges.isEmpty()) {
+			scheduleChanges();
+		}
+	}
+
+	public synchronized void updateCache(HashMap<String, DataValue> tempCache) {
+		cache = tempCache == null ? new HashMap<>() : new HashMap<>(tempCache);
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
@@ -1,0 +1,74 @@
+package com.bencodez.advancedcore.tests.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.user.usercache.UserDataCache;
+import com.bencodez.advancedcore.api.user.usercache.UserDataManager;
+import com.bencodez.advancedcore.api.user.usercache.change.UserDataChangeString;
+import com.bencodez.simpleapi.sql.data.DataValue;
+import com.bencodez.simpleapi.sql.data.DataValueString;
+
+public class UserDataCacheSchedulingTest {
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void changesQueuedDuringScheduledFlushAreRescheduled() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		UserDataManager manager = mock(UserDataManager.class);
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		ScheduledFuture future = mock(ScheduledFuture.class);
+		List<Runnable> scheduledTasks = new ArrayList<>();
+
+		when(manager.getPlugin()).thenReturn(plugin);
+		when(manager.getTimer()).thenReturn(timer);
+		doAnswer(invocation -> {
+			scheduledTasks.add(invocation.getArgument(0));
+			return future;
+		}).when(timer).schedule(any(Runnable.class), eq(3L), eq(TimeUnit.SECONDS));
+
+		UserDataCache cache = spy(new UserDataCache(manager, UUID.randomUUID()));
+		doAnswer(invocation -> {
+			cache.addChange(new UserDataChangeString("second", "two"), true);
+			return null;
+		}).when(cache).processChanges();
+
+		cache.addChange(new UserDataChangeString("first", "one"), true);
+		assertEquals(1, scheduledTasks.size());
+
+		scheduledTasks.get(0).run();
+
+		assertEquals(2, scheduledTasks.size(), "a change queued during the flush must schedule another flush");
+	}
+
+	@Test
+	public void updateCacheDefensivelyCopiesInput() {
+		UserDataManager manager = mock(UserDataManager.class);
+		UserDataCache cache = new UserDataCache(manager, UUID.randomUUID());
+		HashMap<String, DataValue> values = new HashMap<>();
+		values.put("PlayerName", new DataValueString("Ben"));
+
+		cache.updateCache(values);
+		values.clear();
+
+		assertTrue(cache.isCached("PlayerName"));
+	}
+}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
@@ -1,6 +1,7 @@
 package com.bencodez.advancedcore.tests.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,12 +18,16 @@ import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
+import com.bencodez.advancedcore.api.user.UserManager;
 import com.bencodez.advancedcore.api.user.usercache.UserDataCache;
 import com.bencodez.advancedcore.api.user.usercache.UserDataManager;
+import com.bencodez.advancedcore.api.user.usercache.change.UserDataChange;
 import com.bencodez.advancedcore.api.user.usercache.change.UserDataChangeString;
 import com.bencodez.simpleapi.sql.data.DataValue;
 import com.bencodez.simpleapi.sql.data.DataValueString;
@@ -57,6 +62,45 @@ public class UserDataCacheSchedulingTest {
 		scheduledTasks.get(0).run();
 
 		assertEquals(2, scheduledTasks.size(), "a change queued during the flush must schedule another flush");
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void failedFlushPreparationRestoresDrainedChanges() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		UserManager userManager = mock(UserManager.class);
+		AdvancedCoreUser user = mock(AdvancedCoreUser.class);
+		UserDataManager manager = mock(UserDataManager.class);
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		ScheduledFuture future = mock(ScheduledFuture.class);
+		UUID uuid = UUID.randomUUID();
+
+		when(manager.getPlugin()).thenReturn(plugin);
+		when(manager.getTimer()).thenReturn(timer);
+		when(plugin.getUserManager()).thenReturn(userManager);
+		when(userManager.getUser(uuid, false)).thenReturn(user);
+		doReturn(future).when(timer).schedule(any(Runnable.class), eq(3L), eq(TimeUnit.SECONDS));
+
+		AtomicInteger conversions = new AtomicInteger();
+		UserDataChange failingChange = new UserDataChange("Custom") {
+			@Override
+			public void dump() {
+			}
+
+			@Override
+			public DataValue toUserDataValue() {
+				if (conversions.getAndIncrement() == 0) {
+					return new DataValueString("value");
+				}
+				throw new IllegalStateException("conversion failed");
+			}
+		};
+
+		UserDataCache cache = new UserDataCache(manager, uuid);
+		cache.addChange(failingChange, true);
+
+		assertThrows(IllegalStateException.class, cache::processChanges);
+		assertTrue(cache.hasChangesToProcess(), "failed preparation must leave the drained change queued for retry");
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
@@ -1,6 +1,7 @@
 package com.bencodez.advancedcore.tests.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
+import com.bencodez.advancedcore.api.user.UserData;
 import com.bencodez.advancedcore.api.user.UserManager;
 import com.bencodez.advancedcore.api.user.usercache.UserDataCache;
 import com.bencodez.advancedcore.api.user.usercache.UserDataManager;
@@ -101,6 +104,83 @@ public class UserDataCacheSchedulingTest {
 
 		assertThrows(IllegalStateException.class, cache::processChanges);
 		assertTrue(cache.hasChangesToProcess(), "failed preparation must leave the drained change queued for retry");
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void dumpWaitsForFailedInFlightBatchToRequeueAndRetry() throws Exception {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		UserManager userManager = mock(UserManager.class);
+		AdvancedCoreUser user = mock(AdvancedCoreUser.class);
+		UserData userData = mock(UserData.class);
+		UserDataManager manager = mock(UserDataManager.class);
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		ScheduledFuture future = mock(ScheduledFuture.class);
+		UUID uuid = UUID.randomUUID();
+
+		when(manager.getPlugin()).thenReturn(plugin);
+		when(manager.getTimer()).thenReturn(timer);
+		when(plugin.getUserManager()).thenReturn(userManager);
+		when(userManager.getUser(uuid, false)).thenReturn(user);
+		when(user.getUserData()).thenReturn(userData);
+		doReturn(future).when(timer).schedule(any(Runnable.class), eq(3L), eq(TimeUnit.SECONDS));
+
+		CountDownLatch inFlight = new CountDownLatch(1);
+		CountDownLatch releaseFailure = new CountDownLatch(1);
+		CountDownLatch dumpFinished = new CountDownLatch(1);
+		AtomicInteger conversions = new AtomicInteger();
+		AtomicInteger dumps = new AtomicInteger();
+		UserDataChange change = new UserDataChange("Custom") {
+			@Override
+			public void dump() {
+				dumps.incrementAndGet();
+			}
+
+			@Override
+			public DataValue toUserDataValue() {
+				int call = conversions.incrementAndGet();
+				if (call == 2) {
+					inFlight.countDown();
+					try {
+						releaseFailure.await();
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new IllegalStateException(e);
+					}
+					throw new IllegalStateException("conversion failed while batch is in flight");
+				}
+				return new DataValueString("value");
+			}
+		};
+
+		UserDataCache cache = new UserDataCache(manager, uuid);
+		cache.addChange(change, true);
+
+		Thread flushThread = new Thread(() -> {
+			try {
+				cache.processChanges();
+			} catch (IllegalStateException expected) {
+				// The failed batch must be restored for dump() to retry.
+			}
+		});
+		flushThread.start();
+		assertTrue(inFlight.await(1, TimeUnit.SECONDS));
+
+		Thread dumpThread = new Thread(() -> {
+			cache.dump();
+			dumpFinished.countDown();
+		});
+		dumpThread.start();
+		assertFalse(dumpFinished.await(100, TimeUnit.MILLISECONDS),
+				"dump must wait while a drained batch is still in flight");
+
+		releaseFailure.countDown();
+		flushThread.join(1000);
+		dumpThread.join(1000);
+
+		assertEquals(0L, dumpFinished.getCount(), "dump should finish after the failed batch is restored and retried");
+		assertEquals(1, dumps.get(), "the restored change must be persisted and dumped exactly once before disposal");
+		assertFalse(cache.hasChangesToProcess());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Tighten `UserDataCache` write scheduling and cache ownership without changing its public API.

- close the race where a change queued while a scheduled flush is finishing could remain unscheduled
- automatically schedule another flush when work arrived during the previous flush
- keep scheduled-state transitions synchronized and recover cleanly if the executor rejects scheduling
- drain queued changes into a stable batch before writing user storage
- make cache inspection/update helpers null-safe around dump/cleanup
- defensively copy replacement cache maps instead of retaining caller-owned mutable maps
- route cache comparison failures through AdvancedCore debug logging instead of raw stack traces

## Tests

- verifies a change queued during an active scheduled flush causes a follow-up flush to be scheduled
- verifies `updateCache(...)` does not retain the caller's mutable map

This PR is focused on user cache/storage write correctness; it does not change storage configuration or public user-data keys.