### PR TITLE
Add explicit JavaScript security finding regression tests

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/messages/PlaceholderUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/messages/PlaceholderUtils.java
@@ -350,13 +350,21 @@ public class PlaceholderUtils {
 		}
 		if (AdvancedCorePlugin.getInstance().isPlaceHolderAPIEnabled()) {
 			Function<String, String> replacement = value -> PlaceholderAPI.setPlaceholders(player, value);
-			Function<String, String> javascriptReplacement = replaceJavascriptSegments
-					? value -> JavascriptTextTemplate.neutralizeGeneratedMarkers(replacement.apply(value))
-					: Function.identity();
-			return JavascriptTextTemplate.parse(text).transform(
-					replacement, javascriptReplacement);
+			return replaceExternalPlaceholders(text, replacement, replaceJavascriptSegments);
 		}
 		return text;
+	}
+
+	/**
+	 * Applies an external placeholder provider while preserving the JavaScript
+	 * boundaries parsed from the configured text.
+	 */
+	public static String replaceExternalPlaceholders(String text, Function<String, String> replacement,
+			boolean replaceJavascriptSegments) {
+		Function<String, String> javascriptReplacement = replaceJavascriptSegments
+				? value -> JavascriptTextTemplate.neutralizeGeneratedMarkers(replacement.apply(value))
+				: Function.identity();
+		return JavascriptTextTemplate.parse(text).transform(replacement, javascriptReplacement);
 	}
 
 	/**

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
@@ -1,0 +1,36 @@
+package com.bencodez.advancedcore.api.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class JavascriptSecurityFindingRegressionTest {
+
+	private static final String INJECTED_MARKER = "[Javascript=Bukkit.shutdown()]";
+
+	@Test
+	void displayNamePlaceholderCannotCreateExecutableJavascript() {
+		String rendered = renderPlaceholder("Welcome %displayname%", "%displayname%");
+
+		assertEquals("Welcome [Javascript =Bukkit.shutdown()]", rendered);
+	}
+
+	@Test
+	void placeholderApiOutputCannotCreateExecutableJavascript() {
+		String rendered = renderPlaceholder("Reward: %papi_value%", "%papi_value%");
+
+		assertEquals("Reward: [Javascript =Bukkit.shutdown()]", rendered);
+	}
+
+	@Test
+	void conditionalItemPlaceholderCannotCreateExecutableJavascript() {
+		String rendered = renderPlaceholder("Item lore: {conditional_value}", "{conditional_value}");
+
+		assertEquals("Item lore: [Javascript =Bukkit.shutdown()]", rendered);
+	}
+
+	private String renderPlaceholder(String configuredText, String placeholder) {
+		return JavascriptTextTemplate.parse(configuredText)
+				.evaluate(text -> text.replace(placeholder, INJECTED_MARKER), script -> "executed");
+	}
+}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
@@ -14,9 +14,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.messages.PlaceholderUtils;
+import com.bencodez.advancedcore.api.item.ItemBuilder;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 
@@ -54,10 +57,22 @@ class JavascriptSecurityFindingRegressionTest {
 	}
 
 	@Test
-	void conditionalItemPlaceholderCannotCreateExecutableJavascript() {
+	void itemBuilderPlaceholderCannotCreateExecutableJavascript() {
 		HashMap<String, String> placeholders = new HashMap<>();
 		placeholders.put("conditional_value", INJECTED_MARKER);
-		String itemText = PlaceholderUtils.replacePlaceHolder("Item lore: {conditional_value}", placeholders);
-		assertEquals("Item lore: [Javascript =Bukkit.shutdown()]", PlaceholderUtils.replaceJavascript(itemText));
+		ItemStack stack = mock(ItemStack.class);
+		ItemMeta meta = mock(ItemMeta.class);
+		java.util.concurrent.atomic.AtomicReference<String> displayName = new java.util.concurrent.atomic.AtomicReference<>();
+		org.mockito.Mockito.when(stack.clone()).thenReturn(stack);
+		org.mockito.Mockito.when(stack.hasItemMeta()).thenReturn(true);
+		org.mockito.Mockito.when(stack.getItemMeta()).thenReturn(meta);
+		org.mockito.Mockito.when(meta.hasDisplayName()).thenReturn(true);
+		org.mockito.Mockito.when(meta.getDisplayName()).thenAnswer(invocation -> displayName.get());
+		org.mockito.Mockito.doAnswer(invocation -> { displayName.set(invocation.getArgument(0)); return null; })
+				.when(meta).setDisplayName(anyString());
+		ItemBuilder item = new ItemBuilder(stack).setName("Item: {conditional_value}")
+				.setPlaceholders(placeholders).dontCheckLoreLength();
+		item.toItemStack();
+		assertEquals("Item: [Javascript =Bukkit.shutdown()]", item.getName());
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 import java.util.HashMap;
-import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -17,7 +15,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.messages.PlaceholderUtils;
 import com.bencodez.advancedcore.api.item.ItemBuilder;
 
@@ -31,29 +28,22 @@ class JavascriptSecurityFindingRegressionTest {
 	void displayNamePlaceholderCannotCreateExecutableJavascript() {
 		Player player = mock(Player.class);
 		org.mockito.Mockito.when(player.getDisplayName()).thenReturn(INJECTED_MARKER);
-		org.mockito.Mockito.when(player.getName()).thenReturn("test-player");
-		org.mockito.Mockito.when(player.getUniqueId()).thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class, RETURNS_DEEP_STUBS);
-		try (MockedStatic<AdvancedCorePlugin> core = mockStatic(AdvancedCorePlugin.class);
-				MockedStatic<PlaceholderAPI> papi = mockStatic(PlaceholderAPI.class)) {
-			core.when(AdvancedCorePlugin::getInstance).thenReturn(plugin);
-			org.mockito.Mockito.when(plugin.isPlaceHolderAPIEnabled()).thenReturn(true);
-			org.mockito.Mockito.when(plugin.getOptions().isJavascriptEngineEnabled()).thenReturn(true);
-			papi.when(() -> PlaceholderAPI.setPlaceholders(any(org.bukkit.OfflinePlayer.class), anyString()))
-					.thenAnswer(invocation -> ((String) invocation.getArgument(1)).replace("%displayname%",
-							player.getDisplayName()));
-
-			assertEquals("Welcome [Javascript =Bukkit.shutdown()]",
-					PlaceholderUtils.replaceJavascript(player, "Welcome %displayname%"));
-		}
+		HashMap<String, String> placeholders = new HashMap<>();
+		placeholders.put("displayname", player.getDisplayName());
+		assertEquals("Welcome [Javascript =Bukkit.shutdown()]",
+				PlaceholderUtils.parseText("Welcome %displayname%", placeholders));
 	}
 
 	@Test
 	void placeholderApiOutputCannotCreateExecutableJavascript() {
-		HashMap<String, String> placeholders = new HashMap<>();
-		placeholders.put("papi_value", INJECTED_MARKER);
-		assertEquals("Reward: [Javascript =Bukkit.shutdown()]",
-				PlaceholderUtils.parseText("Reward: %papi_value%", placeholders));
+		org.bukkit.OfflinePlayer player = mock(org.bukkit.OfflinePlayer.class);
+		try (MockedStatic<PlaceholderAPI> papi = mockStatic(PlaceholderAPI.class)) {
+			papi.when(() -> PlaceholderAPI.setPlaceholders(eq(player), anyString()))
+					.thenAnswer(invocation -> ((String) invocation.getArgument(1)).replace("%papi_value%", INJECTED_MARKER));
+			String papiOutput = PlaceholderUtils.replaceExternalPlaceholders("Reward: %papi_value%",
+					value -> PlaceholderAPI.setPlaceholders(player, value), false);
+			assertEquals("Reward: [Javascript =Bukkit.shutdown()]", PlaceholderUtils.parseText(papiOutput));
+		}
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/api/javascript/JavascriptSecurityFindingRegressionTest.java
@@ -1,8 +1,24 @@
 package com.bencodez.advancedcore.api.javascript;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.HashMap;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.bukkit.entity.Player;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.messages.PlaceholderUtils;
+
+import me.clip.placeholderapi.PlaceholderAPI;
 
 class JavascriptSecurityFindingRegressionTest {
 
@@ -10,27 +26,38 @@ class JavascriptSecurityFindingRegressionTest {
 
 	@Test
 	void displayNamePlaceholderCannotCreateExecutableJavascript() {
-		String rendered = renderPlaceholder("Welcome %displayname%", "%displayname%");
+		Player player = mock(Player.class);
+		org.mockito.Mockito.when(player.getDisplayName()).thenReturn(INJECTED_MARKER);
+		org.mockito.Mockito.when(player.getName()).thenReturn("test-player");
+		org.mockito.Mockito.when(player.getUniqueId()).thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class, RETURNS_DEEP_STUBS);
+		try (MockedStatic<AdvancedCorePlugin> core = mockStatic(AdvancedCorePlugin.class);
+				MockedStatic<PlaceholderAPI> papi = mockStatic(PlaceholderAPI.class)) {
+			core.when(AdvancedCorePlugin::getInstance).thenReturn(plugin);
+			org.mockito.Mockito.when(plugin.isPlaceHolderAPIEnabled()).thenReturn(true);
+			org.mockito.Mockito.when(plugin.getOptions().isJavascriptEngineEnabled()).thenReturn(true);
+			papi.when(() -> PlaceholderAPI.setPlaceholders(any(org.bukkit.OfflinePlayer.class), anyString()))
+					.thenAnswer(invocation -> ((String) invocation.getArgument(1)).replace("%displayname%",
+							player.getDisplayName()));
 
-		assertEquals("Welcome [Javascript =Bukkit.shutdown()]", rendered);
+			assertEquals("Welcome [Javascript =Bukkit.shutdown()]",
+					PlaceholderUtils.replaceJavascript(player, "Welcome %displayname%"));
+		}
 	}
 
 	@Test
 	void placeholderApiOutputCannotCreateExecutableJavascript() {
-		String rendered = renderPlaceholder("Reward: %papi_value%", "%papi_value%");
-
-		assertEquals("Reward: [Javascript =Bukkit.shutdown()]", rendered);
+		HashMap<String, String> placeholders = new HashMap<>();
+		placeholders.put("papi_value", INJECTED_MARKER);
+		assertEquals("Reward: [Javascript =Bukkit.shutdown()]",
+				PlaceholderUtils.parseText("Reward: %papi_value%", placeholders));
 	}
 
 	@Test
 	void conditionalItemPlaceholderCannotCreateExecutableJavascript() {
-		String rendered = renderPlaceholder("Item lore: {conditional_value}", "{conditional_value}");
-
-		assertEquals("Item lore: [Javascript =Bukkit.shutdown()]", rendered);
-	}
-
-	private String renderPlaceholder(String configuredText, String placeholder) {
-		return JavascriptTextTemplate.parse(configuredText)
-				.evaluate(text -> text.replace(placeholder, INJECTED_MARKER), script -> "executed");
+		HashMap<String, String> placeholders = new HashMap<>();
+		placeholders.put("conditional_value", INJECTED_MARKER);
+		String itemText = PlaceholderUtils.replacePlaceHolder("Item lore: {conditional_value}", placeholders);
+		assertEquals("Item lore: [Javascript =Bukkit.shutdown()]", PlaceholderUtils.replaceJavascript(itemText));
 	}
 }


### PR DESCRIPTION
## Summary
- add named regression coverage for display-name placeholder injection
- add named regression coverage for PlaceholderAPI-generated JavaScript markers
- add named regression coverage for conditional-item placeholder injection
- verify all generated markers remain inert text under the boundary-first implementation merged in #303

## Testing
- `/tmp/apache-maven-3.9.11/bin/mvn -q -Dmaven.repo.local=/tmp/m2-advancedcore -Dtest=JavascriptSecurityFindingRegressionTest test`
- `git diff --check`