### PR TITLE
Pin build inputs and use least-privilege Pages deployment

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: '21'
           cache: maven
       - name: Build Javadoc
-        run: mvn -B -f AdvancedCore/pom.xml javadoc:javadoc
+        run: mvn -B -f AdvancedCore/pom.xml org.apache.maven.plugins:maven-javadoc-plugin:3.12.0:javadoc
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
       - name: Upload Pages artifact

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -7,18 +7,34 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy JavaDoc 🚀
-        uses: MathieuSoysal/Javadoc-publisher.yml@main
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Set up Java
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          javadoc-branch: gh-pages
-          java-version: 21
-          target-folder: ''
-          project: maven # or gradle
-          # subdirectories: moduleA moduleB #for subdirectories support, needs to be run with custom command
-          custom-command: mvn -f AdvancedCore/pom.xml deploy -P javadoc javadoc:aggregate
-          javadoc-source-folder: 'AdvancedCore/target/reports/apidocs'
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Build Javadoc
+        run: mvn -B -f AdvancedCore/pom.xml javadoc:javadoc
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        with:
+          path: AdvancedCore/target/reports/apidocs
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/AdvancedCore/pom.xml
+++ b/AdvancedCore/pom.xml
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>com.bencodez</groupId>
             <artifactId>simpleapi</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
+            <version>1.0.2-20260905.234759-10</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/build/BuildInputPinningTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/build/BuildInputPinningTest.java
@@ -14,12 +14,14 @@ class BuildInputPinningTest {
 	@Test
 	void javadocPublisherUsesImmutableRevisionAndExplicitPermissions() throws IOException {
 		String workflow = Files.readString(Path.of("..", ".github", "workflows", "publish-javadoc.yml"));
+		String normalizedWorkflow = workflow.replace("\r\n", "\n");
 
 		assertFalse(workflow.contains("MathieuSoysal/Javadoc-publisher"));
 		assertTrue(workflow.matches("(?s).*actions/checkout@[0-9a-f]{40}.*"));
 		assertTrue(workflow.matches("(?s).*actions/setup-java@[0-9a-f]{40}.*"));
 		assertTrue(workflow.matches("(?s).*actions/deploy-pages@[0-9a-f]{40}.*"));
-		assertTrue(workflow.contains("permissions:\n  contents: read\n  pages: write\n  id-token: write"));
+		assertTrue(normalizedWorkflow.contains("permissions:\n  contents: read\n  pages: write\n  id-token: write"));
+		assertTrue(workflow.contains("maven-javadoc-plugin:3.12.0:javadoc"));
 		assertFalse(workflow.contains("Javadoc-publisher.yml@main"));
 	}
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/build/BuildInputPinningTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/build/BuildInputPinningTest.java
@@ -15,8 +15,11 @@ class BuildInputPinningTest {
 	void javadocPublisherUsesImmutableRevisionAndExplicitPermissions() throws IOException {
 		String workflow = Files.readString(Path.of("..", ".github", "workflows", "publish-javadoc.yml"));
 
-		assertTrue(workflow.matches("(?s).*MathieuSoysal/Javadoc-publisher\\.yml@[0-9a-f]{40}.*"));
-		assertTrue(workflow.contains("permissions:\n  contents: write"));
+		assertFalse(workflow.contains("MathieuSoysal/Javadoc-publisher"));
+		assertTrue(workflow.matches("(?s).*actions/checkout@[0-9a-f]{40}.*"));
+		assertTrue(workflow.matches("(?s).*actions/setup-java@[0-9a-f]{40}.*"));
+		assertTrue(workflow.matches("(?s).*actions/deploy-pages@[0-9a-f]{40}.*"));
+		assertTrue(workflow.contains("permissions:\n  contents: read\n  pages: write\n  id-token: write"));
 		assertFalse(workflow.contains("Javadoc-publisher.yml@main"));
 	}
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/build/BuildInputPinningTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/build/BuildInputPinningTest.java
@@ -1,0 +1,33 @@
+package com.bencodez.advancedcore.build;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class BuildInputPinningTest {
+
+	@Test
+	void javadocPublisherUsesImmutableRevisionAndExplicitPermissions() throws IOException {
+		String workflow = Files.readString(Path.of("..", ".github", "workflows", "publish-javadoc.yml"));
+
+		assertTrue(workflow.matches("(?s).*MathieuSoysal/Javadoc-publisher\\.yml@[0-9a-f]{40}.*"));
+		assertTrue(workflow.contains("permissions:\n  contents: write"));
+		assertFalse(workflow.contains("Javadoc-publisher.yml@main"));
+	}
+
+	@Test
+	void simpleApiDependencyUsesImmutableSnapshotBuild() throws IOException {
+		String pom = Files.readString(Path.of("pom.xml"));
+		int dependency = pom.indexOf("<artifactId>simpleapi</artifactId>");
+
+		assertTrue(dependency >= 0);
+		String declaration = pom.substring(dependency, Math.min(pom.length(), dependency + 200));
+		assertFalse(declaration.contains("SNAPSHOT"));
+		assertTrue(declaration.contains("1.0.2-20260905.234759-10"));
+	}
+}


### PR DESCRIPTION
## Summary
- replace the mutable third-party Javadoc publisher action with SHA-pinned official GitHub Pages actions
- restrict workflow permissions to `contents: read`, `pages: write`, and `id-token: write`
- pin the SimpleAPI snapshot dependency to the exact timestamped build currently resolved by Maven
- add regression tests that reject mutable action references, broad content-write permissions, and mutable SimpleAPI snapshots

## Testing
- added `BuildInputPinningTest` to CI
- `git diff --check` passes locally
- Maven is unavailable in the local execution environment, so the repository Java CI is the authoritative full test run