### PR TITLE
docs: distinguish complete reviews from clean reviews

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -246,11 +246,25 @@ Coverage: <complete, static-only, partial, or stale; material limitations>
 <prioritized findings, or the applicable zero-finding result below>
 ```
 
-When required coverage and validation are complete with no findings, the findings
-section is exactly `No findings.` Otherwise use `Review incomplete.` with specific
-limitations, while still reporting verified findings. An explicitly scoped
-static-only review can be complete within that scope but does not pass a gate
-requiring builds. Do not add praise, scores, generic advice, or merge approval.
+Determine review completeness independently from findings and publishing readiness:
+
+- Complete review with findings: when required coverage and validation evidence
+  are complete, report the verified findings in priority order and keep coverage
+  marked complete. Do not label the review incomplete or invent limitations merely
+  because defects were found.
+- Complete review without findings: when required coverage and validation evidence
+  are complete and no findings remain, the findings section is exactly
+  `No findings.`
+- Incomplete review, with or without findings: only when required coverage or
+  validation evidence is missing, unresolved, or stale, use `Review incomplete.`
+  with the actual limitations. Still report all verified findings; do not present
+  an incomplete review as a clean verdict.
+
+A completed, investigated check that demonstrates a defect is validation evidence,
+not by itself a coverage gap; unresolved failures still block publishing. An
+explicitly scoped static-only review can be complete within that scope but does
+not pass a gate requiring builds. Do not add praise, scores, generic advice, or
+merge approval.
 
 For a pre-publish gate, the implementation coordinator, not the reviewer, fixes
 accepted findings, reruns required checks, and obtains a fresh independent review


### PR DESCRIPTION
## Summary

Address the review comment on the already-merged #307: https://github.com/BenCodez/AdvancedCore/pull/307#discussion_r3942448579

The previous `Otherwise` branch incorrectly required `Review incomplete.` whenever a review found a defect, even when coverage and validation were complete. This follow-up separates completeness from findings and publishing readiness:

| Review state | Required output |
| --- | --- |
| Complete, with findings | Keep coverage complete and report prioritized findings; do not invent limitations. |
| Complete, without findings | Use `No findings.` in the findings section. |
| Incomplete, with or without findings | Use `Review incomplete.`, explain actual missing/unresolved/stale evidence, and still report verified findings. |

A completed, investigated failing check is evidence of a defect, not automatically a coverage gap. Unresolved failures still block publishing; the existing pre-publish gate and static-only review caveat are preserved.

## Scope

Only `.github/skills/code-review/SKILL.md` changes: **19 insertions, 5 deletions**. No additional files, application code, workflow changes, or changes to SimpleAPI/VotingPlugin.

Branched from `master` at `c3bdd207c46824eee15358e62c6b7c28fd9bdfea`, which includes #307. The existing open PRs and matching branch names were checked first.

## Validation

- **PASS:** YAML frontmatter parsing; unchanged metadata, earlier skill sections, publishing gate, and shell examples.
- **PASS:** UTF-8/LF/final newline, whitespace, balanced Markdown fences, and `bash -n` on the unchanged shell examples (syntax only; no builds executed).
- **PASS:** Static text assertions for the three explicit output cases, removal of the erroneous fallback, and the failed-check clarification. These are document checks, not live agent behavioral tests.
- **PASS:** `git diff --check` and single-file scope in a disposable local fixture containing the exact old/new skill bytes. This was not a full repository checkout.
- **PASS:** GitHub comparison confirms one commit and only the requested file changed; uploaded blob `403efbb0f2bd3c43b3213e37874c384e6f6ca4fb` matches the locally validated bytes.
- **NOT RUN:** Maven/JAR build (`mvn` is unavailable), live agent execution, or an independent reviewer. No build or independent clean-review result is claimed.

Kept as a draft. No external review was manually requested.

**AI disclosure:** This pull request was prepared with assistance from ChatGPT.