### PR TITLE
Extract shared executor runtime with a Bukkit lifecycle adapter

### DIFF
--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
@@ -1,0 +1,84 @@
+package com.bencodez.advancedcore.bukkit.runtime;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.item.FullInventoryHandler;
+import com.bencodez.advancedcore.api.javascript.JavascriptEngineHandler;
+import com.bencodez.advancedcore.api.time.TimeChecker;
+import com.bencodez.advancedcore.api.user.UserStorage;
+import com.bencodez.advancedcore.core.platform.RuntimePlatform;
+
+/** Bukkit services for the shared executor lifecycle; no duplicate owners are created. */
+public final class BukkitRuntimePlatform implements RuntimePlatform {
+    private final AdvancedCorePlugin plugin;
+
+    public BukkitRuntimePlatform(AdvancedCorePlugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    @Override public ScheduledExecutorService getTimer() { return plugin.getTimer(); }
+    @Override public ScheduledExecutorService getLoginTimer() { return plugin.getLoginTimer(); }
+    @Override public ScheduledExecutorService getInventoryTimer() { return plugin.getInventoryTimer(); }
+    @Override public ScheduledExecutorService getTimeTimer() {
+        TimeChecker checker = plugin.getTimeChecker();
+        return checker == null ? null : checker.getTimer();
+    }
+
+    @Override public List<Cleanup> beforeExecutorShutdown() {
+        return List.of(
+                new Cleanup("Javascript engine", () -> {
+                    if (plugin.getOptions() != null && plugin.getOptions().isJavascriptEngineEnabled()) {
+                        plugin.getLogger().info("Shutting down Javascript engine");
+                        JavascriptEngineHandler.getInstance().clearCachedEngine();
+                    }
+                }),
+                new Cleanup("MySQL", () -> {
+                    if (plugin.isLoadUserData() && plugin.getOptions() != null
+                            && UserStorage.MYSQL.equals(plugin.getOptions().getStorageType()) && plugin.getMysql() != null) {
+                        plugin.getMysql().close();
+                    }
+                }),
+                new Cleanup("server data timestamp", () -> {
+                    if (plugin.getServerDataFile() != null) plugin.getServerDataFile().setLastUpdated();
+                }));
+    }
+
+    @Override public List<Cleanup> afterExecutorGrace() {
+        return List.of(new Cleanup("reward handler", () -> {
+            if (plugin.getRewardHandler() != null) plugin.getRewardHandler().shutdown();
+        }));
+    }
+
+    @Override public List<Cleanup> afterExecutorShutdown() {
+        return List.of(
+                new Cleanup("plugin unload hook", plugin::onUnLoad),
+                new Cleanup("skull cache", () -> {
+                    if (plugin.getSkullCacheHandler() != null) plugin.getSkullCacheHandler().close();
+                }),
+                new Cleanup("full inventory handler", () -> {
+                    FullInventoryHandler handler = plugin.getFullInventoryHandler();
+                    if (handler != null) {
+                        handler.shutdown();
+                        handler.save();
+                    }
+                }),
+                new Cleanup("hologram handler", () -> {
+                    if (plugin.getHologramHandler() != null) plugin.getHologramHandler().onShutDown();
+                }),
+                new Cleanup("permission handler", () -> {
+                    if (plugin.getPermissionHandler() != null) plugin.getPermissionHandler().shutDown();
+                }),
+                new Cleanup("dialog service", () -> {
+                    if (plugin.getDialogService() != null) plugin.getDialogService().unregister();
+                }));
+    }
+
+    @Override public void info(String message) { plugin.getLogger().info(message); }
+    @Override public void cleanupFailed(String component, Throwable failure) {
+        plugin.getLogger().warning("Failed to shut down " + component + ": " + failure.getMessage());
+        plugin.debug(failure);
+    }
+}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/core/platform/RuntimePlatform.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/core/platform/RuntimePlatform.java
@@ -1,0 +1,25 @@
+package com.bencodez.advancedcore.core.platform;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+
+/** Supplies existing executor owners and platform cleanup without exposing game APIs. */
+public interface RuntimePlatform {
+    record Cleanup(String name, Runnable action) {
+        public Cleanup {
+            Objects.requireNonNull(name, "name");
+            Objects.requireNonNull(action, "action");
+        }
+    }
+
+    ScheduledExecutorService getTimer();
+    ScheduledExecutorService getLoginTimer();
+    ScheduledExecutorService getInventoryTimer();
+    ScheduledExecutorService getTimeTimer();
+    List<Cleanup> beforeExecutorShutdown();
+    List<Cleanup> afterExecutorGrace();
+    List<Cleanup> afterExecutorShutdown();
+    void info(String message);
+    void cleanupFailed(String component, Throwable failure);
+}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/core/runtime/AdvancedCoreRuntime.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/core/runtime/AdvancedCoreRuntime.java
@@ -1,0 +1,91 @@
+package com.bencodez.advancedcore.core.runtime;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.bencodez.advancedcore.core.platform.RuntimePlatform;
+import com.bencodez.advancedcore.core.platform.RuntimePlatform.Cleanup;
+
+/**
+ * First shared runtime slice: executor creation and existing shutdown sequencing.
+ * It creates no second cache/service registry, and does not replace an entity or
+ * region scheduler with a global executor. The platform serializes lifecycle
+ * calls; cleanup hooks are synchronous and retain their existing failure policy.
+ */
+public final class AdvancedCoreRuntime {
+    private final RuntimePlatform platform;
+
+    public AdvancedCoreRuntime(RuntimePlatform platform) {
+        this.platform = Objects.requireNonNull(platform, "platform");
+    }
+
+    /** The same three independent executor owners used by the Bukkit plugin. */
+    public record ExecutorGroup(ScheduledExecutorService timer, ScheduledExecutorService loginTimer,
+            ScheduledExecutorService inventoryTimer) { }
+
+    public static ExecutorGroup createExecutors() {
+        ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor();
+        ScheduledExecutorService loginTimer = null;
+        try {
+            loginTimer = Executors.newSingleThreadScheduledExecutor();
+            return new ExecutorGroup(timer, loginTimer, Executors.newSingleThreadScheduledExecutor());
+        } catch (RuntimeException | Error failure) {
+            timer.shutdownNow();
+            if (loginTimer != null) loginTimer.shutdownNow();
+            throw failure;
+        }
+    }
+
+    public void shutdown() {
+        clean(platform.beforeExecutorShutdown());
+
+        // Resolve the time-checker timer once, after the pre-shutdown actions,
+        // just as the old lifecycle did. Other getters retain their lookup order.
+        ScheduledExecutorService timeTimer = platform.getTimeTimer();
+        shutdown(platform.getLoginTimer());
+        shutdown(platform.getTimer());
+        shutdown(timeTimer);
+        shutdown(platform.getInventoryTimer());
+
+        platform.info("Allowing background tasks to finish before shutdown");
+        await(platform.getLoginTimer(), 2, TimeUnit.SECONDS);
+        await(platform.getTimer(), 2, TimeUnit.SECONDS);
+        await(timeTimer, 2, TimeUnit.SECONDS);
+        await(platform.getInventoryTimer(), 1, TimeUnit.SECONDS);
+
+        clean(platform.afterExecutorGrace());
+        shutdownNow(platform.getLoginTimer());
+        shutdownNow(platform.getTimer());
+        shutdownNow(timeTimer);
+        shutdownNow(platform.getInventoryTimer());
+        clean(platform.afterExecutorShutdown());
+    }
+
+    private void clean(List<Cleanup> actions) {
+        for (Cleanup action : actions) {
+            try {
+                action.action().run();
+            } catch (Throwable failure) {
+                platform.cleanupFailed(action.name(), failure);
+            }
+        }
+    }
+
+    public static void shutdown(ScheduledExecutorService executor) {
+        if (executor != null && !executor.isShutdown()) executor.shutdown();
+    }
+    public static void shutdownNow(ScheduledExecutorService executor) {
+        if (executor != null && !executor.isTerminated()) executor.shutdownNow();
+    }
+    public static void await(ScheduledExecutorService executor, long timeout, TimeUnit unit) {
+        if (executor == null) return;
+        try {
+            executor.awaitTermination(timeout, unit);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/lifecycle/AdvancedCoreLifecycle.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/lifecycle/AdvancedCoreLifecycle.java
@@ -1,177 +1,62 @@
 package com.bencodez.advancedcore.lifecycle;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
-import com.bencodez.advancedcore.api.item.FullInventoryHandler;
-import com.bencodez.advancedcore.api.javascript.JavascriptEngineHandler;
-import com.bencodez.advancedcore.api.time.TimeChecker;
-import com.bencodez.advancedcore.api.user.UserStorage;
+import com.bencodez.advancedcore.bukkit.runtime.BukkitRuntimePlatform;
+import com.bencodez.advancedcore.core.runtime.AdvancedCoreRuntime;
 import com.bencodez.simpleapi.scheduler.BukkitScheduler;
 
 /**
- * Owns AdvancedCore runtime executor creation and best-effort shutdown sequencing.
- * Public plugin getters remain the compatibility surface; this class only
- * centralizes lifecycle mechanics that were previously embedded in the plugin.
+ * Existing Bukkit lifecycle facade. Public signatures and executor identity are
+ * retained; the shared runtime owns the same sequencing through a Bukkit adapter.
  */
 public final class AdvancedCoreLifecycle {
 
-	private final AdvancedCorePlugin plugin;
+    private final AdvancedCorePlugin plugin;
 
-	public AdvancedCoreLifecycle(AdvancedCorePlugin plugin) {
-		this.plugin = plugin;
-	}
+    public AdvancedCoreLifecycle(AdvancedCorePlugin plugin) {
+        this.plugin = plugin;
+    }
 
-	public static RuntimeExecutors createRuntimeExecutors(AdvancedCorePlugin plugin) {
-		return new RuntimeExecutors(new BukkitScheduler(plugin), Executors.newSingleThreadScheduledExecutor(),
-				Executors.newSingleThreadScheduledExecutor(), Executors.newSingleThreadScheduledExecutor());
-	}
+    public static RuntimeExecutors createRuntimeExecutors(AdvancedCorePlugin plugin) {
+        BukkitScheduler scheduler = new BukkitScheduler(plugin);
+        AdvancedCoreRuntime.ExecutorGroup executors = AdvancedCoreRuntime.createExecutors();
+        return new RuntimeExecutors(scheduler, executors.timer(), executors.loginTimer(), executors.inventoryTimer());
+    }
 
-	public void shutdown() {
-		if (plugin == null) {
-			return;
-		}
+    public void shutdown() {
+        if (plugin != null) new AdvancedCoreRuntime(new BukkitRuntimePlatform(plugin)).shutdown();
+    }
 
-		runCleanup("Javascript engine", () -> {
-			if (plugin.getOptions() != null && plugin.getOptions().isJavascriptEngineEnabled()) {
-				plugin.getLogger().info("Shutting down Javascript engine");
-				JavascriptEngineHandler.getInstance().clearCachedEngine();
-			}
-		});
+    static void shutdown(ScheduledExecutorService executor) {
+        AdvancedCoreRuntime.shutdown(executor);
+    }
+    static void shutdownNow(ScheduledExecutorService executor) {
+        AdvancedCoreRuntime.shutdownNow(executor);
+    }
+    static void await(ScheduledExecutorService executor, long timeout, TimeUnit unit) {
+        AdvancedCoreRuntime.await(executor, timeout, unit);
+    }
 
-		runCleanup("MySQL", () -> {
-			if (plugin.isLoadUserData() && plugin.getOptions() != null
-					&& UserStorage.MYSQL.equals(plugin.getOptions().getStorageType()) && plugin.getMysql() != null) {
-				plugin.getMysql().close();
-			}
-		});
+    public static final class RuntimeExecutors {
+        private final BukkitScheduler bukkitScheduler;
+        private final ScheduledExecutorService timer;
+        private final ScheduledExecutorService loginTimer;
+        private final ScheduledExecutorService inventoryTimer;
 
-		runCleanup("server data timestamp", () -> {
-			if (plugin.getServerDataFile() != null) {
-				plugin.getServerDataFile().setLastUpdated();
-			}
-		});
+        public RuntimeExecutors(BukkitScheduler bukkitScheduler, ScheduledExecutorService timer,
+                ScheduledExecutorService loginTimer, ScheduledExecutorService inventoryTimer) {
+            this.bukkitScheduler = bukkitScheduler;
+            this.timer = timer;
+            this.loginTimer = loginTimer;
+            this.inventoryTimer = inventoryTimer;
+        }
 
-		ScheduledExecutorService timeTimer = null;
-		TimeChecker timeChecker = plugin.getTimeChecker();
-		if (timeChecker != null) {
-			timeTimer = timeChecker.getTimer();
-		}
-
-		shutdown(plugin.getLoginTimer());
-		shutdown(plugin.getTimer());
-		shutdown(timeTimer);
-		shutdown(plugin.getInventoryTimer());
-
-		plugin.getLogger().info("Allowing background tasks to finish before shutdown");
-		await(plugin.getLoginTimer(), 2, TimeUnit.SECONDS);
-		await(plugin.getTimer(), 2, TimeUnit.SECONDS);
-		await(timeTimer, 2, TimeUnit.SECONDS);
-		await(plugin.getInventoryTimer(), 1, TimeUnit.SECONDS);
-
-		runCleanup("reward handler", () -> {
-			if (plugin.getRewardHandler() != null) {
-				plugin.getRewardHandler().shutdown();
-			}
-		});
-
-		shutdownNow(plugin.getLoginTimer());
-		shutdownNow(plugin.getTimer());
-		shutdownNow(timeTimer);
-		shutdownNow(plugin.getInventoryTimer());
-
-		runCleanup("plugin unload hook", plugin::onUnLoad);
-		runCleanup("skull cache", () -> {
-			if (plugin.getSkullCacheHandler() != null) {
-				plugin.getSkullCacheHandler().close();
-			}
-		});
-		runCleanup("full inventory handler", () -> {
-			FullInventoryHandler handler = plugin.getFullInventoryHandler();
-			if (handler != null) {
-				handler.shutdown();
-				handler.save();
-			}
-		});
-		runCleanup("hologram handler", () -> {
-			if (plugin.getHologramHandler() != null) {
-				plugin.getHologramHandler().onShutDown();
-			}
-		});
-		runCleanup("permission handler", () -> {
-			if (plugin.getPermissionHandler() != null) {
-				plugin.getPermissionHandler().shutDown();
-			}
-		});
-		runCleanup("dialog service", () -> {
-			if (plugin.getDialogService() != null) {
-				plugin.getDialogService().unregister();
-			}
-		});
-	}
-
-	private void runCleanup(String component, Runnable cleanup) {
-		try {
-			cleanup.run();
-		} catch (Throwable e) {
-			plugin.getLogger().warning("Failed to shut down " + component + ": " + e.getMessage());
-			plugin.debug(e);
-		}
-	}
-
-	static void shutdown(ScheduledExecutorService executor) {
-		if (executor != null && !executor.isShutdown()) {
-			executor.shutdown();
-		}
-	}
-
-	static void shutdownNow(ScheduledExecutorService executor) {
-		if (executor != null && !executor.isTerminated()) {
-			executor.shutdownNow();
-		}
-	}
-
-	static void await(ScheduledExecutorService executor, long timeout, TimeUnit unit) {
-		if (executor == null) {
-			return;
-		}
-		try {
-			executor.awaitTermination(timeout, unit);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-		}
-	}
-
-	public static final class RuntimeExecutors {
-		private final BukkitScheduler bukkitScheduler;
-		private final ScheduledExecutorService timer;
-		private final ScheduledExecutorService loginTimer;
-		private final ScheduledExecutorService inventoryTimer;
-
-		public RuntimeExecutors(BukkitScheduler bukkitScheduler, ScheduledExecutorService timer,
-				ScheduledExecutorService loginTimer, ScheduledExecutorService inventoryTimer) {
-			this.bukkitScheduler = bukkitScheduler;
-			this.timer = timer;
-			this.loginTimer = loginTimer;
-			this.inventoryTimer = inventoryTimer;
-		}
-
-		public BukkitScheduler getBukkitScheduler() {
-			return bukkitScheduler;
-		}
-
-		public ScheduledExecutorService getTimer() {
-			return timer;
-		}
-
-		public ScheduledExecutorService getLoginTimer() {
-			return loginTimer;
-		}
-
-		public ScheduledExecutorService getInventoryTimer() {
-			return inventoryTimer;
-		}
-	}
+        public BukkitScheduler getBukkitScheduler() { return bukkitScheduler; }
+        public ScheduledExecutorService getTimer() { return timer; }
+        public ScheduledExecutorService getLoginTimer() { return loginTimer; }
+        public ScheduledExecutorService getInventoryTimer() { return inventoryTimer; }
+    }
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
@@ -1,0 +1,110 @@
+package com.bencodez.advancedcore.tests.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.bukkit.runtime.BukkitRuntimePlatform;
+import com.bencodez.advancedcore.core.platform.RuntimePlatform;
+import com.bencodez.advancedcore.core.platform.RuntimePlatform.Cleanup;
+import com.bencodez.advancedcore.core.runtime.AdvancedCoreRuntime;
+import com.bencodez.advancedcore.lifecycle.AdvancedCoreLifecycle;
+
+class CoreRuntimeTest {
+    private RuntimePlatform platform() {
+        RuntimePlatform platform = mock(RuntimePlatform.class);
+        when(platform.beforeExecutorShutdown()).thenReturn(List.of());
+        when(platform.afterExecutorGrace()).thenReturn(List.of());
+        when(platform.afterExecutorShutdown()).thenReturn(List.of());
+        return platform;
+    }
+
+    @Test void constructionDoesNotStartOrReplaceExistingServices() {
+        RuntimePlatform platform = platform();
+        clearInvocations(platform);
+        new AdvancedCoreRuntime(platform);
+        verifyNoInteractions(platform);
+    }
+
+    @Test void preservesExecutorShutdownGraceAndRewardOrdering() throws Exception {
+        RuntimePlatform platform = platform();
+        var events = new ArrayList<String>();
+        ScheduledExecutorService login = executor("login", events);
+        ScheduledExecutorService timer = executor("timer", events);
+        ScheduledExecutorService time = executor("time", events);
+        ScheduledExecutorService inventory = executor("inventory", events);
+        when(platform.getLoginTimer()).thenReturn(login);
+        when(platform.getTimer()).thenReturn(timer);
+        when(platform.getTimeTimer()).thenReturn(time);
+        when(platform.getInventoryTimer()).thenReturn(inventory);
+        when(platform.beforeExecutorShutdown()).thenReturn(List.of(new Cleanup("pre", () -> events.add("pre"))));
+        when(platform.afterExecutorGrace()).thenReturn(List.of(new Cleanup("rewards", () -> events.add("rewards"))));
+        when(platform.afterExecutorShutdown()).thenReturn(List.of(new Cleanup("post", () -> events.add("post"))));
+        doAnswer(call -> { events.add("wait-log"); return null; }).when(platform).info(anyString());
+        new AdvancedCoreRuntime(platform).shutdown();
+        assertEquals(List.of("pre", "login-stop", "timer-stop", "time-stop", "inventory-stop", "wait-log",
+                "login-wait", "timer-wait", "time-wait", "inventory-wait", "rewards",
+                "login-force", "timer-force", "time-force", "inventory-force", "post"), events);
+        verify(login).awaitTermination(2, TimeUnit.SECONDS);
+        verify(timer).awaitTermination(2, TimeUnit.SECONDS);
+        verify(time).awaitTermination(2, TimeUnit.SECONDS);
+        verify(inventory).awaitTermination(1, TimeUnit.SECONDS);
+        verify(platform, times(1)).getTimeTimer();
+    }
+
+    private ScheduledExecutorService executor(String name, List<String> events) throws Exception {
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        doAnswer(call -> { events.add(name + "-stop"); return null; }).when(executor).shutdown();
+        when(executor.awaitTermination(anyLong(), any())).thenAnswer(call -> { events.add(name + "-wait"); return false; });
+        when(executor.shutdownNow()).thenAnswer(call -> { events.add(name + "-force"); return List.of(); });
+        return executor;
+    }
+
+    @Test void cleanupFailureIsReportedWithoutSkippingLaterComponents() {
+        RuntimePlatform platform = platform();
+        var events = new ArrayList<String>();
+        var failure = new IllegalStateException("fixture");
+        when(platform.beforeExecutorShutdown()).thenReturn(List.of(
+                new Cleanup("failed", () -> { throw failure; }),
+                new Cleanup("next", () -> events.add("next"))));
+        when(platform.afterExecutorShutdown()).thenReturn(List.of(new Cleanup("last", () -> events.add("last"))));
+        new AdvancedCoreRuntime(platform).shutdown();
+        assertEquals(List.of("next", "last"), events);
+        verify(platform).cleanupFailed("failed", failure);
+    }
+
+    @Test void preservesInterruptAndSkipsAlreadyFinishedExecutors() throws Exception {
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        when(executor.awaitTermination(2, TimeUnit.SECONDS)).thenThrow(new InterruptedException("fixture"));
+        try {
+            AdvancedCoreRuntime.await(executor, 2, TimeUnit.SECONDS);
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally { Thread.interrupted(); }
+        when(executor.isShutdown()).thenReturn(true);
+        when(executor.isTerminated()).thenReturn(true);
+        AdvancedCoreRuntime.shutdown(executor);
+        AdvancedCoreRuntime.shutdownNow(executor);
+        verify(executor, never()).shutdown();
+        verify(executor, never()).shutdownNow();
+        assertDoesNotThrow(() -> AdvancedCoreRuntime.shutdown(null));
+        assertDoesNotThrow(() -> AdvancedCoreRuntime.shutdownNow(null));
+        assertDoesNotThrow(() -> AdvancedCoreRuntime.await(null, 1, TimeUnit.SECONDS));
+    }
+
+    @Test void bukkitAdapterRetainsExecutorIdentityAndLegacyNullShutdown() {
+        AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+        ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+        when(plugin.getTimer()).thenReturn(timer);
+        var platform = new BukkitRuntimePlatform(plugin);
+        assertSame(timer, platform.getTimer());
+        assertNull(platform.getTimeTimer());
+        assertDoesNotThrow(() -> new AdvancedCoreLifecycle(null).shutdown());
+    }
+}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/RuntimeHeadlessFixture.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/RuntimeHeadlessFixture.java
@@ -1,0 +1,46 @@
+package com.bencodez.advancedcore.tests.lifecycle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.bencodez.advancedcore.core.platform.RuntimePlatform;
+import com.bencodez.advancedcore.core.runtime.AdvancedCoreRuntime;
+
+/** Runs with only project classes and the JDK, not Bukkit or the testing libraries. */
+public final class RuntimeHeadlessFixture {
+    private RuntimeHeadlessFixture() { }
+
+    public static void run() throws Exception {
+        var group = AdvancedCoreRuntime.createExecutors();
+        var steps = new ArrayList<String>();
+        try {
+            if (group.timer() == group.loginTimer() || group.loginTimer() == group.inventoryTimer()) {
+                throw new AssertionError("Executor ownership was combined");
+            }
+            if (group.timer().submit(() -> 7).get(2, TimeUnit.SECONDS) != 7) throw new AssertionError("Task failed");
+            var runtime = new AdvancedCoreRuntime(new RuntimePlatform() {
+                public ScheduledExecutorService getTimer() { return group.timer(); }
+                public ScheduledExecutorService getLoginTimer() { return group.loginTimer(); }
+                public ScheduledExecutorService getInventoryTimer() { return group.inventoryTimer(); }
+                public ScheduledExecutorService getTimeTimer() { return null; }
+                public List<Cleanup> beforeExecutorShutdown() { return List.of(new Cleanup("before", () -> steps.add("before"))); }
+                public List<Cleanup> afterExecutorGrace() { return List.of(new Cleanup("reward", () -> steps.add("reward"))); }
+                public List<Cleanup> afterExecutorShutdown() { return List.of(new Cleanup("after", () -> steps.add("after"))); }
+                public void info(String message) { steps.add("wait"); }
+                public void cleanupFailed(String component, Throwable failure) { throw new AssertionError(component, failure); }
+            });
+            runtime.shutdown();
+            if (!steps.equals(List.of("before", "wait", "reward", "after"))) throw new AssertionError(steps);
+            try { group.timer().execute(() -> { }); throw new AssertionError("Accepted after shutdown"); }
+            catch (RejectedExecutionException expected) { }
+            if (!group.timer().isTerminated() || !group.loginTimer().isTerminated() || !group.inventoryTimer().isTerminated()) {
+                throw new AssertionError("Executor did not terminate");
+            }
+        } finally {
+            group.timer().shutdownNow(); group.loginTimer().shutdownNow(); group.inventoryTimer().shutdownNow();
+        }
+    }
+}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/RuntimeHeadlessTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/RuntimeHeadlessTest.java
@@ -1,0 +1,24 @@
+package com.bencodez.advancedcore.tests.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.core.runtime.AdvancedCoreRuntime;
+
+class RuntimeHeadlessTest {
+    @Test void runtimeExecutesAndStopsWithNoServerApiOnItsClasspath() throws Exception {
+        URL main = AdvancedCoreRuntime.class.getProtectionDomain().getCodeSource().getLocation();
+        URL tests = getClass().getProtectionDomain().getCodeSource().getLocation();
+        try (var isolated = new URLClassLoader(new URL[] { main, tests }, ClassLoader.getPlatformClassLoader())) {
+            assertThrows(ClassNotFoundException.class, () -> isolated.loadClass("org.bukkit.Bukkit"));
+            assertThrows(ClassNotFoundException.class, () -> isolated.loadClass("org.junit.jupiter.api.Test"));
+            Class<?> fixture = isolated.loadClass(RuntimeHeadlessFixture.class.getName());
+            assertSame(isolated, fixture.getClassLoader());
+            fixture.getMethod("run").invoke(null);
+        }
+    }
+}

--- a/docs/shared-runtime-foundation.md
+++ b/docs/shared-runtime-foundation.md
@@ -1,0 +1,49 @@
+# Shared runtime foundation
+
+AdvancedCore remains one Maven project with one existing POM. New shared runtime
+mechanics live under `core/runtime` and their platform contract under
+`core/platform`; Bukkit cleanup hooks live under `bukkit/runtime`. No modules,
+workflow files, dependency versions, publishing changes or game-loader stubs are
+introduced.
+
+The existing `AdvancedCoreLifecycle` facade now delegates its executor creation
+and shutdown sequence to `core.runtime.AdvancedCoreRuntime` through
+`BukkitRuntimePlatform`. AdvancedCorePlugin's current enable/disable calls already
+use that facade, so Bukkit uses the extracted code immediately. There is no
+parallel runtime with different caches or a second set of background tasks.
+
+## Preserved contracts
+
+- The facade constructor, nested RuntimeExecutors constructor and getters retain
+  their signatures and return the same executor/scheduler objects.
+- General, login and inventory work retain separate single-thread executors.
+- BukkitScheduler/Folia behavior is unchanged; game/entity/region scheduling is
+  not redirected to these background executors.
+- JavaScript cleanup, MySQL closing and server timestamp happen before executor
+  shutdown, as before. This extraction does not redesign database flushing.
+- Executor grace periods remain 2/2/2/1 seconds, followed by reward shutdown,
+  forced executor shutdown and the existing unload/cache/inventory/integration
+  cleanup order. The time-checker timer is captured at the same point.
+- Individual component failures retain the warning/debug callback behavior and
+  do not skip later components. Interrupted waits restore the interrupt flag.
+- Lifecycle calls remain serialized by the owning platform. Hook execution is
+  synchronous; the executor grace periods are not a global bound on all cleanup
+  callbacks. No stronger transactional or idempotency guarantee is claimed.
+
+## What this does not port yet
+
+This is the executor/lifecycle slice of the future shared runtime, not a complete
+Bukkit-free AdvancedCore service graph. Users, settings, storage, rewards, game
+operations and integration providers are extracted in subsequent changes. Native
+packaging must only include dependency-clean classes once that graph is ready;
+this PR does not tell a Fabric server to load the full existing AdvancedCore JAR.
+
+## Validation
+
+Use the existing `mvn -B -f AdvancedCore/pom.xml package` command. Existing Bukkit
+lifecycle tests remain in place. New tests compare the cleanup/executor ordering,
+timeouts, failure handling, object identity and interrupt behavior. A headless
+fixture creates real executor owners, runs a task, shuts down and checks rejection
+of new work while Bukkit/JUnit are absent from its isolated classpath.
+
+No live-server or downstream VotingPlugin validation is implied by those tests.


### PR DESCRIPTION
## Summary

Second requested platform-preparation PR. Extract the existing executor/lifecycle implementation into `core/runtime` and the Bukkit-specific cleanup hooks into `bukkit/runtime`, in the current single Maven project.

- Introduce `RuntimePlatform` with JDK-only executor and cleanup contracts.
- Move creation of the three background executor owners and shutdown sequencing into `AdvancedCoreRuntime`.
- Keep `AdvancedCoreLifecycle` as the public compatibility facade. AdvancedCorePlugin already uses it, so the Bukkit path uses the extracted implementation immediately.
- Preserve scheduler/executor identity, separate executor ownership, cleanup order, 2/2/2/1-second grace periods, reward shutdown position, interruption handling and warning/debug callbacks.
- Retain existing lifecycle tests and add six tests for exact ordering, failure handling, identity and a real JDK-only runtime fixture.

## Compatibility and scope

One POM, no submodules, no new workflows, no dependency/version changes, and no AdvancedCorePlugin public API changes. The existing BukkitScheduler/Folia behavior is untouched. This does not redirect entity/region work to a global executor.

This is the executor/lifecycle slice, not a complete native AdvancedCore service graph. User/storage/reward services and final native artifact packaging remain separate steps. There is no duplicate user cache or second service registry. Existing lifecycle serialization and synchronous cleanup behavior remain; the executor grace periods are not a global timeout for arbitrary cleanup callbacks.

## Verified build

[Existing Java CI with Maven — run 530](https://github.com/BenCodez/AdvancedCore/actions/runs/34180807987) **passed** on Java 21. Inspected build job `101919368836` and its actual Maven log:

- `mvn -B -f AdvancedCore/pom.xml package` — **BUILD SUCCESS**.
- **284 tests**, zero failures/errors/skips, including all **six new tests** and both original lifecycle tests.
- The headless fixture passed with Bukkit and JUnit absent from its isolated runtime.
- `AdvancedCore.jar` was generated and normal shading/minimization completed.
- Tested PR merge ref `dc303c9aeea529f58e9a6c1a950830e7f2602c34` for head `50eb4bec1a0e0c42c757d428fa3ce778af3e7cb2` and base `5fe205bca26236a92ee2fda1634f056639b307a3`.

Local Java 21 compilation of the two shared production classes also passed. A local JDK-only smoke program ran a real task, checked independent executor owners and cleanup order, verified termination, and verified rejection after shutdown.

The editing container has no Maven/dependency network access. The full Maven result is from **GitHub Actions**, not a local Maven run. No current downstream VotingPlugin build, live-server test or live-database matrix was run. Source inspection was same-context; no independent reviewer execution is claimed.

## Related work

- BenCodez/SimpleAPI#78: structured reward configuration boundary.
- #314: shared scalar user-data reads preserving existing caches and storage hooks.

These initial AdvancedCore PRs have disjoint production changes and independently target master. This lifecycle slice does not require SimpleAPI#78 to be published or merged.

Nothing is merged, deployed or published by this PR.

**AI disclosure:** This implementation and pull-request description were prepared with assistance from ChatGPT.