### PR TITLE
Require dedicated authorization for bulk player commands

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/command/PlayerCommandHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/command/PlayerCommandHandler.java
@@ -3,6 +3,8 @@ package com.bencodez.advancedcore.api.command;
 import org.bukkit.command.CommandSender;
 
 import java.util.regex.Pattern;
+import java.util.Collections;
+import java.util.List;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 
@@ -80,6 +82,21 @@ public abstract class PlayerCommandHandler extends CommandHandler {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Returns permissions used by special player targets in addition to the normal
+	 * command permission. Permission-listing commands can use this without granting
+	 * the bulk permission during ordinary command checks.
+	 *
+	 * @return the dedicated permission for the {@code all} target
+	 */
+	public List<String> getAdditionalPermissions() {
+		String permission = getPerm();
+		if (permission == null || permission.isEmpty()) {
+			return Collections.emptyList();
+		}
+		return Collections.singletonList(permission.split(Pattern.quote("|"))[0] + ".All");
 	}
 
 	private void figureOutPlayerArg() {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/command/PlayerCommandHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/command/PlayerCommandHandler.java
@@ -2,6 +2,8 @@ package com.bencodez.advancedcore.api.command;
 
 import org.bukkit.command.CommandSender;
 
+import java.util.regex.Pattern;
+
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 
 public abstract class PlayerCommandHandler extends CommandHandler {
@@ -31,7 +33,7 @@ public abstract class PlayerCommandHandler extends CommandHandler {
 
 	public PlayerCommandHandler(AdvancedCorePlugin plugin, String[] args, String perm, String helpMessage,
 			boolean allowConsole, boolean forceConsole) {
-		super(plugin, args, perm, helpMessage, allowConsole);
+		super(plugin, args, perm, helpMessage, allowConsole, forceConsole);
 		figureOutPlayerArg();
 	}
 
@@ -39,7 +41,10 @@ public abstract class PlayerCommandHandler extends CommandHandler {
 	public void execute(CommandSender sender, String[] args) {
 		if (playerArg >= 0) {
 			if (args[playerArg].equalsIgnoreCase("all")) {
-				executeAll(sender, args);
+				if (hasAllPermission(sender)) {
+					executeAll(sender, args);
+				}
+				return;
 			}
 		}
 		executeSinglePlayer(sender, args);
@@ -48,6 +53,34 @@ public abstract class PlayerCommandHandler extends CommandHandler {
 	public abstract void executeAll(CommandSender sender, String[] args);
 
 	public abstract void executeSinglePlayer(CommandSender sender, String[] args);
+
+	/**
+	 * Checks the stronger permission required for the special {@code all} target.
+	 * The first configured permission is treated as the granular command permission
+	 * and receives an {@code .All} suffix. Any alternative permissions, such as an
+	 * administrator permission, continue to act as overrides.
+	 *
+	 * @param sender command sender
+	 * @return whether bulk execution is authorized
+	 */
+	public boolean hasAllPermission(CommandSender sender) {
+		String permission = getPerm();
+		if (permission == null || permission.isEmpty()) {
+			return false;
+		}
+		String[] permissions = permission.split(Pattern.quote("|"));
+		if (sender.hasPermission(permissions[0] + ".All")) {
+			return true;
+		}
+		if (isAllowMultiplePermissions()) {
+			for (int i = 1; i < permissions.length; i++) {
+				if (sender.hasPermission(permissions[i])) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 
 	private void figureOutPlayerArg() {
 		for (int i = 0; i < getArgs().length; i++) {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/command/PlayerCommandHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/command/PlayerCommandHandlerTest.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.api.command;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +40,12 @@ class PlayerCommandHandlerTest {
 		when(sender.hasPermission("example.admin")).thenReturn(true);
 
 		assertTrue(handler.hasAllPermission(sender));
+	}
+
+	@Test
+	void exposesBulkPermissionForPermissionListings() {
+		assertEquals(java.util.Collections.singletonList("example.command.All"),
+				handler(false).getAdditionalPermissions());
 	}
 
 	private TestHandler handler(boolean forceConsole) {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/command/PlayerCommandHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/command/PlayerCommandHandlerTest.java
@@ -1,0 +1,66 @@
+package com.bencodez.advancedcore.api.command;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
+
+class PlayerCommandHandlerTest {
+
+	@Test
+	void forceConsoleConstructorForwardsFlag() {
+		TestHandler handler = handler(true);
+
+		assertTrue(handler.isForceConsole());
+	}
+
+	@Test
+	void bulkTargetRequiresDedicatedPermission() {
+		TestHandler handler = handler(false);
+		CommandSender sender = mock(CommandSender.class);
+		when(sender.hasPermission("example.command")).thenReturn(true);
+
+		assertFalse(handler.hasAllPermission(sender));
+
+		when(sender.hasPermission("example.command.All")).thenReturn(true);
+		assertTrue(handler.hasAllPermission(sender));
+	}
+
+	@Test
+	void administratorAlternativeStillAuthorizesBulkTarget() {
+		TestHandler handler = handler(false);
+		CommandSender sender = mock(CommandSender.class);
+		when(sender.hasPermission("example.admin")).thenReturn(true);
+
+		assertTrue(handler.hasAllPermission(sender));
+	}
+
+	private TestHandler handler(boolean forceConsole) {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		AdvancedCoreConfigOptions options = mock(AdvancedCoreConfigOptions.class);
+		when(plugin.getOptions()).thenReturn(options);
+		when(options.isMultiplePermissionChecks()).thenReturn(true);
+		return new TestHandler(plugin, forceConsole);
+	}
+
+	private static final class TestHandler extends PlayerCommandHandler {
+		private TestHandler(AdvancedCorePlugin plugin, boolean forceConsole) {
+			super(plugin, new String[] { "user", "(player)" }, "example.command|example.admin", "help", true,
+					forceConsole);
+		}
+
+		@Override
+		public void executeAll(CommandSender sender, String[] args) {
+		}
+
+		@Override
+		public void executeSinglePlayer(CommandSender sender, String[] args) {
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- correctly forward the `forceConsole` constructor flag
- require the granular command's `.All` permission before accepting the special `all` player target
- retain configured administrator permissions as bulk-operation overrides
- stop the single-player handler from running after a bulk target
- add regression tests for console-only propagation, granular-vs-bulk permissions, and administrator overrides

## Testing
- `/tmp/apache-maven-3.9.11/bin/mvn -q -Dmaven.repo.local=/tmp/m2-advancedcore -Dtest=PlayerCommandHandlerTest test`
- `git diff --check`