### PR TITLE
Add ordered async reward injection support

### DIFF
--- a/AdvancedCore/pom.xml
+++ b/AdvancedCore/pom.xml
@@ -87,6 +87,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -522,8 +522,22 @@ public class FullInventoryHandler {
 
 			boolean dropItems = plugin.getOptions().isDropOnFullInv();
 			if (dropItems) {
-				for (ItemStack extra : excess.values()) {
-					player.getWorld().dropItem(player.getLocation(), extra);
+				if (reservationId == null) {
+					for (ItemStack extra : excess.values()) player.getWorld().dropItem(player.getLocation(), extra);
+				} else {
+					ReservedOverflow reservation = new ReservedOverflow(player.getUniqueId(), excess.values());
+					replayOverflowReservations.put(reservationId, reservation);
+					ArrayList<ItemStack> undropped = new ArrayList<>();
+					for (ItemStack extra : reservation.items) {
+						try {
+							if (player.getWorld().dropItem(player.getLocation(), extra) == null) undropped.add(extra);
+						} catch (Throwable failure) {
+							undropped.add(extra);
+						}
+					}
+					if (undropped.isEmpty()) replayOverflowReservations.remove(reservationId, reservation);
+					else replayOverflowReservations.put(reservationId,
+							new ReservedOverflow(player.getUniqueId(), undropped));
 				}
 			} else if (reservationId != null) {
 				replayOverflowReservations.put(reservationId,
@@ -536,7 +550,7 @@ public class FullInventoryHandler {
 				sendMessage(player);
 			}
 			player.updateInventory();
-			return !dropItems;
+			return reservationId != null && replayOverflowReservations.containsKey(reservationId);
 		} finally {
 			deliveryLock.readLock().unlock();
 		}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -41,6 +41,14 @@ public class FullInventoryHandler {
 	@Getter
 	private final ConcurrentHashMap<UUID, ArrayList<ItemStack>> items = new ConcurrentHashMap<>();
 
+	/*
+	 * Replay-aware delivery cannot place an overflow into the ordinary pending map
+	 * until its snapshot has been written.  The ordinary periodic sweep is allowed
+	 * to consume that map, so doing so earlier makes a failed save indistinguishable
+	 * from a delivery that has already happened and a replay can duplicate items.
+	 */
+	private final ConcurrentHashMap<String, ReservedOverflow> replayOverflowReservations = new ConcurrentHashMap<>();
+
 	private final AdvancedCorePlugin plugin;
 	private final ReentrantReadWriteLock deliveryLock = new ReentrantReadWriteLock(true);
 
@@ -51,6 +59,19 @@ public class FullInventoryHandler {
 
 	@Getter
 	private final ConcurrentHashMap<UUID, Long> lastMessageTime = new ConcurrentHashMap<>();
+
+	private static final class ReservedOverflow {
+		private final UUID playerId;
+		private final ArrayList<ItemStack> items;
+
+		private ReservedOverflow(UUID playerId, Collection<ItemStack> items) {
+			this.playerId = playerId;
+			this.items = new ArrayList<>();
+			for (ItemStack item : items) {
+				if (item != null) this.items.add(item);
+			}
+		}
+	}
 
 	public FullInventoryHandler(AdvancedCorePlugin plugin) {
 		this.plugin = plugin;
@@ -123,18 +144,19 @@ public class FullInventoryHandler {
 			}
 		}
 		final UUID deliveryPlayerId = playerId;
+		final String reservationId = completion == null ? null : UUID.randomUUID().toString();
 		ItemStack[] itemsToGive = item.clone();
 		AtomicBoolean deliveryClaimed = new AtomicBoolean();
 		Runnable delivery = () -> {
 			if (!deliveryClaimed.compareAndSet(false, true)) return;
 			try {
 				if (completion != null) validateReplayDeliveryTarget(player, deliveryPlayerId);
-				boolean pendingOverflow = giveItemOwnedPlayer(player, itemsToGive);
+				boolean pendingOverflow = giveItemOwnedPlayer(player, itemsToGive, reservationId);
 				if (completion != null) {
 					if (pendingOverflow) {
-						persistPendingItemsAsync().whenComplete((ignored, failure) -> {
+						persistReservedOverflowAsync(reservationId).whenComplete((ignored, failure) -> {
 							if (failure == null) completion.complete(null);
-							else completion.completeExceptionally(failure);
+							else completeStartedOverflowWithFallback(player, deliveryPlayerId, reservationId, completion);
 						});
 					} else {
 						completion.complete(null);
@@ -227,47 +249,23 @@ public class FullInventoryHandler {
 	public boolean saveDurably() {
 		deliveryLock.writeLock().lock();
 		try {
-			ServerData serverData = plugin.getServerDataFile();
-			if (serverData == null || serverData.getData() == null) {
-				return false;
+			HashMap<String, ReservedOverflow> reservations = new HashMap<>(replayOverflowReservations);
+			if (!savePendingItemsLocked(reservations.values())) return false;
+			for (Entry<String, ReservedOverflow> entry : reservations.entrySet()) {
+				promoteReservedOverflowLocked(entry.getKey(), entry.getValue());
 			}
-
-			YamlConfiguration snapshot = new YamlConfiguration();
-			long now = System.currentTimeMillis();
-			for (Entry<UUID, ArrayList<ItemStack>> entry : items.entrySet()) {
-				ArrayList<ItemStack> pending = new ArrayList<>(entry.getValue());
-				String basePath = "FullInventory." + entry.getKey();
-				for (int i = 0; i < pending.size(); i++) {
-					snapshot.set(basePath + ".Items." + i, pending.get(i));
-				}
-				snapshot.set(basePath + ".Time", now);
-			}
-
-			FileConfiguration data = serverData.getData();
-			data.set("FullInventory", null);
-			ConfigurationSection replacement = snapshot.getConfigurationSection("FullInventory");
-			if (replacement != null) {
-				for (String path : replacement.getKeys(true)) {
-					if (!replacement.isConfigurationSection(path)) {
-						data.set("FullInventory." + path, replacement.get(path));
-					}
-				}
-			}
-			serverData.saveData();
 			return true;
-		} catch (Exception e) {
-			plugin.getLogger().log(Level.WARNING, "Failed to save pending full-inventory items", e);
-			return false;
 		} finally {
 			deliveryLock.writeLock().unlock();
 		}
 	}
 
-	private CompletionStage<Void> persistPendingItemsAsync() {
+	/** Persists one replay reservation before making it visible to ordinary pending checks. */
+	private CompletionStage<Void> persistReservedOverflowAsync(String reservationId) {
 		CompletableFuture<Void> persisted = new CompletableFuture<>();
 		try {
 			timer.execute(() -> {
-				if (saveDurably()) persisted.complete(null);
+				if (persistReservedOverflow(reservationId)) persisted.complete(null);
 				else persisted.completeExceptionally(
 						new IllegalStateException("Unable to persist full-inventory reward overflow"));
 			});
@@ -275,6 +273,157 @@ public class FullInventoryHandler {
 			persisted.completeExceptionally(failure);
 		}
 		return persisted;
+	}
+
+	private boolean persistReservedOverflow(String reservationId) {
+		deliveryLock.writeLock().lock();
+		try {
+			ReservedOverflow reservation = replayOverflowReservations.get(reservationId);
+			if (reservation == null || reservation.items.isEmpty()) return true;
+			if (!savePendingItemsLocked(java.util.List.of(reservation))) return false;
+			promoteReservedOverflowLocked(reservationId, reservation);
+			return true;
+		} finally {
+			deliveryLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * A save failure happens after Bukkit has already accepted part of this reward.
+	 * Complete the replay action after a best-effort owner-thread handoff instead of
+	 * replaying those already-inserted items. Un-dropped items stay reserved and are
+	 * retried for persistence without being visible to the normal delivery sweep.
+	 */
+	private void completeStartedOverflowWithFallback(Player player, UUID playerId, String reservationId,
+			CompletableFuture<Void> completion) {
+		Runnable fallback = () -> {
+			try {
+				dropReservedOverflowOwnedPlayer(player, playerId, reservationId);
+			} finally {
+				scheduleReservedOverflowPersistenceRetry(reservationId);
+				completion.complete(null);
+			}
+		};
+		try {
+			plugin.getBukkitScheduler().runTask(plugin, fallback, player);
+		} catch (Throwable failure) {
+			// The mutation has already started. Retain the reservation for a later disk
+			// retry, but never make the outer replay issue the full item stack again.
+			scheduleReservedOverflowPersistenceRetry(reservationId);
+			completion.complete(null);
+		}
+	}
+
+	/** Runs only on the player owner scheduler. */
+	private void dropReservedOverflowOwnedPlayer(Player player, UUID playerId, String reservationId) {
+		if (player == null || playerId == null || Bukkit.getPlayer(playerId) != player || !player.isOnline()) return;
+		deliveryLock.writeLock().lock();
+		try {
+			ReservedOverflow reservation = replayOverflowReservations.get(reservationId);
+			if (reservation == null || !playerId.equals(reservation.playerId)) return;
+			ArrayList<ItemStack> remaining = new ArrayList<>();
+			for (ItemStack item : reservation.items) {
+				try {
+					if (player.getWorld().dropItem(player.getLocation(), item) == null) remaining.add(item);
+				} catch (Throwable failure) {
+					remaining.add(item);
+				}
+			}
+			if (remaining.isEmpty()) replayOverflowReservations.remove(reservationId, reservation);
+			else replayOverflowReservations.put(reservationId, new ReservedOverflow(playerId, remaining));
+		} finally {
+			deliveryLock.writeLock().unlock();
+		}
+	}
+
+	private void scheduleReservedOverflowPersistenceRetry(String reservationId) {
+		if (!replayOverflowReservations.containsKey(reservationId)) return;
+		try {
+			timer.schedule(() -> {
+				if (!persistReservedOverflow(reservationId)) scheduleReservedOverflowPersistenceRetry(reservationId);
+			}, 30, TimeUnit.SECONDS);
+		} catch (Throwable ignored) {
+			// Shutdown may reject this retry. The retained reservation remains excluded
+			// from normal checks and can be saved by a later live handler instance.
+		}
+	}
+
+	/** Caller holds the write lock. Includes only the reservations in this durable handoff. */
+	private boolean savePendingItemsLocked(Collection<ReservedOverflow> reservedOverflows) {
+		FileConfiguration data = null;
+		YamlConfiguration previous = null;
+		try {
+			ServerData serverData = plugin.getServerDataFile();
+			if (serverData == null || serverData.getData() == null) return false;
+
+			HashMap<UUID, ArrayList<ItemStack>> snapshotItems = new HashMap<>();
+			for (Entry<UUID, ArrayList<ItemStack>> entry : items.entrySet()) {
+				snapshotItems.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+			}
+			for (ReservedOverflow reservedOverflow : reservedOverflows) {
+				if (!reservedOverflow.items.isEmpty()) {
+					snapshotItems.computeIfAbsent(reservedOverflow.playerId, ignored -> new ArrayList<>())
+						.addAll(reservedOverflow.items);
+				}
+			}
+
+			YamlConfiguration snapshot = new YamlConfiguration();
+			long now = System.currentTimeMillis();
+			for (Entry<UUID, ArrayList<ItemStack>> entry : snapshotItems.entrySet()) {
+				String basePath = "FullInventory." + entry.getKey();
+				for (int i = 0; i < entry.getValue().size(); i++) {
+					snapshot.set(basePath + ".Items." + i, entry.getValue().get(i));
+				}
+				snapshot.set(basePath + ".Time", now);
+			}
+
+			data = serverData.getData();
+			previous = copySection(data, "FullInventory");
+			data.set("FullInventory", null);
+			ConfigurationSection replacement = snapshot.getConfigurationSection("FullInventory");
+			if (replacement != null) {
+				for (String path : replacement.getKeys(true)) {
+					if (!replacement.isConfigurationSection(path)) data.set("FullInventory." + path, replacement.get(path));
+				}
+			}
+			serverData.saveData();
+			return true;
+		} catch (Exception e) {
+			if (data != null && previous != null) replaceSection(data, "FullInventory", previous);
+			try {
+				plugin.getLogger().log(Level.WARNING, "Failed to save pending full-inventory items", e);
+			} catch (Throwable ignored) {
+				// A partially initialized plugin can still retain the reservation for retry.
+			}
+			return false;
+		}
+	}
+
+	private static YamlConfiguration copySection(ConfigurationSection source, String path) {
+		YamlConfiguration copy = new YamlConfiguration();
+		ConfigurationSection section = source.getConfigurationSection(path);
+		if (section == null) return copy;
+		for (String child : section.getKeys(true)) {
+			if (!section.isConfigurationSection(child)) copy.set(child, section.get(child));
+		}
+		return copy;
+	}
+
+	private static void replaceSection(ConfigurationSection target, String path, YamlConfiguration replacement) {
+		target.set(path, null);
+		for (String child : replacement.getKeys(true)) {
+			if (!replacement.isConfigurationSection(child)) target.set(path + "." + child, replacement.get(child));
+		}
+	}
+
+	/** Caller holds the write lock. */
+	private void promoteReservedOverflowLocked(String reservationId, ReservedOverflow reservation) {
+		if (!replayOverflowReservations.remove(reservationId, reservation)) return;
+		items.compute(reservation.playerId, (key, current) -> {
+			ArrayList<ItemStack> merged = current == null ? new ArrayList<>() : new ArrayList<>(current);
+			merged.addAll(reservation.items);
+			return merged;
+		});
 	}
 
 	public void startup() {
@@ -361,7 +510,7 @@ public class FullInventoryHandler {
 		}
 	}
 
-	private boolean giveItemOwnedPlayer(Player player, ItemStack[] item) {
+	private boolean giveItemOwnedPlayer(Player player, ItemStack[] item, String reservationId) {
 		deliveryLock.readLock().lock();
 		try {
 			HashMap<Integer, ItemStack> excess = player.getInventory().addItem(item);
@@ -371,12 +520,15 @@ public class FullInventoryHandler {
 			}
 
 			boolean dropItems = plugin.getOptions().isDropOnFullInv();
-			for (ItemStack extra : excess.values()) {
-				if (dropItems) {
+			if (dropItems) {
+				for (ItemStack extra : excess.values()) {
 					player.getWorld().dropItem(player.getLocation(), extra);
-				} else {
-					add(player.getUniqueId(), extra);
 				}
+			} else if (reservationId != null) {
+				replayOverflowReservations.put(reservationId,
+						new ReservedOverflow(player.getUniqueId(), excess.values()));
+			} else {
+				for (ItemStack extra : excess.values()) add(player.getUniqueId(), extra);
 			}
 
 			if (shouldSendMessage(player.getUniqueId())) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -52,6 +52,7 @@ public class FullInventoryHandler {
 
 	private final AdvancedCorePlugin plugin;
 	private final ReentrantReadWriteLock deliveryLock = new ReentrantReadWriteLock(true);
+	private final AtomicBoolean shuttingDown = new AtomicBoolean();
 
 	@Getter
 	private ScheduledExecutorService timer;
@@ -127,6 +128,11 @@ public class FullInventoryHandler {
 	private void scheduleItemDelivery(Player player, ItemStack[] item, CompletableFuture<Void> completion) {
 		if (player == null || item == null || item.length == 0) {
 			if (completion != null) completion.complete(null);
+			return;
+		}
+		if (completion != null && shuttingDown.get()) {
+			completion.completeExceptionally(AdvancedCoreUser.replayActionNotStarted(
+					"Full-inventory handler is shutting down before item delivery"));
 			return;
 		}
 		UUID playerId = null;
@@ -227,6 +233,7 @@ public class FullInventoryHandler {
 	}
 
 	public synchronized void shutdown() {
+		shuttingDown.set(true);
 		// Flush accepted replay reservations while their completion stages can still
 		// advance the outer reward checkpoint. Stopping the executor first can discard
 		// an accepted persistence task and later replay the already-inserted items.
@@ -534,6 +541,10 @@ public class FullInventoryHandler {
 	private boolean giveItemOwnedPlayer(Player player, ItemStack[] item, String reservationId) {
 		deliveryLock.readLock().lock();
 		try {
+			if (reservationId != null && shuttingDown.get()) {
+				throw AdvancedCoreUser.replayActionNotStarted(
+						"Full-inventory handler shut down before queued item delivery began");
+			}
 			HashMap<Integer, ItemStack> excess = player.getInventory().addItem(item);
 			if (excess.isEmpty()) {
 				player.updateInventory();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -290,37 +290,33 @@ public class FullInventoryHandler {
 
 	/**
 	 * A save failure happens after Bukkit has already accepted part of this reward.
-	 * Complete the replay action after a best-effort owner-thread handoff instead of
-	 * replaying those already-inserted items. Un-dropped items stay reserved and are
-	 * retried for persistence without being visible to the normal delivery sweep.
+	 * Complete the replay action only after an owner-thread fallback consumes every
+	 * reserved item or a later retry persists the remainder. Reserved items stay
+	 * excluded from the normal delivery sweep while either handoff is pending.
 	 */
 	private void completeStartedOverflowWithFallback(Player player, UUID playerId, String reservationId,
 			CompletableFuture<Void> completion) {
 		Runnable fallback = () -> {
-			try {
-				dropReservedOverflowOwnedPlayer(player, playerId, reservationId);
-			} finally {
-				scheduleReservedOverflowPersistenceRetry(reservationId);
-				completion.complete(null);
-			}
+			if (dropReservedOverflowOwnedPlayer(player, playerId, reservationId)) completion.complete(null);
+			else scheduleReservedOverflowPersistenceRetry(reservationId, completion);
 		};
 		try {
 			plugin.getBukkitScheduler().runTask(plugin, fallback, player);
 		} catch (Throwable failure) {
-			// The mutation has already started. Retain the reservation for a later disk
-			// retry, but never make the outer replay issue the full item stack again.
-			scheduleReservedOverflowPersistenceRetry(reservationId);
-			completion.complete(null);
+			// The mutation has already started, so neither acknowledge it nor fail it as
+			// replayable. Keep the stage pending until the reservation is durable.
+			scheduleReservedOverflowPersistenceRetry(reservationId, completion);
 		}
 	}
 
 	/** Runs only on the player owner scheduler. */
-	private void dropReservedOverflowOwnedPlayer(Player player, UUID playerId, String reservationId) {
-		if (player == null || playerId == null || Bukkit.getPlayer(playerId) != player || !player.isOnline()) return;
+	private boolean dropReservedOverflowOwnedPlayer(Player player, UUID playerId, String reservationId) {
+		if (player == null || playerId == null || Bukkit.getPlayer(playerId) != player || !player.isOnline()) return false;
 		deliveryLock.writeLock().lock();
 		try {
 			ReservedOverflow reservation = replayOverflowReservations.get(reservationId);
-			if (reservation == null || !playerId.equals(reservation.playerId)) return;
+			if (reservation == null) return true;
+			if (!playerId.equals(reservation.playerId)) return false;
 			ArrayList<ItemStack> remaining = new ArrayList<>();
 			for (ItemStack item : reservation.items) {
 				try {
@@ -331,20 +327,25 @@ public class FullInventoryHandler {
 			}
 			if (remaining.isEmpty()) replayOverflowReservations.remove(reservationId, reservation);
 			else replayOverflowReservations.put(reservationId, new ReservedOverflow(playerId, remaining));
+			return remaining.isEmpty();
 		} finally {
 			deliveryLock.writeLock().unlock();
 		}
 	}
 
-	private void scheduleReservedOverflowPersistenceRetry(String reservationId) {
-		if (!replayOverflowReservations.containsKey(reservationId)) return;
+	private void scheduleReservedOverflowPersistenceRetry(String reservationId, CompletableFuture<Void> completion) {
+		if (!replayOverflowReservations.containsKey(reservationId)) {
+			completion.complete(null);
+			return;
+		}
 		try {
 			timer.schedule(() -> {
-				if (!persistReservedOverflow(reservationId)) scheduleReservedOverflowPersistenceRetry(reservationId);
+				if (persistReservedOverflow(reservationId)) completion.complete(null);
+				else scheduleReservedOverflowPersistenceRetry(reservationId, completion);
 			}, 30, TimeUnit.SECONDS);
 		} catch (Throwable ignored) {
-			// Shutdown may reject this retry. The retained reservation remains excluded
-			// from normal checks and can be saved by a later live handler instance.
+			// Shutdown may reject this retry. Leave the completion pending: acknowledging
+			// an in-memory-only remainder would lose it from the durable reward replay.
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -106,11 +106,26 @@ public class FullInventoryHandler {
 			if (completion != null) completion.complete(null);
 			return;
 		}
+		UUID playerId = null;
+		if (completion != null) {
+			try {
+				playerId = player.getUniqueId();
+				if (playerId == null) {
+					completion.completeExceptionally(new IllegalStateException("Item delivery player has no UUID"));
+					return;
+				}
+			} catch (Throwable failure) {
+				completion.completeExceptionally(failure);
+				return;
+			}
+		}
+		final UUID deliveryPlayerId = playerId;
 		ItemStack[] itemsToGive = item.clone();
 		AtomicBoolean deliveryClaimed = new AtomicBoolean();
 		Runnable delivery = () -> {
 			if (!deliveryClaimed.compareAndSet(false, true)) return;
 			try {
+				if (completion != null) validateReplayDeliveryTarget(player, deliveryPlayerId);
 				giveItemOwnedPlayer(player, itemsToGive);
 				if (completion != null) completion.complete(null);
 			} catch (Throwable failure) {
@@ -136,6 +151,22 @@ public class FullInventoryHandler {
 	/** Bounds a replay-aware delivery; timeout claims the delivery to prevent a duplicate retry. */
 	protected long getItemDeliveryTimeoutMillis() {
 		return TimeUnit.SECONDS.toMillis(30);
+	}
+
+	/**
+	 * Runs on the owning player scheduler immediately before a replay-aware inventory
+	 * mutation. A reconnect creates a different player entity, so require both the
+	 * captured UUID and entity identity to remain current; a retry can then safely
+	 * schedule delivery for the live entity.
+	 */
+	private void validateReplayDeliveryTarget(Player player, UUID playerId) {
+		if (!plugin.isEnabled()) {
+			throw new IllegalStateException("Plugin disabled before item delivery");
+		}
+		Player current = Bukkit.getPlayer(playerId);
+		if (current != player || !current.isOnline()) {
+			throw new IllegalStateException("Player became unavailable before item delivery");
+		}
 	}
 
 	private static void rethrowDeliveryFailure(Throwable failure) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 import com.bencodez.advancedcore.data.ServerData;
 import com.bencodez.simpleapi.messages.MessageAPI;
 
@@ -111,11 +112,13 @@ public class FullInventoryHandler {
 			try {
 				playerId = player.getUniqueId();
 				if (playerId == null) {
-					completion.completeExceptionally(new IllegalStateException("Item delivery player has no UUID"));
+					completion.completeExceptionally(AdvancedCoreUser.replayActionNotStarted(
+							"Item delivery player has no UUID"));
 					return;
 				}
 			} catch (Throwable failure) {
-				completion.completeExceptionally(failure);
+				completion.completeExceptionally(AdvancedCoreUser.replayActionNotStarted(
+						"Unable to resolve item delivery player before dispatch", failure));
 				return;
 			}
 		}
@@ -137,13 +140,15 @@ public class FullInventoryHandler {
 			plugin.getBukkitScheduler().runTask(plugin, delivery, player);
 		} catch (Throwable failure) {
 			deliveryClaimed.set(true);
-			if (completion != null) completion.completeExceptionally(failure);
+			if (completion != null) completion.completeExceptionally(AdvancedCoreUser.replayActionNotStarted(
+					"Scheduler rejected item delivery before dispatch", failure));
 			else rethrowDeliveryFailure(failure);
 		}
 		if (completion == null) return;
 		CompletableFuture.delayedExecutor(getItemDeliveryTimeoutMillis(), TimeUnit.MILLISECONDS).execute(() -> {
 			if (deliveryClaimed.compareAndSet(false, true)) {
-				completion.completeExceptionally(new TimeoutException("Timed out waiting for item delivery"));
+				completion.completeExceptionally(AdvancedCoreUser.replayActionNotStarted(
+						"Timed out waiting for item delivery", new TimeoutException()));
 			}
 		});
 	}
@@ -161,11 +166,11 @@ public class FullInventoryHandler {
 	 */
 	private void validateReplayDeliveryTarget(Player player, UUID playerId) {
 		if (!plugin.isEnabled()) {
-			throw new IllegalStateException("Plugin disabled before item delivery");
+			throw AdvancedCoreUser.replayActionNotStarted("Plugin disabled before item delivery");
 		}
 		Player current = Bukkit.getPlayer(playerId);
 		if (current != player || !current.isOnline()) {
-			throw new IllegalStateException("Player became unavailable before item delivery");
+			throw AdvancedCoreUser.replayActionNotStarted("Player became unavailable before item delivery");
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -129,8 +129,17 @@ public class FullInventoryHandler {
 			if (!deliveryClaimed.compareAndSet(false, true)) return;
 			try {
 				if (completion != null) validateReplayDeliveryTarget(player, deliveryPlayerId);
-				giveItemOwnedPlayer(player, itemsToGive);
-				if (completion != null) completion.complete(null);
+				boolean pendingOverflow = giveItemOwnedPlayer(player, itemsToGive);
+				if (completion != null) {
+					if (pendingOverflow) {
+						persistPendingItemsAsync().whenComplete((ignored, failure) -> {
+							if (failure == null) completion.complete(null);
+							else completion.completeExceptionally(failure);
+						});
+					} else {
+						completion.complete(null);
+					}
+				}
 			} catch (Throwable failure) {
 				if (completion != null) completion.completeExceptionally(failure);
 				else rethrowDeliveryFailure(failure);
@@ -211,11 +220,16 @@ public class FullInventoryHandler {
 	 * the temporary remove/re-add state of an in-flight inventory check.
 	 */
 	public void save() {
+		saveDurably();
+	}
+
+	/** Saves pending items and reports whether the disk snapshot completed. */
+	public boolean saveDurably() {
 		deliveryLock.writeLock().lock();
 		try {
 			ServerData serverData = plugin.getServerDataFile();
 			if (serverData == null || serverData.getData() == null) {
-				return;
+				return false;
 			}
 
 			YamlConfiguration snapshot = new YamlConfiguration();
@@ -240,11 +254,27 @@ public class FullInventoryHandler {
 				}
 			}
 			serverData.saveData();
+			return true;
 		} catch (Exception e) {
 			plugin.getLogger().log(Level.WARNING, "Failed to save pending full-inventory items", e);
+			return false;
 		} finally {
 			deliveryLock.writeLock().unlock();
 		}
+	}
+
+	private CompletionStage<Void> persistPendingItemsAsync() {
+		CompletableFuture<Void> persisted = new CompletableFuture<>();
+		try {
+			timer.execute(() -> {
+				if (saveDurably()) persisted.complete(null);
+				else persisted.completeExceptionally(
+						new IllegalStateException("Unable to persist full-inventory reward overflow"));
+			});
+		} catch (Throwable failure) {
+			persisted.completeExceptionally(failure);
+		}
+		return persisted;
 	}
 
 	public void startup() {
@@ -331,13 +361,13 @@ public class FullInventoryHandler {
 		}
 	}
 
-	private void giveItemOwnedPlayer(Player player, ItemStack[] item) {
+	private boolean giveItemOwnedPlayer(Player player, ItemStack[] item) {
 		deliveryLock.readLock().lock();
 		try {
 			HashMap<Integer, ItemStack> excess = player.getInventory().addItem(item);
 			if (excess.isEmpty()) {
 				player.updateInventory();
-				return;
+				return false;
 			}
 
 			boolean dropItems = plugin.getOptions().isDropOnFullInv();
@@ -353,6 +383,7 @@ public class FullInventoryHandler {
 				sendMessage(player);
 			}
 			player.updateInventory();
+			return !dropItems;
 		} finally {
 			deliveryLock.readLock().unlock();
 		}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -6,10 +6,14 @@ import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 
@@ -82,11 +86,62 @@ public class FullInventoryHandler {
 	}
 
 	public void giveItem(Player player, ItemStack... item) {
+		scheduleItemDelivery(player, item, null);
+	}
+
+	/**
+	 * Gives items on the owning player scheduler and completes after the inventory
+	 * mutation, including full-inventory handling, has finished. The established
+	 * void API remains fire-and-forget; replay-aware callers use this boundary so
+	 * they never checkpoint a queued delivery as completed.
+	 */
+	public CompletionStage<Void> giveItemAsync(Player player, ItemStack... item) {
+		CompletableFuture<Void> completion = new CompletableFuture<>();
+		scheduleItemDelivery(player, item, completion);
+		return completion;
+	}
+
+	private void scheduleItemDelivery(Player player, ItemStack[] item, CompletableFuture<Void> completion) {
 		if (player == null || item == null || item.length == 0) {
+			if (completion != null) completion.complete(null);
 			return;
 		}
 		ItemStack[] itemsToGive = item.clone();
-		plugin.getBukkitScheduler().runTask(plugin, () -> giveItemOwnedPlayer(player, itemsToGive), player);
+		AtomicBoolean deliveryClaimed = new AtomicBoolean();
+		Runnable delivery = () -> {
+			if (!deliveryClaimed.compareAndSet(false, true)) return;
+			try {
+				giveItemOwnedPlayer(player, itemsToGive);
+				if (completion != null) completion.complete(null);
+			} catch (Throwable failure) {
+				if (completion != null) completion.completeExceptionally(failure);
+				else rethrowDeliveryFailure(failure);
+			}
+		};
+		try {
+			plugin.getBukkitScheduler().runTask(plugin, delivery, player);
+		} catch (Throwable failure) {
+			deliveryClaimed.set(true);
+			if (completion != null) completion.completeExceptionally(failure);
+			else rethrowDeliveryFailure(failure);
+		}
+		if (completion == null) return;
+		CompletableFuture.delayedExecutor(getItemDeliveryTimeoutMillis(), TimeUnit.MILLISECONDS).execute(() -> {
+			if (deliveryClaimed.compareAndSet(false, true)) {
+				completion.completeExceptionally(new TimeoutException("Timed out waiting for item delivery"));
+			}
+		});
+	}
+
+	/** Bounds a replay-aware delivery; timeout claims the delivery to prevent a duplicate retry. */
+	protected long getItemDeliveryTimeoutMillis() {
+		return TimeUnit.SECONDS.toMillis(30);
+	}
+
+	private static void rethrowDeliveryFailure(Throwable failure) {
+		if (failure instanceof RuntimeException) throw (RuntimeException) failure;
+		if (failure instanceof Error) throw (Error) failure;
+		throw new IllegalStateException("Failed to schedule item delivery", failure);
 	}
 
 	public synchronized void loadTimer() {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/item/FullInventoryHandler.java
@@ -48,6 +48,7 @@ public class FullInventoryHandler {
 	 * from a delivery that has already happened and a replay can duplicate items.
 	 */
 	private final ConcurrentHashMap<String, ReservedOverflow> replayOverflowReservations = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, CompletableFuture<Void>> replayOverflowCompletions = new ConcurrentHashMap<>();
 
 	private final AdvancedCorePlugin plugin;
 	private final ReentrantReadWriteLock deliveryLock = new ReentrantReadWriteLock(true);
@@ -154,8 +155,9 @@ public class FullInventoryHandler {
 				boolean pendingOverflow = giveItemOwnedPlayer(player, itemsToGive, reservationId);
 				if (completion != null) {
 					if (pendingOverflow) {
+						replayOverflowCompletions.put(reservationId, completion);
 						persistReservedOverflowAsync(reservationId).whenComplete((ignored, failure) -> {
-							if (failure == null) completion.complete(null);
+							if (failure == null) completeReplayOverflow(reservationId, completion);
 							else completeStartedOverflowWithFallback(player, deliveryPlayerId, reservationId, completion);
 						});
 					} else {
@@ -225,6 +227,10 @@ public class FullInventoryHandler {
 	}
 
 	public synchronized void shutdown() {
+		// Flush accepted replay reservations while their completion stages can still
+		// advance the outer reward checkpoint. Stopping the executor first can discard
+		// an accepted persistence task and later replay the already-inserted items.
+		saveDurably();
 		if (checkTask != null) {
 			checkTask.cancel(false);
 			checkTask = null;
@@ -247,17 +253,23 @@ public class FullInventoryHandler {
 
 	/** Saves pending items and reports whether the disk snapshot completed. */
 	public boolean saveDurably() {
+		HashMap<String, ReservedOverflow> reservations;
+		boolean saved;
 		deliveryLock.writeLock().lock();
 		try {
-			HashMap<String, ReservedOverflow> reservations = new HashMap<>(replayOverflowReservations);
+			reservations = new HashMap<>(replayOverflowReservations);
 			if (!savePendingItemsLocked(reservations.values())) return false;
 			for (Entry<String, ReservedOverflow> entry : reservations.entrySet()) {
 				promoteReservedOverflowLocked(entry.getKey(), entry.getValue());
 			}
-			return true;
+			saved = true;
 		} finally {
 			deliveryLock.writeLock().unlock();
 		}
+		if (saved) {
+			for (String reservationId : reservations.keySet()) completeReplayOverflow(reservationId, null);
+		}
+		return true;
 	}
 
 	/** Persists one replay reservation before making it visible to ordinary pending checks. */
@@ -297,7 +309,9 @@ public class FullInventoryHandler {
 	private void completeStartedOverflowWithFallback(Player player, UUID playerId, String reservationId,
 			CompletableFuture<Void> completion) {
 		Runnable fallback = () -> {
-			if (dropReservedOverflowOwnedPlayer(player, playerId, reservationId)) completion.complete(null);
+			if (dropReservedOverflowOwnedPlayer(player, playerId, reservationId)) {
+				completeReplayOverflow(reservationId, completion);
+			}
 			else scheduleReservedOverflowPersistenceRetry(reservationId, completion);
 		};
 		try {
@@ -335,18 +349,24 @@ public class FullInventoryHandler {
 
 	private void scheduleReservedOverflowPersistenceRetry(String reservationId, CompletableFuture<Void> completion) {
 		if (!replayOverflowReservations.containsKey(reservationId)) {
-			completion.complete(null);
+			completeReplayOverflow(reservationId, completion);
 			return;
 		}
 		try {
 			timer.schedule(() -> {
-				if (persistReservedOverflow(reservationId)) completion.complete(null);
+				if (persistReservedOverflow(reservationId)) completeReplayOverflow(reservationId, completion);
 				else scheduleReservedOverflowPersistenceRetry(reservationId, completion);
 			}, 30, TimeUnit.SECONDS);
 		} catch (Throwable ignored) {
 			// Shutdown may reject this retry. Leave the completion pending: acknowledging
 			// an in-memory-only remainder would lose it from the durable reward replay.
 		}
+	}
+
+	private void completeReplayOverflow(String reservationId, CompletableFuture<Void> fallbackCompletion) {
+		CompletableFuture<Void> completion = replayOverflowCompletions.remove(reservationId);
+		if (completion == null) completion = fallbackCompletion;
+		if (completion != null) completion.complete(null);
 	}
 
 	/** Caller holds the write lock. Includes only the reservations in this durable handoff. */

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
@@ -258,8 +258,8 @@ public class MiscUtils {
 				expanded = PlaceholderUtils.replacePlaceHolder(expanded, placeholders);
 				if (p != null) expanded = PlaceholderUtils.replacePlaceHolders(p, expanded);
 			}
-			ArrayList<String> commands = expanded == null || expanded.isEmpty()
-					? new ArrayList<>() : new ArrayList<>(java.util.List.of(expanded));
+			ArrayList<String> commands = command == null || command.isEmpty()
+					? new ArrayList<>() : new ArrayList<>(java.util.List.of(expanded == null ? "" : expanded));
 			return Reward.replayCommandSequence(plugin, placeholders, "console", templates, commands,
 					(cmd, ignoredIndex) -> {
 						plugin.debug("Executing console command: " + cmd);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
@@ -19,7 +19,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
@@ -232,7 +237,18 @@ public class MiscUtils {
 	}
 
 	public void executeConsoleCommands(String playerName, String command, HashMap<String, String> placeholders) {
-		if (command != null && !command.isEmpty()) {
+		executeConsoleCommandsAsync(playerName, command, placeholders);
+	}
+
+	/**
+	 * Schedules one console command and completes only after Bukkit has dispatched
+	 * it. Async reward replay uses this completion boundary so it never records a
+	 * durable checkpoint ahead of a queued command.
+	 */
+	public CompletionStage<Void> executeConsoleCommandsAsync(String playerName, String command,
+			HashMap<String, String> placeholders) {
+		if (command == null || command.isEmpty()) return CompletableFuture.completedFuture(null);
+		try {
 			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
 			if (p != null) {
 				command = PlaceholderUtils.replaceJavascriptOnly(p, command);
@@ -244,16 +260,40 @@ public class MiscUtils {
 			final String cmd = stripLeadingSlash(command);
 
 			plugin.debug("Executing console command: " + command);
-			plugin.getBukkitScheduler().executeOrScheduleSync(plugin, new Runnable() {
-
-				@Override
-				public void run() {
-					Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), cmd);
-				}
-
-			});
+			return runConsoleCommandAsync(cmd, 0, false, false);
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
 		}
+	}
 
+	/**
+	 * Schedules every console command using the legacy stagger timing and completes
+	 * only after every dispatch has run. This keeps an async reward injector from
+	 * checkpointing a command list while any member is still queued.
+	 */
+	@SuppressWarnings("deprecation")
+	public CompletionStage<Void> executeConsoleCommandsAsync(final String playerName, final ArrayList<String> cmds,
+			final HashMap<String, String> placeholders, final boolean stagger) {
+		if (cmds == null || cmds.isEmpty()) return CompletableFuture.completedFuture(null);
+		try {
+			placeholders.put("player", playerName);
+			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
+			ArrayList<String> commands = cmds;
+			if (p != null) commands = PlaceholderUtils.replaceJavascriptOnly(p, commands);
+			commands = PlaceholderUtils.replacePlaceHolder(commands, placeholders);
+			if (p != null) commands = PlaceholderUtils.replacePlaceHolders(p, commands);
+
+			ArrayList<CompletableFuture<Void>> completions = new ArrayList<>();
+			int delay = 0;
+			for (String command : commands) {
+				plugin.debug("Executing console command: " + command);
+				completions.add(runConsoleCommandAsync(stripLeadingSlash(command), delay++, stagger, true)
+						.toCompletableFuture());
+			}
+			return CompletableFuture.allOf(completions.toArray(new CompletableFuture[0]));
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
+		}
 	}
 
 	public Object getBlockMeta(Block block, String str) {
@@ -477,6 +517,42 @@ public class MiscUtils {
 				}
 			});
 		}
+	}
+
+	/**
+	 * Schedules one command with a completion boundary. The timeout claims the
+	 * runnable before it can execute, so a task delayed past shutdown cannot run
+	 * after a failed replay has already been retried.
+	 */
+	private CompletionStage<Void> runConsoleCommandAsync(String command, int delay, boolean hasDelay,
+			boolean scheduleAsTask) {
+		CompletableFuture<Void> completion = new CompletableFuture<>();
+		AtomicBoolean claimed = new AtomicBoolean();
+		Runnable dispatch = () -> {
+			if (!claimed.compareAndSet(false, true)) return;
+			try {
+				Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), command);
+				completion.complete(null);
+			} catch (Throwable failure) {
+				completion.completeExceptionally(failure);
+			}
+		};
+		try {
+			if (hasDelay && delay > 0) plugin.getBukkitScheduler().runTaskLater(plugin, dispatch, delay);
+			else if (scheduleAsTask) plugin.getBukkitScheduler().runTask(plugin, dispatch);
+			else plugin.getBukkitScheduler().executeOrScheduleSync(plugin, dispatch);
+		} catch (Throwable failure) {
+			claimed.set(true);
+			completion.completeExceptionally(failure);
+			return completion;
+		}
+		long timeoutSeconds = 30L + Math.max(0, delay);
+		CompletableFuture.delayedExecutor(timeoutSeconds, TimeUnit.SECONDS).execute(() -> {
+			if (claimed.compareAndSet(false, true)) {
+				completion.completeExceptionally(new TimeoutException("Timed out waiting for scheduled console command"));
+			}
+		});
+		return completion;
 	}
 
 	private String stripLeadingSlash(String command) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
@@ -248,25 +248,23 @@ public class MiscUtils {
 	 */
 	public CompletionStage<Void> executeConsoleCommandsAsync(String playerName, String command,
 			HashMap<String, String> placeholders) {
-		return executeConsoleCommandAsync(playerName, command, placeholders, false);
-	}
-
-	private CompletionStage<Void> executeConsoleCommandAsync(String playerName, String command,
-			HashMap<String, String> placeholders, boolean delayed) {
-		if (command == null || command.isEmpty()) return CompletableFuture.completedFuture(null);
 		try {
+			ArrayList<String> templates = command == null || command.isEmpty()
+					? new ArrayList<>() : new ArrayList<>(java.util.List.of(command));
+			String expanded = command;
 			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
-			if (p != null) {
-				command = PlaceholderUtils.replaceJavascriptOnly(p, command);
+			if (expanded != null && !expanded.isEmpty()) {
+				if (p != null) expanded = PlaceholderUtils.replaceJavascriptOnly(p, expanded);
+				expanded = PlaceholderUtils.replacePlaceHolder(expanded, placeholders);
+				if (p != null) expanded = PlaceholderUtils.replacePlaceHolders(p, expanded);
 			}
-			command = PlaceholderUtils.replacePlaceHolder(command, placeholders);
-			if (p != null) {
-				command = PlaceholderUtils.replacePlaceHolders(p, command);
-			}
-			final String cmd = stripLeadingSlash(command);
-
-			plugin.debug("Executing console command: " + command);
-			return runConsoleCommandAsync(cmd, delayed ? 1 : 0, delayed, delayed);
+			ArrayList<String> commands = expanded == null || expanded.isEmpty()
+					? new ArrayList<>() : new ArrayList<>(java.util.List.of(expanded));
+			return Reward.replayCommandSequence(plugin, placeholders, "console", templates, commands,
+					(cmd, ignoredIndex) -> {
+						plugin.debug("Executing console command: " + cmd);
+						return runConsoleCommandAsync(stripLeadingSlash(cmd), 0, false, false);
+					});
 		} catch (Throwable failure) {
 			return CompletableFuture.failedFuture(failure);
 		}
@@ -280,17 +278,16 @@ public class MiscUtils {
 	@SuppressWarnings("deprecation")
 	public CompletionStage<Void> executeConsoleCommandsAsync(final String playerName, final ArrayList<String> cmds,
 			final HashMap<String, String> placeholders, final boolean stagger) {
-		if (cmds == null || cmds.isEmpty()) return CompletableFuture.completedFuture(null);
 		try {
 			placeholders.put("player", playerName);
 			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
-			ArrayList<String> templates = new ArrayList<>(cmds);
-			ArrayList<String> commands = cmds;
+			ArrayList<String> templates = cmds == null ? new ArrayList<>() : new ArrayList<>(cmds);
+			ArrayList<String> commands = new ArrayList<>(templates);
 			if (p != null) commands = PlaceholderUtils.replaceJavascriptOnly(p, commands);
 			commands = PlaceholderUtils.replacePlaceHolder(commands, placeholders);
 			if (p != null) commands = PlaceholderUtils.replacePlaceHolders(p, commands);
 
-			return Reward.replayCommandSequence(plugin, placeholders, "console:" + stagger, templates, commands,
+			return Reward.replayCommandSequence(plugin, placeholders, "console", templates, commands,
 					(command, index) -> {
 						plugin.debug("Executing console command: " + command);
 						return runConsoleCommandAsync(stripLeadingSlash(command), index > 0 ? 1 : 0,

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
@@ -284,12 +284,13 @@ public class MiscUtils {
 		try {
 			placeholders.put("player", playerName);
 			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
+			ArrayList<String> templates = new ArrayList<>(cmds);
 			ArrayList<String> commands = cmds;
 			if (p != null) commands = PlaceholderUtils.replaceJavascriptOnly(p, commands);
 			commands = PlaceholderUtils.replacePlaceHolder(commands, placeholders);
 			if (p != null) commands = PlaceholderUtils.replacePlaceHolders(p, commands);
 
-			return Reward.replayCommandSequence(plugin, placeholders, "console:" + stagger, commands,
+			return Reward.replayCommandSequence(plugin, placeholders, "console:" + stagger, templates, commands,
 					(command, index) -> {
 						plugin.debug("Executing console command: " + command);
 						return runConsoleCommandAsync(stripLeadingSlash(command), index > 0 ? 1 : 0,

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/misc/MiscUtils.java
@@ -43,6 +43,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffectType;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.item.ItemBuilder;
 import com.bencodez.advancedcore.api.messages.PlaceholderUtils;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
@@ -247,6 +248,11 @@ public class MiscUtils {
 	 */
 	public CompletionStage<Void> executeConsoleCommandsAsync(String playerName, String command,
 			HashMap<String, String> placeholders) {
+		return executeConsoleCommandAsync(playerName, command, placeholders, false);
+	}
+
+	private CompletionStage<Void> executeConsoleCommandAsync(String playerName, String command,
+			HashMap<String, String> placeholders, boolean delayed) {
 		if (command == null || command.isEmpty()) return CompletableFuture.completedFuture(null);
 		try {
 			OfflinePlayer p = Bukkit.getOfflinePlayer(playerName);
@@ -260,7 +266,7 @@ public class MiscUtils {
 			final String cmd = stripLeadingSlash(command);
 
 			plugin.debug("Executing console command: " + command);
-			return runConsoleCommandAsync(cmd, 0, false, false);
+			return runConsoleCommandAsync(cmd, delayed ? 1 : 0, delayed, delayed);
 		} catch (Throwable failure) {
 			return CompletableFuture.failedFuture(failure);
 		}
@@ -283,14 +289,12 @@ public class MiscUtils {
 			commands = PlaceholderUtils.replacePlaceHolder(commands, placeholders);
 			if (p != null) commands = PlaceholderUtils.replacePlaceHolders(p, commands);
 
-			ArrayList<CompletableFuture<Void>> completions = new ArrayList<>();
-			int delay = 0;
-			for (String command : commands) {
-				plugin.debug("Executing console command: " + command);
-				completions.add(runConsoleCommandAsync(stripLeadingSlash(command), delay++, stagger, true)
-						.toCompletableFuture());
-			}
-			return CompletableFuture.allOf(completions.toArray(new CompletableFuture[0]));
+			return Reward.replayCommandSequence(plugin, placeholders, "console:" + stagger, commands,
+					(command, index) -> {
+						plugin.debug("Executing console command: " + command);
+						return runConsoleCommandAsync(stripLeadingSlash(command), index > 0 ? 1 : 0,
+								stagger && index > 0, true);
+					});
 		} catch (Throwable failure) {
 			return CompletableFuture.failedFuture(failure);
 		}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/QueuedGeneratedReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/QueuedGeneratedReward.java
@@ -23,12 +23,23 @@ public final class QueuedGeneratedReward extends Reward {
 
 	@Override
 	public void giveReward(AdvancedCoreUser user, RewardOptions rewardOptions) {
-		if (user == null || user.getUUID() == null || !allowedUserUuids.contains(user.getUUID())) {
-			plugin.getLogger().warning("Blocked generated queued reward " + getRewardName()
-					+ " for a user without a matching persisted queue entry");
-			return;
-		}
+		if (!isAllowed(user)) return;
 		super.giveReward(user, rewardOptions);
+	}
+
+	@Override
+	public java.util.concurrent.CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user,
+			RewardOptions rewardOptions) {
+		if (!isAllowed(user)) return java.util.concurrent.CompletableFuture.failedFuture(
+				new IllegalStateException("Generated queued reward is not authorized for this user"));
+		return super.giveRewardAsync(user, rewardOptions);
+	}
+
+	private boolean isAllowed(AdvancedCoreUser user) {
+		if (user != null && user.getUUID() != null && allowedUserUuids.contains(user.getUUID())) return true;
+		plugin.getLogger().warning("Blocked generated queued reward " + getRewardName()
+				+ " for a user without a matching persisted queue entry");
+		return false;
 	}
 
 	@Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -966,8 +966,8 @@ public class Reward {
 	}
 
 	public void giveReward(AdvancedCoreUser user, RewardOptions rewardOptions) {
-		if (!AdvancedCorePlugin.getInstance().getOptions().isProcessRewards()) {
-			AdvancedCorePlugin.getInstance().debug("Processing rewards is disabled");
+		if (!plugin.getOptions().isProcessRewards()) {
+			plugin.debug("Processing rewards is disabled");
 			return;
 		}
 
@@ -1063,7 +1063,8 @@ public class Reward {
 				&& (!isForceOffline() && !rewardOptions.isForceOffline()))) {
 			if (rewardOptions.isGiveOffline()) {
 				checkRewardFile();
-				user.addOfflineRewards(this, rewardOptions.getPlaceholders());
+				preserveReplayState(rewardOptions);
+				user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
 				plugin.debug("Saving offline reward " + getRewardName() + " for " + user.getPlayerName());
 			}
 			return;
@@ -1090,8 +1091,8 @@ public class Reward {
 	 * @return completion stage for the complete reward injection chain
 	 */
 	public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, RewardOptions rewardOptions) {
-		if (!AdvancedCorePlugin.getInstance().getOptions().isProcessRewards()) {
-			AdvancedCorePlugin.getInstance().debug("Processing rewards is disabled");
+		if (!plugin.getOptions().isProcessRewards()) {
+			plugin.debug("Processing rewards is disabled");
 			return CompletableFuture.completedFuture(null);
 		}
 
@@ -1152,7 +1153,8 @@ public class Reward {
 				&& (!isForceOffline() && !rewardOptions.isForceOffline()))) {
 			if (rewardOptions.isGiveOffline()) {
 				checkRewardFile();
-				user.addOfflineRewards(this, rewardOptions.getPlaceholders());
+				preserveReplayState(rewardOptions);
+				user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
 			}
 			return CompletableFuture.completedFuture(null);
 		}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -54,6 +54,7 @@ public class Reward {
 	private static final ThreadLocal<String> ACTIVE_REPLAY_OCCURRENCE_ID = new ThreadLocal<>();
 	private static final String REPLAY_SELECTION_PREFIX = "__advancedcore_replay_selection_";
 	private static final String REPLAY_COMMAND_PREFIX = "__advancedcore_replay_commands_";
+	private static final String REPLAY_NESTED_LIST_PREFIX = "__advancedcore_replay_nested_list_";
 	private static final String REPLAY_LEGACY_ACTION_PREFIX = "__advancedcore_replay_legacy_actions_";
 
 	@Getter
@@ -303,7 +304,11 @@ public class Reward {
 			HashMap<String, String> placeholders, int completedStages, ReplayState replayState, String replayKey,
 			String occurrenceId) {
 		List<RewardInject> orderedRewards = orderedInjectedRewards();
-		int resumeAfter = Math.max(0, replayState.getCompleted(replayKey, completedStages));
+		int resumeAfter = replayState.getCompleted(replayKey, completedStages);
+		if (resumeAfter < 0 || resumeAfter > orderedRewards.size()) {
+			return CompletableFuture.failedFuture(
+					new IllegalStateException("Reward replay progress exceeds the injection registry"));
+		}
 		String registryFingerprint = injectionRegistryFingerprint(orderedRewards);
 		if (!replayState.matchesRegistryFingerprint(registryFingerprint)) {
 			return CompletableFuture.failedFuture(new IncompatibleReplayCheckpointException(replayKey));
@@ -527,11 +532,12 @@ public class Reward {
 			List<String> expandedCommands,
 			ReplayState replayState, String activeKey,
 			BiFunction<String, Integer, CompletionStage<Void>> dispatch) {
-		if (commandTemplates == null || commandTemplates.isEmpty()) return CompletableFuture.completedFuture(null);
-		if (expandedCommands == null || expandedCommands.size() != commandTemplates.size()) {
-			return CompletableFuture.failedFuture(new IllegalArgumentException("Command templates and expansions differ in size"));
-		}
 		if (replayState == null || activeKey == null) {
+			if (commandTemplates == null || commandTemplates.isEmpty()) return CompletableFuture.completedFuture(null);
+			if (expandedCommands == null || expandedCommands.size() != commandTemplates.size()) {
+				return CompletableFuture.failedFuture(
+						new IllegalArgumentException("Command templates and expansions differ in size"));
+			}
 			CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 			for (int index = 0; index < expandedCommands.size(); index++) {
 				String command = expandedCommands.get(index);
@@ -540,35 +546,43 @@ public class Reward {
 			}
 			return sequence;
 		}
-		StringBuilder identity = new StringBuilder(activeKey == null ? "root" : activeKey)
-				.append('\n').append(lane == null ? "commands" : lane);
-		identity.append('\n').append(encodeCommandSnapshot(commandTemplates));
-		String storageKey = REPLAY_COMMAND_PREFIX + digest(identity.toString());
+		String storageKey = replaySequenceKey(REPLAY_COMMAND_PREFIX, activeKey,
+				lane == null ? "commands" : lane);
 		String snapshotKey = storageKey + "_snapshot";
 		List<String> commands;
-		String storedSnapshot = placeholders.get(snapshotKey);
+		String storedSnapshot = replayMetadata(placeholders, replayState, snapshotKey);
 		boolean createdSnapshot = storedSnapshot == null;
 		if (storedSnapshot == null) {
-			commands = new ArrayList<>(expandedCommands);
+			List<String> templates = commandTemplates == null ? List.of() : commandTemplates;
+			List<String> expansions = expandedCommands == null ? List.of() : expandedCommands;
+			if (expansions.size() != templates.size()) {
+				return CompletableFuture.failedFuture(
+						new IllegalArgumentException("Command templates and expansions differ in size"));
+			}
+			commands = new ArrayList<>(expansions);
 			String encodedSnapshot = encodeCommandSnapshot(commands);
 			placeholders.put(snapshotKey, encodedSnapshot);
 			replayState.recordReplayMetadata(snapshotKey, encodedSnapshot);
 		} else {
 			replayState.recordReplayMetadata(snapshotKey, storedSnapshot);
 			try {
-				commands = decodeCommandSnapshot(storedSnapshot, commandTemplates.size());
+				commands = decodeCommandSnapshot(storedSnapshot);
 			} catch (IllegalArgumentException failure) {
 				return CompletableFuture.failedFuture(new IllegalStateException("Malformed command replay snapshot", failure));
 			}
 		}
-		int completed = 0;
+		String storedProgress = replayMetadata(placeholders, replayState, storageKey);
+		int completed;
 		try {
-			completed = Integer.parseInt(placeholders.getOrDefault(storageKey, "0"));
-		} catch (NumberFormatException ignored) { }
-		if (placeholders.containsKey(storageKey)) {
-			replayState.recordReplayMetadata(storageKey, placeholders.get(storageKey));
+			completed = storedProgress == null ? 0 : Integer.parseInt(storedProgress);
+		} catch (NumberFormatException failure) {
+			return CompletableFuture.failedFuture(
+					new IllegalStateException("Malformed command replay progress", failure));
 		}
-		if (completed < 0 || completed > commandTemplates.size()) completed = 0;
+		if (storedProgress != null) replayState.recordReplayMetadata(storageKey, storedProgress);
+		if (completed < 0 || completed > commands.size()) {
+			return CompletableFuture.failedFuture(new IllegalStateException("Command replay progress exceeds snapshot"));
+		}
 		// Persist the concrete expansion before issuing its first side effect. A
 		// restart during an indeterminate dispatch must reuse this exact payload,
 		// even though no command-progress marker exists yet.
@@ -587,6 +601,66 @@ public class Reward {
 			});
 		}
 		return sequence;
+	}
+
+	/** Freezes one nested reward list before any child side effect is dispatched. */
+	public static CompletionStage<List<String>> replayNestedRewardSnapshot(AdvancedCorePlugin plugin,
+			HashMap<String, String> placeholders, String lane, List<String> configuredRewards,
+			ReplayState replayState, String activeKey) {
+		if (replayState == null || activeKey == null) {
+			return CompletableFuture.completedFuture(configuredRewards == null ? List.of()
+					: new ArrayList<>(configuredRewards));
+		}
+		String snapshotKey = replaySequenceKey(REPLAY_NESTED_LIST_PREFIX, activeKey,
+				lane == null ? "nested" : lane) + "_snapshot";
+		String storedSnapshot = replayMetadata(placeholders, replayState, snapshotKey);
+		if (storedSnapshot != null) {
+			replayState.recordReplayMetadata(snapshotKey, storedSnapshot);
+			try {
+				return CompletableFuture.completedFuture(decodeCommandSnapshot(storedSnapshot));
+			} catch (IllegalArgumentException failure) {
+				return CompletableFuture.failedFuture(
+						new IllegalStateException("Malformed nested reward replay snapshot", failure));
+			}
+		}
+		List<String> snapshot = configuredRewards == null ? List.of() : new ArrayList<>(configuredRewards);
+		String encodedSnapshot = encodeCommandSnapshot(snapshot);
+		placeholders.put(snapshotKey, encodedSnapshot);
+		replayState.recordReplayMetadata(snapshotKey, encodedSnapshot);
+		return replayState.persistCheckpointAsync(plugin, placeholders).thenApply(ignored -> snapshot);
+	}
+
+	private static String replaySequenceKey(String prefix, String activeKey, String lane) {
+		return prefix + digest(activeKey.length() + ":" + activeKey + lane.length() + ":" + lane);
+	}
+
+	/** Returns whether the active replay already froze this logical command lane. */
+	public static boolean hasReplayCommandSnapshot(HashMap<String, String> placeholders, String lane) {
+		ReplayState replayState = currentReplayState();
+		String activeKey = currentReplayKey();
+		if (replayState == null || activeKey == null) return false;
+		String storageKey = replaySequenceKey(REPLAY_COMMAND_PREFIX, activeKey,
+				lane == null ? "commands" : lane);
+		return replayMetadata(placeholders, replayState, storageKey + "_snapshot") != null;
+	}
+
+	/** Returns whether the active replay already froze this nested reward lane. */
+	public static boolean hasReplayNestedRewardSnapshot(HashMap<String, String> placeholders, String lane) {
+		return hasReplayNestedRewardSnapshot(placeholders, lane, currentReplayState(), currentReplayKey());
+	}
+
+	/** Returns whether the supplied replay already froze this nested reward lane. */
+	public static boolean hasReplayNestedRewardSnapshot(HashMap<String, String> placeholders, String lane,
+			ReplayState replayState, String activeKey) {
+		if (replayState == null || activeKey == null) return false;
+		String storageKey = replaySequenceKey(REPLAY_NESTED_LIST_PREFIX, activeKey,
+				lane == null ? "nested" : lane);
+		return replayMetadata(placeholders, replayState, storageKey + "_snapshot") != null;
+	}
+
+	private static String replayMetadata(HashMap<String, String> placeholders, ReplayState replayState, String key) {
+		String value = placeholders == null ? null : placeholders.get(key);
+		return value == null && replayState != null ? replayState.replayMetadata(key) : value;
 	}
 
 	static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
@@ -609,6 +683,12 @@ public class Reward {
 	}
 
 	private static List<String> decodeCommandSnapshot(String encoded, int expectedSize) {
+		List<String> commands = decodeCommandSnapshot(encoded);
+		if (commands.size() != expectedSize) throw new IllegalArgumentException("Command snapshot size changed");
+		return commands;
+	}
+
+	private static List<String> decodeCommandSnapshot(String encoded) {
 		if (!encoded.startsWith("v1:")) throw new IllegalArgumentException("Unknown command snapshot version");
 		String body = encoded.substring(3);
 		ArrayList<String> commands = new ArrayList<>();
@@ -629,7 +709,6 @@ public class Reward {
 				}
 			}
 		}
-		if (commands.size() != expectedSize) throw new IllegalArgumentException("Command snapshot size changed");
 		return commands;
 	}
 
@@ -654,6 +733,7 @@ public class Reward {
 
 	private static boolean isReplayMetadataKey(String key) {
 		return key != null && (key.startsWith(REPLAY_SELECTION_PREFIX) || key.startsWith(REPLAY_COMMAND_PREFIX)
+				|| key.startsWith(REPLAY_NESTED_LIST_PREFIX)
 				|| key.startsWith(REPLAY_LEGACY_ACTION_PREFIX));
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -6,13 +6,18 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
@@ -36,6 +41,9 @@ import lombok.Setter;
  * The Class Reward.
  */
 public class Reward {
+	private static final ThreadLocal<ReplayState> ACTIVE_REPLAY_STATE = new ThreadLocal<>();
+	private static final ThreadLocal<String> ACTIVE_REPLAY_KEY = new ThreadLocal<>();
+	private static final String REPLAY_SELECTION_PREFIX = "__advancedcore_replay_selection_";
 
 	@Getter
 	@Setter
@@ -263,34 +271,193 @@ public class Reward {
 	 */
 	public CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
 			HashMap<String, String> placeholders) {
+		return giveInjectedRewardsAsync(user, placeholders, 0, new ReplayState(null), getRewardName());
+	}
+
+	/**
+	 * Resumes a persisted asynchronous reward after the supplied number of
+	 * injection stages have completed. Queue recovery uses this checkpoint to
+	 * avoid replaying already-applied non-idempotent injections.
+	 */
+	private CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
+			HashMap<String, String> placeholders, int completedStages, ReplayState replayState, String replayKey) {
 		List<RewardInject> postRewards = new ArrayList<>();
-		CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
-
+		List<RewardInject> orderedRewards = new ArrayList<>();
 		for (RewardInject inject : plugin.getRewardHandler().getInjectedRewards()) {
-			if (inject.isPostReward()) {
-				postRewards.add(inject);
-				continue;
-			}
-			sequence = sequence.thenCompose(ignored -> invokeInjectionAsync(inject, user, placeholders))
-					.thenCompose(result -> resumeOnServerThread(user).thenRun(() -> {
+			if (inject.isPostReward()) postRewards.add(inject);
+			else orderedRewards.add(inject);
+		}
+		orderedRewards.addAll(postRewards);
+		int resumeAfter = Math.max(0, replayState.getCompleted(replayKey, completedStages));
+		AtomicInteger completed = new AtomicInteger(resumeAfter);
+		CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+		for (int index = 0; index < orderedRewards.size(); index++) {
+			if (index < resumeAfter) continue;
+			final RewardInject inject = orderedRewards.get(index);
+			final String injectionKey = replayKey + "/" + index;
+			sequence = sequence.thenCompose(ignored -> invokeInjectionAsync(inject, user, placeholders, replayState,
+					injectionKey))
+					.thenApply(result -> {
 						if (inject.isAddAsPlaceholder() && result != null) addPlaceholder(inject, result, placeholders);
-					}));
+						int checkpoint = completed.incrementAndGet();
+						replayState.setCompleted(replayKey, checkpoint);
+						replayState.persistCheckpoint(placeholders);
+						return result;
+					}).thenCompose(ignored -> resumeOnServerThread(user));
+		}
+		return sequence.handle((ignored, failure) -> {
+			if (failure == null) return null;
+			RewardReplayFailure nestedFailure = findReplayFailure(failure);
+			if (nestedFailure != null) throw nestedFailure;
+			replayState.setCompleted(replayKey, completed.get());
+			throw new RewardReplayFailure(replayState, placeholders, failure);
+		});
+	}
+
+	// Kept as a narrow compatibility bridge for internal callers/tests that only
+	// have a single reward checkpoint.
+	private CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
+			HashMap<String, String> placeholders, int completedStages) {
+		return giveInjectedRewardsAsync(user, placeholders, completedStages, new ReplayState(null), getRewardName());
+	}
+
+	/** Details the last durably safe replay checkpoint when an async chain fails. */
+	public static final class RewardReplayFailure extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+		private final ReplayState replayState;
+		@Getter private final int completedInjectionCount;
+		@Getter private final HashMap<String, String> replayPlaceholders;
+
+		private RewardReplayFailure(ReplayState replayState, HashMap<String, String> replayPlaceholders, Throwable cause) {
+			super("Asynchronous reward replay failed after a completed asynchronous reward stage",
+					cause);
+			this.replayState = replayState;
+			this.completedInjectionCount = replayState.highestCompletedCount();
+			this.replayPlaceholders = new HashMap<>(replayPlaceholders);
 		}
 
-		for (RewardInject inject : postRewards) {
-			sequence = sequence.thenCompose(ignored -> invokeInjectionAsync(inject, user, placeholders))
-					.thenCompose(result -> resumeOnServerThread(user));
+		public Map<String, Integer> getReplayProgress() { return replayState.copyProgress(); }
+	}
+
+	private static RewardReplayFailure findReplayFailure(Throwable failure) {
+		for (Throwable current = failure; current != null; current = current.getCause()) {
+			if (current instanceof RewardReplayFailure) return (RewardReplayFailure) current;
 		}
-		return sequence;
+		return null;
+	}
+
+	/** Captures the active nested replay state for deferred child dispatch. */
+	public static ReplayState currentReplayState() { return ACTIVE_REPLAY_STATE.get(); }
+
+	/** Captures the active parent execution path before deferred work runs. */
+	public static String currentReplayKey() { return ACTIVE_REPLAY_KEY.get(); }
+
+	/** Obtains one shared replay state for a group of nested dispatches. */
+	public static ReplayState replayStateFor(RewardOptions options) {
+		ReplayState replayState = options.getAsyncReplayState();
+		if (replayState == null) {
+			replayState = ACTIVE_REPLAY_STATE.get();
+			if (replayState == null) replayState = new ReplayState(options.getAsyncReplayProgress());
+			options.setAsyncReplayState(replayState);
+		}
+		if (options.getAsyncReplayCheckpointConsumer() != null) {
+			replayState.setCheckpointConsumer(options.getAsyncReplayCheckpointConsumer());
+		}
+		return replayState;
+	}
+
+	/**
+	 * Records a nondeterministic nested-reward decision in the placeholder
+	 * snapshot carried by {@link RewardReplayFailure}. A retry consequently
+	 * executes the same selected branch instead of rolling a new outcome after a
+	 * child has already performed a side effect.
+	 */
+	public static String replaySelection(HashMap<String, String> placeholders, Supplier<String> selector) {
+		String activeKey = ACTIVE_REPLAY_KEY.get();
+		String storageKey = REPLAY_SELECTION_PREFIX + Base64.getUrlEncoder().withoutPadding()
+				.encodeToString((activeKey == null ? "root" : activeKey).getBytes(StandardCharsets.UTF_8));
+		if (placeholders.containsKey(storageKey)) {
+			String stored = placeholders.get(storageKey);
+			return stored.isEmpty() ? null : new String(Base64.getUrlDecoder().decode(stored), StandardCharsets.UTF_8);
+		}
+		String selected = selector.get();
+		placeholders.put(storageKey, selected == null ? "" : Base64.getUrlEncoder().withoutPadding()
+				.encodeToString(selected.getBytes(StandardCharsets.UTF_8)));
+		return selected;
+	}
+
+	/** Attaches a captured replay state to an option object for a deferred child. */
+	public static RewardOptions withReplayState(RewardOptions options, ReplayState replayState) {
+		if (replayState != null) options.setAsyncReplayState(replayState);
+		return options;
+	}
+
+	/**
+	 * Associates a deferred nested reward with a deterministic child occurrence.
+	 * A list may intentionally contain the same reward more than once, so its
+	 * replay checkpoint must never be shared merely because its name is equal.
+	 */
+	public static RewardOptions withReplayState(RewardOptions options, ReplayState replayState,
+			String childOccurrence) {
+		return withReplayState(options, replayState, ACTIVE_REPLAY_KEY.get(), childOccurrence);
+	}
+
+	/**
+	 * Associates deferred nested work with the parent path captured while the
+	 * injector was invoked. Later completion callbacks do not retain ThreadLocal
+	 * context, so they must use this explicit form.
+	 */
+	public static RewardOptions withReplayState(RewardOptions options, ReplayState replayState,
+			String parentKey, String childOccurrence) {
+		withReplayState(options, replayState);
+		if (parentKey != null && childOccurrence != null) {
+			options.setAsyncReplayKey(parentKey + "/" + childOccurrence);
+		}
+		return options;
+	}
+
+	/** Internal shared state passed through nested async reward dispatch. */
+	public static final class ReplayState {
+		private final HashMap<String, Integer> completed = new HashMap<>();
+		private Consumer<ReplayCheckpoint> checkpointConsumer;
+		private ReplayState(Map<String, Integer> initial) { if (initial != null) completed.putAll(initial); }
+		private synchronized int getCompleted(String rewardName, int fallback) {
+			return completed.getOrDefault(rewardName, fallback);
+		}
+		private synchronized void setCompleted(String rewardName, int count) { completed.put(rewardName, count); }
+		private synchronized Map<String, Integer> copyProgress() { return new HashMap<>(completed); }
+		private synchronized int highestCompletedCount() {
+			int highest = 0;
+			for (int count : completed.values()) highest = Math.max(highest, count);
+			return highest;
+		}
+		private synchronized void setCheckpointConsumer(Consumer<ReplayCheckpoint> consumer) {
+			checkpointConsumer = consumer;
+		}
+		private void persistCheckpoint(HashMap<String, String> placeholders) {
+			Consumer<ReplayCheckpoint> consumer;
+			synchronized (this) { consumer = checkpointConsumer; }
+			if (consumer != null) consumer.accept(new ReplayCheckpoint(copyProgress(), placeholders));
+		}
+	}
+
+	/** Immutable durable replay data emitted after every completed injection. */
+	public static final class ReplayCheckpoint {
+		@Getter private final Map<String, Integer> replayProgress;
+		@Getter private final HashMap<String, String> placeholders;
+		private ReplayCheckpoint(Map<String, Integer> replayProgress, HashMap<String, String> placeholders) {
+			this.replayProgress = new HashMap<>(replayProgress);
+			this.placeholders = new HashMap<>(placeholders);
+		}
 	}
 
 	private CompletionStage<Object> invokeInjectionAsync(RewardInject inject, AdvancedCoreUser user,
-			HashMap<String, String> placeholders) {
+			HashMap<String, String> placeholders, ReplayState replayState, String injectionKey) {
 		try {
 			if (!plugin.isEnabled()) return CompletableFuture.failedFuture(
 					new IllegalStateException("Plugin disabled before reward injection completed"));
 			Supplier<CompletionStage<Object>> request = () -> requestOnServerThread(user,
-					() -> requestInjectionAsync(inject, user, placeholders));
+					() -> requestInjectionAsync(inject, user, placeholders, replayState, injectionKey));
 			CompletionStage<Object> result = inject.isSynchronize() && inject.supportsAsyncSynchronization()
 					? inject.runSynchronizedAsync(request)
 					: request.get();
@@ -365,7 +532,12 @@ public class Reward {
 	}
 
 	private CompletionStage<Object> requestInjectionAsync(RewardInject inject, AdvancedCoreUser user,
-			HashMap<String, String> placeholders) {
+			HashMap<String, String> placeholders, ReplayState replayState, String injectionKey) {
+		ReplayState previous = ACTIVE_REPLAY_STATE.get();
+		String previousKey = ACTIVE_REPLAY_KEY.get();
+		ACTIVE_REPLAY_STATE.set(replayState);
+		ACTIVE_REPLAY_KEY.set(injectionKey);
+		try {
 		if (inject.supportsAsyncRequest()) {
 			return inject.onRewardRequestAsync(this, user, getConfig().getConfigData(), placeholders);
 		}
@@ -377,6 +549,10 @@ public class Reward {
 			// opted-in asynchronous injections to propagate durable failures.
 			failure.printStackTrace();
 			return CompletableFuture.completedFuture(null);
+		}
+		} finally {
+			if (previous == null) ACTIVE_REPLAY_STATE.remove(); else ACTIVE_REPLAY_STATE.set(previous);
+			if (previousKey == null) ACTIVE_REPLAY_KEY.remove(); else ACTIVE_REPLAY_KEY.set(previousKey);
 		}
 	}
 
@@ -658,7 +834,14 @@ public class Reward {
 		if (placeholders == null) {
 			return CompletableFuture.completedFuture(null);
 		}
-		return giveInjectedRewardsAsync(user, placeholders)
+		ReplayState replayState = replayStateFor(rewardOptions);
+		String replayKey = rewardOptions.getAsyncReplayKey();
+		if (replayKey == null) {
+			String parentKey = ACTIVE_REPLAY_KEY.get();
+			replayKey = parentKey == null ? getRewardName() : parentKey + "/" + getRewardName();
+			rewardOptions.setAsyncReplayKey(replayKey);
+		}
+		return giveInjectedRewardsAsync(user, placeholders, rewardOptions.getCompletedAsyncInjections(), replayState, replayKey)
 				.thenRun(() -> plugin.debug("Gave " + user.getPlayerName() + " reward " + name));
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -642,6 +642,11 @@ public class Reward {
 		return REPLAY_LEGACY_ACTION_PREFIX + encoded;
 	}
 
+	/** Stable fingerprint for an already-resolved legacy reward action payload. */
+	public static String legacyActionFingerprint(String descriptor) {
+		return digest(descriptor == null ? "" : descriptor);
+	}
+
 	/** Reads the number of legacy actions that have a durable per-injection checkpoint. */
 	public static int completedLegacyActions(ReplayState replayState, HashMap<String, String> placeholders,
 			String checkpointKey) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -1,6 +1,8 @@
 package com.bencodez.advancedcore.api.rewards;
 
 import java.io.File;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -12,6 +14,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -43,6 +47,7 @@ import lombok.Setter;
 public class Reward {
 	private static final ThreadLocal<ReplayState> ACTIVE_REPLAY_STATE = new ThreadLocal<>();
 	private static final ThreadLocal<String> ACTIVE_REPLAY_KEY = new ThreadLocal<>();
+	private static final ThreadLocal<String> ACTIVE_REPLAY_OCCURRENCE_ID = new ThreadLocal<>();
 	private static final String REPLAY_SELECTION_PREFIX = "__advancedcore_replay_selection_";
 
 	@Getter
@@ -271,7 +276,16 @@ public class Reward {
 	 */
 	public CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
 			HashMap<String, String> placeholders) {
-		return giveInjectedRewardsAsync(user, placeholders, 0, new ReplayState(null), getRewardName());
+		return giveInjectedRewardsAsync(user, placeholders, 0, new ReplayState(null), getRewardName(),
+				UUID.randomUUID().toString());
+	}
+
+	// Compatibility bridge for internal callers/tests that only carry replay path
+	// metadata. Persisted queue dispatch supplies the explicit occurrence id below.
+	private CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
+			HashMap<String, String> placeholders, int completedStages, ReplayState replayState, String replayKey) {
+		return giveInjectedRewardsAsync(user, placeholders, completedStages, replayState, replayKey,
+				UUID.randomUUID().toString());
 	}
 
 	/**
@@ -280,27 +294,32 @@ public class Reward {
 	 * avoid replaying already-applied non-idempotent injections.
 	 */
 	private CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
-			HashMap<String, String> placeholders, int completedStages, ReplayState replayState, String replayKey) {
-		List<RewardInject> postRewards = new ArrayList<>();
-		List<RewardInject> orderedRewards = new ArrayList<>();
-		for (RewardInject inject : plugin.getRewardHandler().getInjectedRewards()) {
-			if (inject.isPostReward()) postRewards.add(inject);
-			else orderedRewards.add(inject);
-		}
-		orderedRewards.addAll(postRewards);
+			HashMap<String, String> placeholders, int completedStages, ReplayState replayState, String replayKey,
+			String occurrenceId) {
+		List<RewardInject> orderedRewards = orderedInjectedRewards();
 		int resumeAfter = Math.max(0, replayState.getCompleted(replayKey, completedStages));
+		String registryFingerprint = injectionRegistryFingerprint(orderedRewards);
+		if (!replayState.matchesRegistryFingerprint(registryFingerprint)) {
+			return CompletableFuture.failedFuture(new IncompatibleReplayCheckpointException(replayKey));
+		}
 		AtomicInteger completed = new AtomicInteger(resumeAfter);
 		CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 		for (int index = 0; index < orderedRewards.size(); index++) {
 			if (index < resumeAfter) continue;
 			final RewardInject inject = orderedRewards.get(index);
 			final String injectionKey = replayKey + "/" + index;
-			sequence = sequence.thenCompose(ignored -> invokeInjectionAsync(inject, user, placeholders, replayState,
-					injectionKey))
+			sequence = sequence.thenCompose(ignored -> {
+				// A nested injector can checkpoint a child before this parent injector
+				// completes. Bind the parent's registry first so that child checkpoint
+				// cannot later be resumed against a shifted parent ordinal.
+				replayState.setRegistryFingerprint(replayKey, registryFingerprint);
+				return invokeInjectionAsync(inject, user, placeholders, replayState, injectionKey, occurrenceId);
+			})
 					.thenApply(result -> {
 						if (inject.isAddAsPlaceholder() && result != null) addPlaceholder(inject, result, placeholders);
 						int checkpoint = completed.incrementAndGet();
 						replayState.setCompleted(replayKey, checkpoint);
+						replayState.setRegistryFingerprint(replayKey, registryFingerprint);
 						replayState.persistCheckpoint(placeholders);
 						return result;
 					}).thenCompose(ignored -> resumeOnServerThread(user));
@@ -314,11 +333,47 @@ public class Reward {
 		});
 	}
 
+	private List<RewardInject> orderedInjectedRewards() {
+		List<RewardInject> postRewards = new ArrayList<>();
+		List<RewardInject> orderedRewards = new ArrayList<>();
+		for (RewardInject inject : plugin.getRewardHandler().getInjectedRewards()) {
+			if (inject.isPostReward()) postRewards.add(inject);
+			else orderedRewards.add(inject);
+		}
+		orderedRewards.addAll(postRewards);
+		return orderedRewards;
+	}
+
+	/**
+	 * A persisted checkpoint is valid only for this exact ordered injector
+	 * registry. Paths, implementation classes, priorities, and post-reward
+	 * placement are all included because each affects which side effect an
+	 * ordinal identifies.
+	 */
+	private static String injectionRegistryFingerprint(List<RewardInject> orderedRewards) {
+		StringBuilder registry = new StringBuilder();
+		for (RewardInject inject : orderedRewards) {
+			String path = inject.getPath() == null ? "" : inject.getPath();
+			registry.append(inject.getClass().getName()).append('\t').append(Base64.getUrlEncoder().withoutPadding()
+					.encodeToString(path.getBytes(StandardCharsets.UTF_8))).append('\t')
+					.append(inject.getPriority()).append('\t').append(inject.isPostReward()).append('\n');
+		}
+		try {
+			byte[] digest = MessageDigest.getInstance("SHA-256").digest(registry.toString().getBytes(StandardCharsets.UTF_8));
+			StringBuilder hex = new StringBuilder(digest.length * 2);
+			for (byte value : digest) hex.append(String.format("%02x", value & 0xff));
+			return hex.toString();
+		} catch (NoSuchAlgorithmException failure) {
+			throw new IllegalStateException("SHA-256 is unavailable for reward replay checkpoints", failure);
+		}
+	}
+
 	// Kept as a narrow compatibility bridge for internal callers/tests that only
 	// have a single reward checkpoint.
 	private CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
 			HashMap<String, String> placeholders, int completedStages) {
-		return giveInjectedRewardsAsync(user, placeholders, completedStages, new ReplayState(null), getRewardName());
+		return giveInjectedRewardsAsync(user, placeholders, completedStages, new ReplayState(null), getRewardName(),
+				UUID.randomUUID().toString());
 	}
 
 	/** Details the last durably safe replay checkpoint when an async chain fails. */
@@ -337,6 +392,16 @@ public class Reward {
 		}
 
 		public Map<String, Integer> getReplayProgress() { return replayState.copyProgress(); }
+		public Map<String, String> getReplayRegistryFingerprints() { return replayState.copyRegistryFingerprints(); }
+	}
+
+	/** Prevents an ordinal checkpoint from targeting a changed injector registry. */
+	private static final class IncompatibleReplayCheckpointException extends IllegalStateException {
+		private static final long serialVersionUID = 1L;
+		private IncompatibleReplayCheckpointException(String replayKey) {
+			super("Cannot safely resume asynchronous reward replay '" + replayKey
+					+ "' because its injector registry changed or its legacy checkpoint has no registry fingerprint");
+		}
 	}
 
 	private static RewardReplayFailure findReplayFailure(Throwable failure) {
@@ -352,12 +417,16 @@ public class Reward {
 	/** Captures the active parent execution path before deferred work runs. */
 	public static String currentReplayKey() { return ACTIVE_REPLAY_KEY.get(); }
 
+	/** Returns the unique logical reward occurrence currently invoking an injector. */
+	public static String currentReplayOccurrenceId() { return ACTIVE_REPLAY_OCCURRENCE_ID.get(); }
+
 	/** Obtains one shared replay state for a group of nested dispatches. */
 	public static ReplayState replayStateFor(RewardOptions options) {
 		ReplayState replayState = options.getAsyncReplayState();
 		if (replayState == null) {
 			replayState = ACTIVE_REPLAY_STATE.get();
-			if (replayState == null) replayState = new ReplayState(options.getAsyncReplayProgress());
+			if (replayState == null) replayState = new ReplayState(options.getAsyncReplayProgress(),
+					options.getAsyncReplayRegistryFingerprints(), options.isLegacyAsyncReplayCheckpoint());
 			options.setAsyncReplayState(replayState);
 		}
 		if (options.getAsyncReplayCheckpointConsumer() != null) {
@@ -389,6 +458,8 @@ public class Reward {
 	/** Attaches a captured replay state to an option object for a deferred child. */
 	public static RewardOptions withReplayState(RewardOptions options, ReplayState replayState) {
 		if (replayState != null) options.setAsyncReplayState(replayState);
+		String occurrenceId = ACTIVE_REPLAY_OCCURRENCE_ID.get();
+		if (occurrenceId != null) options.setAsyncReplayOccurrenceId(occurrenceId);
 		return options;
 	}
 
@@ -409,7 +480,18 @@ public class Reward {
 	 */
 	public static RewardOptions withReplayState(RewardOptions options, ReplayState replayState,
 			String parentKey, String childOccurrence) {
-		withReplayState(options, replayState);
+		return withReplayState(options, replayState, parentKey, childOccurrence, ACTIVE_REPLAY_OCCURRENCE_ID.get());
+	}
+
+	/**
+	 * Explicit deferred-child form. Completion callbacks must carry both the
+	 * replay path and its logical occurrence because ThreadLocal context is not
+	 * retained after an asynchronous parent injector returns.
+	 */
+	public static RewardOptions withReplayState(RewardOptions options, ReplayState replayState,
+			String parentKey, String childOccurrence, String occurrenceId) {
+		if (replayState != null) options.setAsyncReplayState(replayState);
+		if (occurrenceId != null) options.setAsyncReplayOccurrenceId(occurrenceId);
 		if (parentKey != null && childOccurrence != null) {
 			options.setAsyncReplayKey(parentKey + "/" + childOccurrence);
 		}
@@ -419,13 +501,41 @@ public class Reward {
 	/** Internal shared state passed through nested async reward dispatch. */
 	public static final class ReplayState {
 		private final HashMap<String, Integer> completed = new HashMap<>();
+		private final HashMap<String, String> registryFingerprints = new HashMap<>();
+		private final boolean legacyCheckpoint;
 		private Consumer<ReplayCheckpoint> checkpointConsumer;
-		private ReplayState(Map<String, Integer> initial) { if (initial != null) completed.putAll(initial); }
+		private ReplayState(Map<String, Integer> initial) { this(initial, null, false); }
+		private ReplayState(Map<String, Integer> initial, Map<String, String> initialFingerprints,
+				boolean legacyCheckpoint) {
+			if (initial != null) completed.putAll(initial);
+			if (initialFingerprints != null) registryFingerprints.putAll(initialFingerprints);
+			this.legacyCheckpoint = legacyCheckpoint;
+		}
 		private synchronized int getCompleted(String rewardName, int fallback) {
 			return completed.getOrDefault(rewardName, fallback);
 		}
 		private synchronized void setCompleted(String rewardName, int count) { completed.put(rewardName, count); }
 		private synchronized Map<String, Integer> copyProgress() { return new HashMap<>(completed); }
+		private synchronized void setRegistryFingerprint(String rewardName, String fingerprint) {
+			registryFingerprints.put(rewardName, fingerprint);
+		}
+		private synchronized Map<String, String> copyRegistryFingerprints() {
+			return new HashMap<>(registryFingerprints);
+		}
+		private synchronized boolean hasPersistedCheckpoint() {
+			return legacyCheckpoint || !completed.isEmpty() || !registryFingerprints.isEmpty();
+		}
+		private synchronized boolean matchesRegistryFingerprint(String currentFingerprint) {
+			if (legacyCheckpoint) return false;
+			for (Entry<String, Integer> entry : completed.entrySet()) {
+				if (entry.getValue() != null && entry.getValue() > 0
+						&& !currentFingerprint.equals(registryFingerprints.get(entry.getKey()))) return false;
+			}
+			for (String fingerprint : registryFingerprints.values()) {
+				if (!currentFingerprint.equals(fingerprint)) return false;
+			}
+			return true;
+		}
 		private synchronized int highestCompletedCount() {
 			int highest = 0;
 			for (int count : completed.values()) highest = Math.max(highest, count);
@@ -437,27 +547,33 @@ public class Reward {
 		private void persistCheckpoint(HashMap<String, String> placeholders) {
 			Consumer<ReplayCheckpoint> consumer;
 			synchronized (this) { consumer = checkpointConsumer; }
-			if (consumer != null) consumer.accept(new ReplayCheckpoint(copyProgress(), placeholders));
+			if (consumer != null) consumer.accept(new ReplayCheckpoint(copyProgress(), copyRegistryFingerprints(), placeholders));
 		}
 	}
 
 	/** Immutable durable replay data emitted after every completed injection. */
 	public static final class ReplayCheckpoint {
 		@Getter private final Map<String, Integer> replayProgress;
+		@Getter private final Map<String, String> replayRegistryFingerprints;
 		@Getter private final HashMap<String, String> placeholders;
 		private ReplayCheckpoint(Map<String, Integer> replayProgress, HashMap<String, String> placeholders) {
+			this(replayProgress, new HashMap<>(), placeholders);
+		}
+		private ReplayCheckpoint(Map<String, Integer> replayProgress, Map<String, String> replayRegistryFingerprints,
+				HashMap<String, String> placeholders) {
 			this.replayProgress = new HashMap<>(replayProgress);
+			this.replayRegistryFingerprints = new HashMap<>(replayRegistryFingerprints);
 			this.placeholders = new HashMap<>(placeholders);
 		}
 	}
 
 	private CompletionStage<Object> invokeInjectionAsync(RewardInject inject, AdvancedCoreUser user,
-			HashMap<String, String> placeholders, ReplayState replayState, String injectionKey) {
+			HashMap<String, String> placeholders, ReplayState replayState, String injectionKey, String occurrenceId) {
 		try {
 			if (!plugin.isEnabled()) return CompletableFuture.failedFuture(
 					new IllegalStateException("Plugin disabled before reward injection completed"));
 			Supplier<CompletionStage<Object>> request = () -> requestOnServerThread(user,
-					() -> requestInjectionAsync(inject, user, placeholders, replayState, injectionKey));
+					() -> requestInjectionAsync(inject, user, placeholders, replayState, injectionKey, occurrenceId));
 			CompletionStage<Object> result = inject.isSynchronize() && inject.supportsAsyncSynchronization()
 					? inject.runSynchronizedAsync(request)
 					: request.get();
@@ -532,11 +648,14 @@ public class Reward {
 	}
 
 	private CompletionStage<Object> requestInjectionAsync(RewardInject inject, AdvancedCoreUser user,
-			HashMap<String, String> placeholders, ReplayState replayState, String injectionKey) {
+			HashMap<String, String> placeholders, ReplayState replayState, String injectionKey, String occurrenceId) {
 		ReplayState previous = ACTIVE_REPLAY_STATE.get();
 		String previousKey = ACTIVE_REPLAY_KEY.get();
+		String previousOccurrenceId = ACTIVE_REPLAY_OCCURRENCE_ID.get();
 		ACTIVE_REPLAY_STATE.set(replayState);
 		ACTIVE_REPLAY_KEY.set(injectionKey);
+		if (occurrenceId == null) ACTIVE_REPLAY_OCCURRENCE_ID.remove();
+		else ACTIVE_REPLAY_OCCURRENCE_ID.set(occurrenceId);
 		try {
 		if (inject.supportsAsyncRequest()) {
 			return inject.onRewardRequestAsync(this, user, getConfig().getConfigData(), placeholders);
@@ -553,6 +672,8 @@ public class Reward {
 		} finally {
 			if (previous == null) ACTIVE_REPLAY_STATE.remove(); else ACTIVE_REPLAY_STATE.set(previous);
 			if (previousKey == null) ACTIVE_REPLAY_KEY.remove(); else ACTIVE_REPLAY_KEY.set(previousKey);
+			if (previousOccurrenceId == null) ACTIVE_REPLAY_OCCURRENCE_ID.remove();
+			else ACTIVE_REPLAY_OCCURRENCE_ID.set(previousOccurrenceId);
 		}
 	}
 
@@ -778,7 +899,9 @@ public class Reward {
 		if (canGive || isForceOffline() || rewardOptions.isForceOffline()) {
 			plugin.debug(name + ": Passed requirements, attempting to give to " + user.getPlayerName() + "/"
 					+ user.getUUID());
-			if (hasAsyncRewardInjection()) return giveRewardUserAsync(user, rewardOptions.getPlaceholders(), rewardOptions);
+			if (hasAsyncRewardInjection() || hasPersistedReplayCheckpoint(rewardOptions)) {
+				return giveRewardUserAsync(user, rewardOptions.getPlaceholders(), rewardOptions);
+			}
 			try {
 				giveRewardUser(user, rewardOptions.getPlaceholders(), rewardOptions);
 				return CompletableFuture.completedFuture(null);
@@ -797,7 +920,7 @@ public class Reward {
 	 * @param rewardOptions rewardOptions
 	 */
 	public void giveRewardUser(AdvancedCoreUser user, HashMap<String, String> phs, RewardOptions rewardOptions) {
-		if (hasAsyncRewardInjection()) {
+		if (hasAsyncRewardInjection() || hasPersistedReplayCheckpoint(rewardOptions)) {
 			giveRewardUserAsync(user, phs, rewardOptions).exceptionally(failure -> {
 				logRewardUserFailure(failure);
 				return null;
@@ -825,6 +948,27 @@ public class Reward {
 	 */
 	public CompletionStage<Void> giveRewardUserAsync(AdvancedCoreUser user, HashMap<String, String> phs,
 			RewardOptions rewardOptions) {
+		ReplayState replayState = replayStateFor(rewardOptions);
+		String replayKey = rewardOptions.getAsyncReplayKey();
+		if (replayKey == null) {
+			String parentKey = ACTIVE_REPLAY_KEY.get();
+			replayKey = parentKey == null ? getRewardName() : parentKey + "/" + getRewardName();
+			rewardOptions.setAsyncReplayKey(replayKey);
+		}
+		if (!replayState.matchesRegistryFingerprint(injectionRegistryFingerprint(orderedInjectedRewards()))) {
+			return CompletableFuture.failedFuture(new IncompatibleReplayCheckpointException(replayKey));
+		}
+		String occurrenceId = rewardOptions.getAsyncReplayOccurrenceId();
+		if (occurrenceId == null || occurrenceId.isEmpty()) {
+			occurrenceId = ACTIVE_REPLAY_OCCURRENCE_ID.get();
+			// A pre-occurrence persisted entry cannot safely survive an ambiguous
+			// side effect, so leave it on the legacy compatibility path rather than
+			// inventing a different id for each retry.
+			if (occurrenceId == null && rewardOptions.getAsyncReplayCheckpointConsumer() == null) {
+				occurrenceId = UUID.randomUUID().toString();
+				rewardOptions.setAsyncReplayOccurrenceId(occurrenceId);
+			}
+		}
 		final HashMap<String, String> placeholders;
 		try {
 			placeholders = prepareRewardUser(user, phs);
@@ -834,15 +978,15 @@ public class Reward {
 		if (placeholders == null) {
 			return CompletableFuture.completedFuture(null);
 		}
-		ReplayState replayState = replayStateFor(rewardOptions);
-		String replayKey = rewardOptions.getAsyncReplayKey();
-		if (replayKey == null) {
-			String parentKey = ACTIVE_REPLAY_KEY.get();
-			replayKey = parentKey == null ? getRewardName() : parentKey + "/" + getRewardName();
-			rewardOptions.setAsyncReplayKey(replayKey);
-		}
-		return giveInjectedRewardsAsync(user, placeholders, rewardOptions.getCompletedAsyncInjections(), replayState, replayKey)
+		return giveInjectedRewardsAsync(user, placeholders, rewardOptions.getCompletedAsyncInjections(), replayState, replayKey,
+				occurrenceId)
 				.thenRun(() -> plugin.debug("Gave " + user.getPlayerName() + " reward " + name));
+	}
+
+	private static boolean hasPersistedReplayCheckpoint(RewardOptions options) {
+		return options.isLegacyAsyncReplayCheckpoint() || options.getCompletedAsyncInjections() > 0
+				|| !options.getAsyncReplayProgress().isEmpty() || !options.getAsyncReplayRegistryFingerprints().isEmpty()
+				|| (options.getAsyncReplayState() != null && options.getAsyncReplayState().hasPersistedCheckpoint());
 	}
 
 	private HashMap<String, String> prepareRewardUser(AdvancedCoreUser user, HashMap<String, String> phs) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -440,6 +440,18 @@ public class Reward {
 	}
 
 	/**
+	 * Copies the durable portion of an in-flight replay into options before the
+	 * reward is deferred.  Pause/vanish handling happens before the async
+	 * injector creates its next checkpoint, so the queue must carry the state
+	 * already accumulated by a nested replay rather than starting a new
+	 * occurrence with placeholders only.
+	 */
+	public static void preserveReplayState(RewardOptions options) {
+		if (options == null || options.getAsyncReplayState() == null) return;
+		options.getAsyncReplayState().copyTo(options);
+	}
+
+	/**
 	 * Records a nondeterministic nested-reward decision in the placeholder
 	 * snapshot carried by {@link RewardReplayFailure}. A retry consequently
 	 * executes the same selected branch instead of rolling a new outcome after a
@@ -698,6 +710,13 @@ public class Reward {
 		}
 		private synchronized boolean hasPersistedCheckpoint() {
 			return legacyCheckpoint || !completed.isEmpty() || !registryFingerprints.isEmpty();
+		}
+		private synchronized void copyTo(RewardOptions options) {
+			options.setCompletedAsyncInjections(Math.max(options.getCompletedAsyncInjections(), highestCompletedCount()));
+			options.setAsyncReplayProgress(copyProgress());
+			options.setAsyncReplayRegistryFingerprints(copyRegistryFingerprints());
+			options.setLegacyAsyncReplayCheckpoint(legacyCheckpoint);
+			mergeReplayMetadataInto(options.getPlaceholders());
 		}
 		private synchronized boolean matchesRegistryFingerprint(String currentFingerprint) {
 			if (legacyCheckpoint) return false;
@@ -995,7 +1014,8 @@ public class Reward {
 
 		if (plugin.getOptions().isPauseRewards()) {
 			checkRewardFile();
-			user.addOfflineRewards(this, rewardOptions.getPlaceholders());
+			preserveReplayState(rewardOptions);
+			user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
 			plugin.getLogger()
 					.info("Rewards are paused, saving offline reward " + getRewardName() + ": " + user.getPlayerName());
 			return;
@@ -1003,7 +1023,8 @@ public class Reward {
 
 		if ((plugin.getOptions().isTreatVanishAsOffline() && user.isVanished())) {
 			checkRewardFile();
-			user.addOfflineRewards(this, rewardOptions.getPlaceholders());
+			preserveReplayState(rewardOptions);
+			user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
 			plugin.getLogger()
 					.info(getRewardName() + ": " + user.getPlayerName() + " is vanished, saving reward offline");
 			return;
@@ -1095,7 +1116,8 @@ public class Reward {
 		}
 		if (plugin.getOptions().isPauseRewards() || (plugin.getOptions().isTreatVanishAsOffline() && user.isVanished())) {
 			checkRewardFile();
-			user.addOfflineRewards(this, rewardOptions.getPlaceholders());
+			preserveReplayState(rewardOptions);
+			user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
 			return CompletableFuture.completedFuture(null);
 		}
 		if (((((!rewardOptions.isOnline() || rewardOptions.getServer() != null) && !user.isOnline()) || allowOffline)
@@ -1130,8 +1152,9 @@ public class Reward {
 	 * @param rewardOptions rewardOptions
 	 */
 	public void giveRewardUser(AdvancedCoreUser user, HashMap<String, String> phs, RewardOptions rewardOptions) {
-		if (hasAsyncRewardInjection() || hasPersistedReplayCheckpoint(rewardOptions)) {
-			giveRewardUserAsync(user, phs, rewardOptions).exceptionally(failure -> {
+		RewardOptions effectiveOptions = rewardOptions == null ? new RewardOptions() : rewardOptions;
+		if (hasAsyncRewardInjection() || hasPersistedReplayCheckpoint(effectiveOptions)) {
+			giveRewardUserAsync(user, phs, effectiveOptions).exceptionally(failure -> {
 				logRewardUserFailure(failure);
 				return null;
 			});

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -52,6 +52,7 @@ public class Reward {
 	private static final ThreadLocal<String> ACTIVE_REPLAY_OCCURRENCE_ID = new ThreadLocal<>();
 	private static final String REPLAY_SELECTION_PREFIX = "__advancedcore_replay_selection_";
 	private static final String REPLAY_COMMAND_PREFIX = "__advancedcore_replay_commands_";
+	private static final String REPLAY_LEGACY_ACTION_PREFIX = "__advancedcore_replay_legacy_actions_";
 
 	@Getter
 	@Setter
@@ -630,7 +631,27 @@ public class Reward {
 	}
 
 	private static boolean isReplayMetadataKey(String key) {
-		return key != null && (key.startsWith(REPLAY_SELECTION_PREFIX) || key.startsWith(REPLAY_COMMAND_PREFIX));
+		return key != null && (key.startsWith(REPLAY_SELECTION_PREFIX) || key.startsWith(REPLAY_COMMAND_PREFIX)
+				|| key.startsWith(REPLAY_LEGACY_ACTION_PREFIX));
+	}
+
+	/** Stable metadata key for the individual legacy actions produced by one injector. */
+	public static String legacyActionReplayKey(String injectionKey) {
+		String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(
+				(injectionKey == null ? "" : injectionKey).getBytes(StandardCharsets.UTF_8));
+		return REPLAY_LEGACY_ACTION_PREFIX + encoded;
+	}
+
+	/** Reads the number of legacy actions that have a durable per-injection checkpoint. */
+	public static int completedLegacyActions(ReplayState replayState, HashMap<String, String> placeholders,
+			String checkpointKey) {
+		String value = placeholders == null ? null : placeholders.get(checkpointKey);
+		if (value == null && replayState != null) value = replayState.replayMetadata(checkpointKey);
+		try {
+			return Math.max(0, value == null ? 0 : Integer.parseInt(value));
+		} catch (NumberFormatException ignored) {
+			return 0;
+		}
 	}
 
 	/** Attaches a captured replay state to an option object for a deferred child. */
@@ -708,6 +729,7 @@ public class Reward {
 		public synchronized void mergeReplayMetadataInto(HashMap<String, String> target) {
 			Reward.mergeReplayMetadata(target, replayMetadata);
 		}
+		public synchronized String replayMetadata(String key) { return replayMetadata.get(key); }
 		private synchronized boolean hasPersistedCheckpoint() {
 			return legacyCheckpoint || !completed.isEmpty() || !registryFingerprints.isEmpty();
 		}
@@ -737,7 +759,7 @@ public class Reward {
 		private synchronized void setCheckpointConsumer(Consumer<ReplayCheckpoint> consumer) {
 			checkpointConsumer = consumer;
 		}
-		private CompletionStage<Void> persistCheckpointAsync(AdvancedCorePlugin plugin,
+		public CompletionStage<Void> persistCheckpointAsync(AdvancedCorePlugin plugin,
 				HashMap<String, String> placeholders) {
 			Consumer<ReplayCheckpoint> consumer;
 			synchronized (this) { consumer = checkpointConsumer; }
@@ -761,6 +783,7 @@ public class Reward {
 			// instead of waiting forever without advancing its checkpoint.
 			return persisted.orTimeout(30, TimeUnit.SECONDS);
 		}
+
 	}
 
 	/** Immutable durable replay data emitted after every completed injection. */
@@ -868,7 +891,8 @@ public class Reward {
 		ACTIVE_REPLAY_KEY.set(injectionKey);
 		if (occurrenceId == null) ACTIVE_REPLAY_OCCURRENCE_ID.remove();
 		else ACTIVE_REPLAY_OCCURRENCE_ID.set(occurrenceId);
-		AdvancedCoreUser.AsyncActionCollection actionCollection = user.beginAsyncActionCollection();
+		AdvancedCoreUser.AsyncActionCollection actionCollection = user.beginAsyncActionCollection(replayState, placeholders,
+				injectionKey);
 		CompletionStage<Object> result = CompletableFuture.failedFuture(
 				new IllegalStateException("Reward injection did not produce a result"));
 		try {
@@ -896,7 +920,6 @@ public class Reward {
 		}
 		CompletableFuture<Object> combined = new CompletableFuture<>();
 		result.whenComplete((value, failure) -> {
-			user.claimAsyncContinuationActions(actionCollection);
 			user.endAsyncActionCollection(actionCollection).whenComplete((ignored, actionFailure) -> {
 			if (failure != null) combined.completeExceptionally(failure);
 			else if (actionFailure != null) combined.completeExceptionally(actionFailure);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -891,6 +891,9 @@ public class Reward {
 		private synchronized void setCheckpointConsumer(Consumer<ReplayCheckpoint> consumer) {
 			checkpointConsumer = consumer;
 		}
+		private synchronized boolean hasCheckpointConsumer() {
+			return checkpointConsumer != null;
+		}
 		public CompletionStage<Void> persistCheckpointAsync(AdvancedCorePlugin plugin,
 				HashMap<String, String> placeholders) {
 			return persistCheckpointAsync(plugin, placeholders, 30, TimeUnit.SECONDS);
@@ -1060,9 +1063,12 @@ public class Reward {
 							inject.onRewardRequest(this, user, getConfig().getConfigData(), placeholders));
 				} catch (Exception failure) {
 					// Preserve the legacy per-injection isolation contract while allowing
-					// opted-in asynchronous injections to propagate durable failures.
+					// persisted replays to retain their queue entry when a player-bound
+					// legacy injection fails after an earlier asynchronous stage.
 					failure.printStackTrace();
-					result = CompletableFuture.completedFuture(null);
+					result = replayState.hasCheckpointConsumer()
+							? CompletableFuture.failedFuture(failure)
+							: CompletableFuture.completedFuture(null);
 				}
 			}
 			if (result == null) result = CompletableFuture.failedFuture(

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -969,6 +969,17 @@ public class Reward {
 
 	private <T> CompletionStage<T> requestOnServerThread(AdvancedCoreUser user,
 			Supplier<CompletionStage<T>> request) {
+		return requestOnServerThread(plugin, user, request, getServerThreadDispatchTimeoutMillis());
+	}
+
+	/** Continues nested reward setup on the owning Bukkit scheduler after async persistence. */
+	public static <T> CompletionStage<T> continueOnServerThread(AdvancedCorePlugin plugin, AdvancedCoreUser user,
+			Supplier<CompletionStage<T>> request) {
+		return requestOnServerThread(plugin, user, request, TimeUnit.SECONDS.toMillis(30));
+	}
+
+	private static <T> CompletionStage<T> requestOnServerThread(AdvancedCorePlugin plugin, AdvancedCoreUser user,
+			Supplier<CompletionStage<T>> request, long timeoutMillis) {
 		CompletableFuture<CompletionStage<T>> handoff = new CompletableFuture<>();
 		Runnable invocation = () -> {
 			if (!plugin.isEnabled()) {
@@ -1014,7 +1025,7 @@ public class Reward {
 		} catch (Throwable failure) {
 			handoff.completeExceptionally(failure);
 		}
-		return handoff.orTimeout(getServerThreadDispatchTimeoutMillis(), TimeUnit.MILLISECONDS)
+		return handoff.orTimeout(timeoutMillis, TimeUnit.MILLISECONDS)
 				.thenCompose(stage -> stage);
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -1371,6 +1371,10 @@ public class Reward {
 			return CompletableFuture.failedFuture(throwable);
 		}
 		if (placeholders == null) {
+			if (rewardOptions.getAsyncReplayCheckpointConsumer() != null || hasPersistedReplayCheckpoint(rewardOptions)) {
+				return CompletableFuture.failedFuture(
+						new IllegalStateException("Player became unavailable before persisted reward replay"));
+			}
 			return CompletableFuture.completedFuture(null);
 		}
 		return giveInjectedRewardsAsync(user, placeholders, rewardOptions.getCompletedAsyncInjections(), replayState, replayKey,

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -1055,7 +1055,10 @@ public class Reward {
 		CompletionStage<Object> result = CompletableFuture.failedFuture(
 				new IllegalStateException("Reward injection did not produce a result"));
 		try {
-			if (inject.supportsAsyncRequest()) {
+			if (replayState.hasCheckpointConsumer() && inject.isPlayerRequired() && user.getPlayer() == null) {
+				result = CompletableFuture.failedFuture(
+						new IllegalStateException("Player became unavailable before " + inject.getPath() + " delivery"));
+			} else if (inject.supportsAsyncRequest()) {
 				result = inject.onRewardRequestAsync(this, user, getConfig().getConfigData(), placeholders);
 			} else {
 				try {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -51,6 +51,7 @@ public class Reward {
 	private static final ThreadLocal<String> ACTIVE_REPLAY_KEY = new ThreadLocal<>();
 	private static final ThreadLocal<String> ACTIVE_REPLAY_OCCURRENCE_ID = new ThreadLocal<>();
 	private static final String REPLAY_SELECTION_PREFIX = "__advancedcore_replay_selection_";
+	private static final String REPLAY_COMMAND_PREFIX = "__advancedcore_replay_commands_";
 
 	@Getter
 	@Setter
@@ -389,7 +390,9 @@ public class Reward {
 					cause);
 			this.replayState = replayState;
 			this.completedInjectionCount = replayState.highestCompletedCount();
-			this.replayPlaceholders = new HashMap<>(replayPlaceholders);
+			HashMap<String, String> placeholders = new HashMap<>(replayPlaceholders);
+			replayState.mergeReplayMetadataInto(placeholders);
+			this.replayPlaceholders = placeholders;
 		}
 
 		public Map<String, Integer> getReplayProgress() { return replayState.copyProgress(); }
@@ -448,11 +451,16 @@ public class Reward {
 				.encodeToString((activeKey == null ? "root" : activeKey).getBytes(StandardCharsets.UTF_8));
 		if (placeholders.containsKey(storageKey)) {
 			String stored = placeholders.get(storageKey);
+			ReplayState replayState = ACTIVE_REPLAY_STATE.get();
+			if (replayState != null) replayState.recordReplayMetadata(storageKey, stored);
 			return stored.isEmpty() ? null : new String(Base64.getUrlDecoder().decode(stored), StandardCharsets.UTF_8);
 		}
 		String selected = selector.get();
-		placeholders.put(storageKey, selected == null ? "" : Base64.getUrlEncoder().withoutPadding()
-				.encodeToString(selected.getBytes(StandardCharsets.UTF_8)));
+		String encoded = selected == null ? "" : Base64.getUrlEncoder().withoutPadding()
+				.encodeToString(selected.getBytes(StandardCharsets.UTF_8));
+		placeholders.put(storageKey, encoded);
+		ReplayState replayState = ACTIVE_REPLAY_STATE.get();
+		if (replayState != null) replayState.recordReplayMetadata(storageKey, encoded);
 		return selected;
 	}
 
@@ -468,18 +476,30 @@ public class Reward {
 	public static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
 			HashMap<String, String> placeholders, String lane, List<String> commands,
 			BiFunction<String, Integer, CompletionStage<Void>> dispatch) {
-		return replayCommandSequence(plugin, placeholders, lane, commands, currentReplayState(), currentReplayKey(), dispatch);
+		return replayCommandSequence(plugin, placeholders, lane, commands, commands, currentReplayState(), currentReplayKey(), dispatch);
+	}
+
+	/** Executes expanded commands while identifying the sequence by stable templates. */
+	public static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
+			HashMap<String, String> placeholders, String lane, List<String> commandTemplates,
+			List<String> expandedCommands, BiFunction<String, Integer, CompletionStage<Void>> dispatch) {
+		return replayCommandSequence(plugin, placeholders, lane, commandTemplates, expandedCommands,
+				currentReplayState(), currentReplayKey(), dispatch);
 	}
 
 	static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
-			HashMap<String, String> placeholders, String lane, List<String> commands,
+			HashMap<String, String> placeholders, String lane, List<String> commandTemplates,
+			List<String> expandedCommands,
 			ReplayState replayState, String activeKey,
 			BiFunction<String, Integer, CompletionStage<Void>> dispatch) {
-		if (commands == null || commands.isEmpty()) return CompletableFuture.completedFuture(null);
+		if (commandTemplates == null || commandTemplates.isEmpty()) return CompletableFuture.completedFuture(null);
+		if (expandedCommands == null || expandedCommands.size() != commandTemplates.size()) {
+			return CompletableFuture.failedFuture(new IllegalArgumentException("Command templates and expansions differ in size"));
+		}
 		if (replayState == null || activeKey == null) {
 			CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
-			for (int index = 0; index < commands.size(); index++) {
-				String command = commands.get(index);
+			for (int index = 0; index < expandedCommands.size(); index++) {
+				String command = expandedCommands.get(index);
 				int commandIndex = index;
 				sequence = sequence.thenCompose(ignored -> dispatch.apply(command, commandIndex));
 			}
@@ -487,25 +507,95 @@ public class Reward {
 		}
 		StringBuilder identity = new StringBuilder(activeKey == null ? "root" : activeKey)
 				.append('\n').append(lane == null ? "commands" : lane);
-		for (String command : commands) identity.append('\n').append(command == null ? "" : command);
-		String storageKey = "__advancedcore_replay_commands_" + digest(identity.toString());
+		identity.append('\n').append(encodeCommandSnapshot(commandTemplates));
+		String storageKey = REPLAY_COMMAND_PREFIX + digest(identity.toString());
+		String snapshotKey = storageKey + "_snapshot";
+		List<String> commands;
+		String storedSnapshot = placeholders.get(snapshotKey);
+		boolean createdSnapshot = storedSnapshot == null;
+		if (storedSnapshot == null) {
+			commands = new ArrayList<>(expandedCommands);
+			String encodedSnapshot = encodeCommandSnapshot(commands);
+			placeholders.put(snapshotKey, encodedSnapshot);
+			replayState.recordReplayMetadata(snapshotKey, encodedSnapshot);
+		} else {
+			replayState.recordReplayMetadata(snapshotKey, storedSnapshot);
+			try {
+				commands = decodeCommandSnapshot(storedSnapshot, commandTemplates.size());
+			} catch (IllegalArgumentException failure) {
+				return CompletableFuture.failedFuture(new IllegalStateException("Malformed command replay snapshot", failure));
+			}
+		}
 		int completed = 0;
 		try {
 			completed = Integer.parseInt(placeholders.getOrDefault(storageKey, "0"));
 		} catch (NumberFormatException ignored) { }
-		if (completed < 0 || completed > commands.size()) completed = 0;
-		CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+		if (placeholders.containsKey(storageKey)) {
+			replayState.recordReplayMetadata(storageKey, placeholders.get(storageKey));
+		}
+		if (completed < 0 || completed > commandTemplates.size()) completed = 0;
+		// Persist the concrete expansion before issuing its first side effect. A
+		// restart during an indeterminate dispatch must reuse this exact payload,
+		// even though no command-progress marker exists yet.
+		CompletionStage<Void> sequence = createdSnapshot
+				? replayState.persistCheckpointAsync(plugin, placeholders)
+				: CompletableFuture.completedFuture(null);
 		for (int index = completed; index < commands.size(); index++) {
 			String command = commands.get(index);
 			int completedCount = index + 1;
 			int commandIndex = index;
 			sequence = sequence.thenCompose(ignored -> dispatch.apply(command, commandIndex)).thenCompose(ignored -> {
 				placeholders.put(storageKey, String.valueOf(completedCount));
+				replayState.recordReplayMetadata(storageKey, String.valueOf(completedCount));
 				return replayState == null ? CompletableFuture.completedFuture(null)
 						: replayState.persistCheckpointAsync(plugin, placeholders);
 			});
 		}
 		return sequence;
+	}
+
+	static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
+			HashMap<String, String> placeholders, String lane, List<String> commands,
+			ReplayState replayState, String activeKey,
+			BiFunction<String, Integer, CompletionStage<Void>> dispatch) {
+		return replayCommandSequence(plugin, placeholders, lane, commands, commands, replayState, activeKey, dispatch);
+	}
+
+	private static String encodeCommandSnapshot(List<String> commands) {
+		StringBuilder encoded = new StringBuilder("v1:");
+		for (String command : commands) {
+			if (encoded.length() > 3) encoded.append('.');
+			if (command == null) encoded.append('~');
+			else if (command.isEmpty()) encoded.append('=');
+			else encoded.append(Base64.getUrlEncoder().withoutPadding()
+					.encodeToString(command.getBytes(StandardCharsets.UTF_8)));
+		}
+		return encoded.toString();
+	}
+
+	private static List<String> decodeCommandSnapshot(String encoded, int expectedSize) {
+		if (!encoded.startsWith("v1:")) throw new IllegalArgumentException("Unknown command snapshot version");
+		String body = encoded.substring(3);
+		ArrayList<String> commands = new ArrayList<>();
+		if (!body.isEmpty()) {
+			for (String item : body.split("\\.", -1)) {
+				if (item.equals("~")) {
+					commands.add(null);
+					continue;
+				}
+				if (item.equals("=")) {
+					commands.add("");
+					continue;
+				}
+				try {
+					commands.add(new String(Base64.getUrlDecoder().decode(item), StandardCharsets.UTF_8));
+				} catch (IllegalArgumentException failure) {
+					throw new IllegalArgumentException("Invalid command snapshot encoding", failure);
+				}
+			}
+		}
+		if (commands.size() != expectedSize) throw new IllegalArgumentException("Command snapshot size changed");
+		return commands;
 	}
 
 	private static String digest(String value) {
@@ -517,6 +607,18 @@ public class Reward {
 		} catch (NoSuchAlgorithmException failure) {
 			throw new IllegalStateException("SHA-256 is unavailable for reward replay checkpoints", failure);
 		}
+	}
+
+	/** Copies only durable replay markers; ordinary reward placeholders stay isolated. */
+	public static void mergeReplayMetadata(HashMap<String, String> target, Map<String, String> source) {
+		if (target == null || source == null) return;
+		for (Entry<String, String> entry : source.entrySet()) {
+			if (isReplayMetadataKey(entry.getKey())) target.put(entry.getKey(), entry.getValue());
+		}
+	}
+
+	private static boolean isReplayMetadataKey(String key) {
+		return key != null && (key.startsWith(REPLAY_SELECTION_PREFIX) || key.startsWith(REPLAY_COMMAND_PREFIX));
 	}
 
 	/** Attaches a captured replay state to an option object for a deferred child. */
@@ -566,6 +668,7 @@ public class Reward {
 	public static final class ReplayState {
 		private final HashMap<String, Integer> completed = new HashMap<>();
 		private final HashMap<String, String> registryFingerprints = new HashMap<>();
+		private final HashMap<String, String> replayMetadata = new HashMap<>();
 		private final boolean legacyCheckpoint;
 		private Consumer<ReplayCheckpoint> checkpointConsumer;
 		private ReplayState(Map<String, Integer> initial) { this(initial, null, false); }
@@ -585,6 +688,13 @@ public class Reward {
 		}
 		private synchronized Map<String, String> copyRegistryFingerprints() {
 			return new HashMap<>(registryFingerprints);
+		}
+		/** Records a reserved marker produced by a nested replay-aware injector. */
+		public synchronized void recordReplayMetadata(String key, String value) {
+			if (isReplayMetadataKey(key)) replayMetadata.put(key, value);
+		}
+		public synchronized void mergeReplayMetadataInto(HashMap<String, String> target) {
+			Reward.mergeReplayMetadata(target, replayMetadata);
 		}
 		private synchronized boolean hasPersistedCheckpoint() {
 			return legacyCheckpoint || !completed.isEmpty() || !registryFingerprints.isEmpty();
@@ -739,25 +849,42 @@ public class Reward {
 		ACTIVE_REPLAY_KEY.set(injectionKey);
 		if (occurrenceId == null) ACTIVE_REPLAY_OCCURRENCE_ID.remove();
 		else ACTIVE_REPLAY_OCCURRENCE_ID.set(occurrenceId);
+		AdvancedCoreUser.AsyncActionCollection actionCollection = user.beginAsyncActionCollection();
+		CompletionStage<Object> result = CompletableFuture.failedFuture(
+				new IllegalStateException("Reward injection did not produce a result"));
 		try {
-		if (inject.supportsAsyncRequest()) {
-			return inject.onRewardRequestAsync(this, user, getConfig().getConfigData(), placeholders);
-		}
-		try {
-			return CompletableFuture.completedFuture(
-					inject.onRewardRequest(this, user, getConfig().getConfigData(), placeholders));
-		} catch (Exception failure) {
-			// Preserve the legacy per-injection isolation contract while allowing
-			// opted-in asynchronous injections to propagate durable failures.
-			failure.printStackTrace();
-			return CompletableFuture.completedFuture(null);
-		}
+			if (inject.supportsAsyncRequest()) {
+				result = inject.onRewardRequestAsync(this, user, getConfig().getConfigData(), placeholders);
+			} else {
+				try {
+					result = CompletableFuture.completedFuture(
+							inject.onRewardRequest(this, user, getConfig().getConfigData(), placeholders));
+				} catch (Exception failure) {
+					// Preserve the legacy per-injection isolation contract while allowing
+					// opted-in asynchronous injections to propagate durable failures.
+					failure.printStackTrace();
+					result = CompletableFuture.completedFuture(null);
+				}
+			}
+			if (result == null) result = CompletableFuture.failedFuture(
+					new IllegalStateException("Reward injection returned a null asynchronous result"));
 		} finally {
+			user.restoreAsyncActionCollectionScope(actionCollection);
 			if (previous == null) ACTIVE_REPLAY_STATE.remove(); else ACTIVE_REPLAY_STATE.set(previous);
 			if (previousKey == null) ACTIVE_REPLAY_KEY.remove(); else ACTIVE_REPLAY_KEY.set(previousKey);
 			if (previousOccurrenceId == null) ACTIVE_REPLAY_OCCURRENCE_ID.remove();
 			else ACTIVE_REPLAY_OCCURRENCE_ID.set(previousOccurrenceId);
 		}
+		CompletableFuture<Object> combined = new CompletableFuture<>();
+		result.whenComplete((value, failure) -> {
+			user.claimAsyncContinuationActions(actionCollection);
+			user.endAsyncActionCollection(actionCollection).whenComplete((ignored, actionFailure) -> {
+			if (failure != null) combined.completeExceptionally(failure);
+			else if (actionFailure != null) combined.completeExceptionally(actionFailure);
+			else combined.complete(value);
+			});
+		});
+		return combined;
 	}
 
 	private void addPlaceholder(RewardInject inject, Object obj, HashMap<String, String> placeholders) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -315,13 +315,12 @@ public class Reward {
 				replayState.setRegistryFingerprint(replayKey, registryFingerprint);
 				return invokeInjectionAsync(inject, user, placeholders, replayState, injectionKey, occurrenceId);
 			})
-					.thenApply(result -> {
+					.thenCompose(result -> {
 						if (inject.isAddAsPlaceholder() && result != null) addPlaceholder(inject, result, placeholders);
 						int checkpoint = completed.incrementAndGet();
 						replayState.setCompleted(replayKey, checkpoint);
 						replayState.setRegistryFingerprint(replayKey, registryFingerprint);
-						replayState.persistCheckpoint(placeholders);
-						return result;
+						return replayState.persistCheckpointAsync(plugin, placeholders).thenApply(ignored -> result);
 					}).thenCompose(ignored -> resumeOnServerThread(user));
 		}
 		return sequence.handle((ignored, failure) -> {
@@ -544,10 +543,29 @@ public class Reward {
 		private synchronized void setCheckpointConsumer(Consumer<ReplayCheckpoint> consumer) {
 			checkpointConsumer = consumer;
 		}
-		private void persistCheckpoint(HashMap<String, String> placeholders) {
+		private CompletionStage<Void> persistCheckpointAsync(AdvancedCorePlugin plugin,
+				HashMap<String, String> placeholders) {
 			Consumer<ReplayCheckpoint> consumer;
 			synchronized (this) { consumer = checkpointConsumer; }
-			if (consumer != null) consumer.accept(new ReplayCheckpoint(copyProgress(), copyRegistryFingerprints(), placeholders));
+			if (consumer == null) return CompletableFuture.completedFuture(null);
+			ReplayCheckpoint checkpoint = new ReplayCheckpoint(copyProgress(), copyRegistryFingerprints(), placeholders);
+			CompletableFuture<Void> persisted = new CompletableFuture<>();
+			try {
+				plugin.getTimer().execute(() -> {
+					try {
+						consumer.accept(checkpoint);
+						persisted.complete(null);
+					} catch (Throwable failure) {
+						persisted.completeExceptionally(failure);
+					}
+				});
+			} catch (Throwable failure) {
+				persisted.completeExceptionally(failure);
+			}
+			// shutdownNow() may remove a task that was accepted just before runtime
+			// teardown. Bound that indeterminate state so the replay fails closed
+			// instead of waiting forever without advancing its checkpoint.
+			return persisted.orTimeout(30, TimeUnit.SECONDS);
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -457,9 +457,17 @@ public class Reward {
 		ReplayState replayState = options.getAsyncReplayState();
 		if (replayState == null) {
 			replayState = ACTIVE_REPLAY_STATE.get();
-			if (replayState == null) replayState = new ReplayState(options.getAsyncReplayProgress(),
-					options.getAsyncReplayRegistryFingerprints(), options.isLegacyAsyncReplayCheckpoint());
-			options.setAsyncReplayState(replayState);
+			if (replayState == null) {
+				// A caller may reuse its RewardOptions for independent recipients. Keep
+				// fresh top-level execution state local to this dispatch so completed
+				// stages cannot leak into the next send.
+				replayState = new ReplayState(options.getAsyncReplayProgress(),
+						options.getAsyncReplayRegistryFingerprints(), options.isLegacyAsyncReplayCheckpoint());
+			} else {
+				// Deferred/nested options must retain their explicitly inherited parent
+				// state after the current thread-local scope ends.
+				options.setAsyncReplayState(replayState);
+			}
 		}
 		if (options.getAsyncReplayCheckpointConsumer() != null) {
 			replayState.setCheckpointConsumer(options.getAsyncReplayCheckpointConsumer());
@@ -1348,7 +1356,6 @@ public class Reward {
 		if (replayKey == null) {
 			String parentKey = ACTIVE_REPLAY_KEY.get();
 			replayKey = parentKey == null ? getRewardName() : parentKey + "/" + getRewardName();
-			rewardOptions.setAsyncReplayKey(replayKey);
 		}
 		if (!replayState.matchesRegistryFingerprint(injectionRegistryFingerprint(orderedInjectedRewards()))) {
 			return CompletableFuture.failedFuture(new IncompatibleReplayCheckpointException(replayKey));
@@ -1361,7 +1368,6 @@ public class Reward {
 			// inventing a different id for each retry.
 			if (occurrenceId == null && rewardOptions.getAsyncReplayCheckpointConsumer() == null) {
 				occurrenceId = UUID.randomUUID().toString();
-				rewardOptions.setAsyncReplayOccurrenceId(occurrenceId);
 			}
 		}
 		final HashMap<String, String> placeholders;

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -19,6 +19,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.function.Consumer;
@@ -786,13 +788,20 @@ public class Reward {
 		}
 		public CompletionStage<Void> persistCheckpointAsync(AdvancedCorePlugin plugin,
 				HashMap<String, String> placeholders) {
+			return persistCheckpointAsync(plugin, placeholders, 30, TimeUnit.SECONDS);
+		}
+
+		private CompletionStage<Void> persistCheckpointAsync(AdvancedCorePlugin plugin,
+				HashMap<String, String> placeholders, long timeout, TimeUnit timeoutUnit) {
 			Consumer<ReplayCheckpoint> consumer;
 			synchronized (this) { consumer = checkpointConsumer; }
 			if (consumer == null) return CompletableFuture.completedFuture(null);
 			ReplayCheckpoint checkpoint = new ReplayCheckpoint(copyProgress(), copyRegistryFingerprints(), placeholders);
 			CompletableFuture<Void> persisted = new CompletableFuture<>();
+			AtomicBoolean claimed = new AtomicBoolean();
 			try {
 				plugin.getTimer().execute(() -> {
+					if (!claimed.compareAndSet(false, true)) return;
 					try {
 						consumer.accept(checkpoint);
 						persisted.complete(null);
@@ -801,12 +810,18 @@ public class Reward {
 					}
 				});
 			} catch (Throwable failure) {
-				persisted.completeExceptionally(failure);
+				if (claimed.compareAndSet(false, true)) persisted.completeExceptionally(failure);
 			}
 			// shutdownNow() may remove a task that was accepted just before runtime
 			// teardown. Bound that indeterminate state so the replay fails closed
-			// instead of waiting forever without advancing its checkpoint.
-			return persisted.orTimeout(30, TimeUnit.SECONDS);
+			// instead of waiting forever without advancing its checkpoint. The same
+			// claim prevents a backlogged task from persisting after timeout recovery.
+			CompletableFuture.delayedExecutor(timeout, timeoutUnit).execute(() -> {
+				if (claimed.compareAndSet(false, true)) {
+					persisted.completeExceptionally(new TimeoutException("Timed out waiting to persist reward checkpoint"));
+				}
+			});
+			return persisted;
 		}
 
 	}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -22,6 +22,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.function.Consumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
@@ -452,6 +454,69 @@ public class Reward {
 		placeholders.put(storageKey, selected == null ? "" : Base64.getUrlEncoder().withoutPadding()
 				.encodeToString(selected.getBytes(StandardCharsets.UTF_8)));
 		return selected;
+	}
+
+	/** Executes a command list sequentially and durably records each successful item. */
+	public static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
+			HashMap<String, String> placeholders, String lane, List<String> commands,
+			Function<String, CompletionStage<Void>> dispatch) {
+		return replayCommandSequence(plugin, placeholders, lane, commands,
+				(command, ignoredIndex) -> dispatch.apply(command));
+	}
+
+	/** Executes an indexed command list sequentially and durably records each successful item. */
+	public static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
+			HashMap<String, String> placeholders, String lane, List<String> commands,
+			BiFunction<String, Integer, CompletionStage<Void>> dispatch) {
+		return replayCommandSequence(plugin, placeholders, lane, commands, currentReplayState(), currentReplayKey(), dispatch);
+	}
+
+	static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
+			HashMap<String, String> placeholders, String lane, List<String> commands,
+			ReplayState replayState, String activeKey,
+			BiFunction<String, Integer, CompletionStage<Void>> dispatch) {
+		if (commands == null || commands.isEmpty()) return CompletableFuture.completedFuture(null);
+		if (replayState == null || activeKey == null) {
+			CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+			for (int index = 0; index < commands.size(); index++) {
+				String command = commands.get(index);
+				int commandIndex = index;
+				sequence = sequence.thenCompose(ignored -> dispatch.apply(command, commandIndex));
+			}
+			return sequence;
+		}
+		StringBuilder identity = new StringBuilder(activeKey == null ? "root" : activeKey)
+				.append('\n').append(lane == null ? "commands" : lane);
+		for (String command : commands) identity.append('\n').append(command == null ? "" : command);
+		String storageKey = "__advancedcore_replay_commands_" + digest(identity.toString());
+		int completed = 0;
+		try {
+			completed = Integer.parseInt(placeholders.getOrDefault(storageKey, "0"));
+		} catch (NumberFormatException ignored) { }
+		if (completed < 0 || completed > commands.size()) completed = 0;
+		CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+		for (int index = completed; index < commands.size(); index++) {
+			String command = commands.get(index);
+			int completedCount = index + 1;
+			int commandIndex = index;
+			sequence = sequence.thenCompose(ignored -> dispatch.apply(command, commandIndex)).thenCompose(ignored -> {
+				placeholders.put(storageKey, String.valueOf(completedCount));
+				return replayState == null ? CompletableFuture.completedFuture(null)
+						: replayState.persistCheckpointAsync(plugin, placeholders);
+			});
+		}
+		return sequence;
+	}
+
+	private static String digest(String value) {
+		try {
+			byte[] bytes = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+			StringBuilder hex = new StringBuilder(bytes.length * 2);
+			for (byte item : bytes) hex.append(String.format("%02x", item & 0xff));
+			return hex.toString();
+		} catch (NoSuchAlgorithmException failure) {
+			throw new IllegalStateException("SHA-256 is unavailable for reward replay checkpoints", failure);
+		}
 	}
 
 	/** Attaches a captured replay state to an option object for a deferred child. */

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -309,9 +309,13 @@ public class Reward {
 		AtomicInteger completed = new AtomicInteger(resumeAfter);
 		CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 		for (int index = 0; index < orderedRewards.size(); index++) {
-			if (index < resumeAfter) continue;
 			final RewardInject inject = orderedRewards.get(index);
 			final String injectionKey = replayKey + "/" + index;
+			if (index < resumeAfter) {
+				sequence = sequence.thenCompose(ignored -> notifyReplayCheckpointPersisted(inject, user, occurrenceId,
+						injectionKey));
+				continue;
+			}
 			sequence = sequence.thenCompose(ignored -> {
 				// A nested injector can checkpoint a child before this parent injector
 				// completes. Bind the parent's registry first so that child checkpoint
@@ -324,7 +328,10 @@ public class Reward {
 						int checkpoint = completed.incrementAndGet();
 						replayState.setCompleted(replayKey, checkpoint);
 						replayState.setRegistryFingerprint(replayKey, registryFingerprint);
-						return replayState.persistCheckpointAsync(plugin, placeholders).thenApply(ignored -> result);
+						return replayState.persistCheckpointAsync(plugin, placeholders)
+								.thenCompose(ignored -> notifyReplayCheckpointPersisted(inject, user, occurrenceId,
+										injectionKey))
+								.thenApply(ignored -> result);
 					}).thenCompose(ignored -> resumeOnServerThread(user));
 		}
 		return sequence.handle((ignored, failure) -> {
@@ -334,6 +341,19 @@ public class Reward {
 			replayState.setCompleted(replayKey, completed.get());
 			throw new RewardReplayFailure(replayState, placeholders, failure);
 		});
+	}
+
+	private CompletionStage<Void> notifyReplayCheckpointPersisted(RewardInject inject, AdvancedCoreUser user,
+			String occurrenceId,
+			String injectionKey) {
+		try {
+			CompletionStage<Void> notification = inject.onReplayCheckpointPersisted(this, user, occurrenceId,
+					injectionKey);
+			return notification == null ? CompletableFuture.failedFuture(new IllegalStateException(
+					"Reward injection returned a null replay-checkpoint result: " + inject.getPath())) : notification;
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
+		}
 	}
 
 	private List<RewardInject> orderedInjectedRewards() {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -504,6 +504,23 @@ public class Reward {
 		return selected;
 	}
 
+	/** Returns whether the active injection already persisted a selected branch. */
+	public static boolean hasReplaySelection(HashMap<String, String> placeholders) {
+		String activeKey = ACTIVE_REPLAY_KEY.get();
+		if (activeKey == null) return false;
+		String storageKey = REPLAY_SELECTION_PREFIX + Base64.getUrlEncoder().withoutPadding()
+				.encodeToString(activeKey.getBytes(StandardCharsets.UTF_8));
+		return replayMetadata(placeholders, ACTIVE_REPLAY_STATE.get(), storageKey) != null;
+	}
+
+	/** Durably records replay metadata before dispatching its selected side effect. */
+	public static CompletionStage<Void> persistReplayMetadataAsync(AdvancedCorePlugin plugin,
+			HashMap<String, String> placeholders) {
+		ReplayState replayState = ACTIVE_REPLAY_STATE.get();
+		return replayState == null ? CompletableFuture.completedFuture(null)
+				: replayState.persistCheckpointAsync(plugin, placeholders);
+	}
+
 	/** Executes a command list sequentially and durably records each successful item. */
 	public static CompletionStage<Void> replayCommandSequence(AdvancedCorePlugin plugin,
 			HashMap<String, String> placeholders, String lane, List<String> commands,

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -1303,15 +1303,14 @@ public class Reward {
 		if (plugin.getOptions().isPauseRewards() || (plugin.getOptions().isTreatVanishAsOffline() && user.isVanished())) {
 			checkRewardFile();
 			preserveReplayState(rewardOptions);
-			user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
-			return CompletableFuture.completedFuture(null);
+			return deferRewardAsync(user, rewardOptions);
 		}
 		if (((((!rewardOptions.isOnline() || rewardOptions.getServer() != null) && !user.isOnline()) || allowOffline)
 				&& (!isForceOffline() && !rewardOptions.isForceOffline()))) {
 			if (rewardOptions.isGiveOffline()) {
 				checkRewardFile();
 				preserveReplayState(rewardOptions);
-				user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
+				return deferRewardAsync(user, rewardOptions);
 			}
 			return CompletableFuture.completedFuture(null);
 		}
@@ -1328,6 +1327,15 @@ public class Reward {
 				return CompletableFuture.failedFuture(failure);
 			}
 		}
+		return CompletableFuture.completedFuture(null);
+	}
+
+	private CompletionStage<Void> deferRewardAsync(AdvancedCoreUser user, RewardOptions rewardOptions) {
+		if (rewardOptions.isTimedQueueReplay()) {
+			return CompletableFuture.failedFuture(
+					new IllegalStateException("Timed reward replay remains deferred in its original queue"));
+		}
+		user.addOfflineRewards(this, rewardOptions.getPlaceholders(), rewardOptions);
 		return CompletableFuture.completedFuture(null);
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -8,6 +8,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -245,6 +251,152 @@ public class Reward {
 		}
 	}
 
+	/**
+	 * Gives injected rewards in registration order, waiting for each asynchronous
+	 * injection before evaluating the next one. Synchronous injections retain
+	 * their existing behavior, and post-reward injections run after all normal
+	 * injections have completed.
+	 *
+	 * @param user         receiving user
+	 * @param placeholders current placeholders
+	 * @return completion stage that completes after all injections have run
+	 */
+	public CompletionStage<Void> giveInjectedRewardsAsync(AdvancedCoreUser user,
+			HashMap<String, String> placeholders) {
+		List<RewardInject> postRewards = new ArrayList<>();
+		CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+
+		for (RewardInject inject : plugin.getRewardHandler().getInjectedRewards()) {
+			if (inject.isPostReward()) {
+				postRewards.add(inject);
+				continue;
+			}
+			sequence = sequence.thenCompose(ignored -> invokeInjectionAsync(inject, user, placeholders))
+					.thenCompose(result -> resumeOnServerThread(user).thenRun(() -> {
+						if (inject.isAddAsPlaceholder() && result != null) addPlaceholder(inject, result, placeholders);
+					}));
+		}
+
+		for (RewardInject inject : postRewards) {
+			sequence = sequence.thenCompose(ignored -> invokeInjectionAsync(inject, user, placeholders))
+					.thenCompose(result -> resumeOnServerThread(user));
+		}
+		return sequence;
+	}
+
+	private CompletionStage<Object> invokeInjectionAsync(RewardInject inject, AdvancedCoreUser user,
+			HashMap<String, String> placeholders) {
+		try {
+			if (!plugin.isEnabled()) return CompletableFuture.failedFuture(
+					new IllegalStateException("Plugin disabled before reward injection completed"));
+			Supplier<CompletionStage<Object>> request = () -> requestOnServerThread(user,
+					() -> requestInjectionAsync(inject, user, placeholders));
+			CompletionStage<Object> result = inject.isSynchronize()
+					? inject.runSynchronizedAsync(request)
+					: request.get();
+			if (result == null) {
+				return CompletableFuture.failedFuture(new IllegalStateException(
+						"Reward injection returned a null asynchronous result: " + inject.getPath()));
+			}
+			return result;
+		} catch (Throwable throwable) {
+			return CompletableFuture.failedFuture(throwable);
+		}
+	}
+
+	private <T> CompletionStage<T> requestOnServerThread(AdvancedCoreUser user,
+			Supplier<CompletionStage<T>> request) {
+		CompletableFuture<CompletionStage<T>> handoff = new CompletableFuture<>();
+		Runnable invocation = () -> {
+			if (!plugin.isEnabled()) {
+				handoff.complete(CompletableFuture.failedFuture(
+						new IllegalStateException("Plugin disabled before reward injection completed")));
+				return;
+			}
+			CompletableFuture<T> result = new CompletableFuture<>();
+			// Claim the handoff before invoking user code. If the timeout won, this
+			// queued task must not produce late reward side effects.
+			if (!handoff.complete(result)) return;
+			try {
+				CompletionStage<T> stage = request.get();
+				if (stage == null) {
+					result.completeExceptionally(
+							new IllegalStateException("Reward injection returned a null asynchronous result"));
+					return;
+				}
+				stage.whenComplete((value, failure) -> {
+					if (failure == null) result.complete(value);
+					else result.completeExceptionally(failure);
+				});
+			} catch (Throwable failure) {
+				result.completeExceptionally(failure);
+			}
+		};
+		Runnable resolvePlayer = () -> {
+			if (!plugin.isEnabled()) {
+				handoff.complete(CompletableFuture.failedFuture(
+						new IllegalStateException("Plugin disabled before reward injection completed")));
+				return;
+			}
+			try {
+				Player player = user.getPlayer();
+				if (player != null) plugin.getBukkitScheduler().executeOrScheduleSync(plugin, invocation, player);
+				else invocation.run();
+			} catch (Throwable failure) {
+				handoff.completeExceptionally(failure);
+			}
+		};
+		try {
+			plugin.getBukkitScheduler().executeOrScheduleSync(plugin, resolvePlayer);
+		} catch (Throwable failure) {
+			handoff.completeExceptionally(failure);
+		}
+		return handoff.orTimeout(getServerThreadDispatchTimeoutMillis(), TimeUnit.MILLISECONDS)
+				.thenCompose(stage -> stage);
+	}
+
+	private CompletionStage<Void> resumeOnServerThread(AdvancedCoreUser user) {
+		return requestOnServerThread(user, () -> CompletableFuture.completedFuture(null));
+	}
+
+	/** Maximum time to wait when a scheduler drops a task during plugin shutdown. */
+	protected long getServerThreadDispatchTimeoutMillis() {
+		return TimeUnit.SECONDS.toMillis(30);
+	}
+
+	private CompletionStage<Object> requestInjectionAsync(RewardInject inject, AdvancedCoreUser user,
+			HashMap<String, String> placeholders) {
+		if (inject.supportsAsyncRequest()) {
+			return inject.onRewardRequestAsync(this, user, getConfig().getConfigData(), placeholders);
+		}
+		return CompletableFuture.completedFuture(inject.onRewardRequest(this, user, getConfig().getConfigData(), placeholders));
+	}
+
+	private void addPlaceholder(RewardInject inject, Object obj, HashMap<String, String> placeholders) {
+		String placeholderName = inject.getPlaceholderName();
+		String value = "";
+		if (obj instanceof Boolean) {
+			value = obj.toString();
+		} else if (obj instanceof String) {
+			value = (String) obj;
+		} else if (obj instanceof Double) {
+			value = obj.toString();
+		} else if (obj instanceof Integer) {
+			value = obj.toString();
+		}
+		plugin.extraDebug("Adding placeholder " + placeholderName + ":" + value);
+		placeholders.put(placeholderName, value);
+	}
+
+	private boolean hasAsyncRewardInjection() {
+		for (RewardInject inject : plugin.getRewardHandler().getInjectedRewards()) {
+			if (inject.supportsAsyncRequest()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public void giveReward(AdvancedCoreUser user, RewardOptions rewardOptions) {
 		if (!AdvancedCorePlugin.getInstance().getOptions().isProcessRewards()) {
 			AdvancedCorePlugin.getInstance().debug("Processing rewards is disabled");
@@ -363,6 +515,48 @@ public class Reward {
 	 * @param rewardOptions rewardOptions
 	 */
 	public void giveRewardUser(AdvancedCoreUser user, HashMap<String, String> phs, RewardOptions rewardOptions) {
+		if (hasAsyncRewardInjection()) {
+			giveRewardUserAsync(user, phs, rewardOptions).exceptionally(failure -> {
+				logRewardUserFailure(failure);
+				return null;
+			});
+			return;
+		}
+
+		HashMap<String, String> placeholders = prepareRewardUser(user, phs);
+		if (placeholders == null) {
+			return;
+		}
+		giveInjectedRewards(user, placeholders);
+		plugin.debug("Gave " + user.getPlayerName() + " reward " + name);
+	}
+
+	/**
+	 * Asynchronously gives a reward to a user when an injection opts into the
+	 * asynchronous API. Preparation remains on the calling thread; only the
+	 * opted-in injection chain is asynchronous.
+	 *
+	 * @param user          receiving user
+	 * @param phs           placeholders
+	 * @param rewardOptions reward options (reserved for API symmetry)
+	 * @return completion stage that completes after reward injections finish
+	 */
+	public CompletionStage<Void> giveRewardUserAsync(AdvancedCoreUser user, HashMap<String, String> phs,
+			RewardOptions rewardOptions) {
+		final HashMap<String, String> placeholders;
+		try {
+			placeholders = prepareRewardUser(user, phs);
+		} catch (Throwable throwable) {
+			return CompletableFuture.failedFuture(throwable);
+		}
+		if (placeholders == null) {
+			return CompletableFuture.completedFuture(null);
+		}
+		return giveInjectedRewardsAsync(user, placeholders)
+				.thenRun(() -> plugin.debug("Gave " + user.getPlayerName() + " reward " + name));
+	}
+
+	private HashMap<String, String> prepareRewardUser(AdvancedCoreUser user, HashMap<String, String> phs) {
 
 		Player player = user.getPlayer();
 		if (player == null) {
@@ -391,14 +585,19 @@ public class Reward {
 				}
 			}
 
-			final HashMap<String, String> placeholders = new HashMap<>(phs);
-
-			giveInjectedRewards(user, placeholders);
-
-			plugin.debug("Gave " + user.getPlayerName() + " reward " + name);
+			return new HashMap<>(phs);
 		} else {
 			plugin.debug(getRewardName() + ": Player == null & forceoffline false, player: " + user.getPlayerName()
 					+ "/" + user.getUUID());
+			return null;
+		}
+	}
+
+	private void logRewardUserFailure(Throwable failure) {
+		if (plugin.getLogger() != null) {
+			plugin.getLogger().log(Level.WARNING, "Failed to give reward " + getRewardName(), failure);
+		} else {
+			failure.printStackTrace();
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/Reward.java
@@ -291,7 +291,7 @@ public class Reward {
 					new IllegalStateException("Plugin disabled before reward injection completed"));
 			Supplier<CompletionStage<Object>> request = () -> requestOnServerThread(user,
 					() -> requestInjectionAsync(inject, user, placeholders));
-			CompletionStage<Object> result = inject.isSynchronize()
+			CompletionStage<Object> result = inject.isSynchronize() && inject.supportsAsyncSynchronization()
 					? inject.runSynchronizedAsync(request)
 					: request.get();
 			if (result == null) {
@@ -369,7 +369,15 @@ public class Reward {
 		if (inject.supportsAsyncRequest()) {
 			return inject.onRewardRequestAsync(this, user, getConfig().getConfigData(), placeholders);
 		}
-		return CompletableFuture.completedFuture(inject.onRewardRequest(this, user, getConfig().getConfigData(), placeholders));
+		try {
+			return CompletableFuture.completedFuture(
+					inject.onRewardRequest(this, user, getConfig().getConfigData(), placeholders));
+		} catch (Exception failure) {
+			// Preserve the legacy per-injection isolation contract while allowing
+			// opted-in asynchronous injections to propagate durable failures.
+			failure.printStackTrace();
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 	private void addPlaceholder(RewardInject inject, Object obj, HashMap<String, String> placeholders) {
@@ -390,11 +398,17 @@ public class Reward {
 
 	private boolean hasAsyncRewardInjection() {
 		for (RewardInject inject : plugin.getRewardHandler().getInjectedRewards()) {
-			if (inject.supportsAsyncRequest()) {
+			if (inject.supportsAsyncRequest()
+					&& (!inject.requiresConfiguredDataForAsync() || isRewardInjectionApplicable(inject))) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	private boolean isRewardInjectionApplicable(RewardInject inject) {
+		ConfigurationSection data = getConfig().getConfigData();
+		return inject.isAlwaysForceNoData() || data.contains(inject.getPath(), true);
 	}
 
 	public void giveReward(AdvancedCoreUser user, RewardOptions rewardOptions) {
@@ -505,6 +519,98 @@ public class Reward {
 					+ user.getUUID());
 			giveRewardUser(user, rewardOptions.getPlaceholders(), rewardOptions);
 		}
+	}
+
+	/**
+	 * Gives this reward and completes when an asynchronous injection chain has
+	 * finished. This is used by nested reward injectors so a child reward cannot
+	 * overtake later parent post-reward injections.
+	 *
+	 * <p>The established void API deliberately remains fire-and-forget. Callers
+	 * that need ordering or durable replay semantics must use this method.</p>
+	 *
+	 * @param user receiving user
+	 * @param rewardOptions reward options
+	 * @return completion stage for the complete reward injection chain
+	 */
+	public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, RewardOptions rewardOptions) {
+		if (!AdvancedCorePlugin.getInstance().getOptions().isProcessRewards()) {
+			AdvancedCorePlugin.getInstance().debug("Processing rewards is disabled");
+			return CompletableFuture.completedFuture(null);
+		}
+
+		if (rewardOptions == null) rewardOptions = new RewardOptions();
+		if (!rewardOptions.getPlaceholders().containsKey("ExecDate")) {
+			rewardOptions.addPlaceholder("ExecDate", "" + System.currentTimeMillis());
+		}
+		if (!rewardOptions.getPlaceholders().containsKey("date")) {
+			try {
+				LocalDateTime ldt = LocalDateTime.now();
+				Date date = Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
+				rewardOptions.addPlaceholder("Date", "" + new SimpleDateFormat(
+						plugin.getOptions().getFormatRewardTimeFormat()).format(date));
+			} catch (Exception e) {
+				return CompletableFuture.failedFuture(e);
+			}
+		}
+
+		PlayerRewardEvent event = new PlayerRewardEvent(this, user, rewardOptions);
+		Bukkit.getPluginManager().callEvent(event);
+		if (event.isCancelled()) {
+			plugin.debug("Reward " + name + " was cancelled for " + user.getPlayerName());
+			return CompletableFuture.completedFuture(null);
+		}
+		if (rewardOptions.isCheckTimed() && (checkDelayed(user, rewardOptions.getPlaceholders())
+				|| checkTimed(user, rewardOptions.getPlaceholders()))) {
+			return CompletableFuture.completedFuture(null);
+		}
+		if (!rewardOptions.isOnlineSet()) rewardOptions.setOnline(user.isOnline());
+		for (RewardPlaceholderHandle handle : plugin.getRewardHandler().getPlaceholders()) {
+			if (handle.isPreProcess()) rewardOptions.addPlaceholder(handle.getKey(), handle.getValue(this, user));
+		}
+
+		boolean allowOffline = false;
+		boolean canGive = true;
+		if (!rewardOptions.isIgnoreRequirements()) {
+			for (RequirementInject inject : plugin.getRewardHandler().getInjectedRequirements()) {
+				try {
+					if (!inject.onRequirementRequest(this, user, getConfig().getConfigData(), rewardOptions)) {
+						canGive = false;
+						if (!inject.isAllowReattempt()) return CompletableFuture.completedFuture(null);
+						allowOffline = true;
+					}
+				} catch (Exception e) {
+					plugin.debug("Failed to check requirement " + inject.getPath());
+					e.printStackTrace();
+					canGive = false;
+				}
+			}
+		}
+		if (plugin.getOptions().isPauseRewards() || (plugin.getOptions().isTreatVanishAsOffline() && user.isVanished())) {
+			checkRewardFile();
+			user.addOfflineRewards(this, rewardOptions.getPlaceholders());
+			return CompletableFuture.completedFuture(null);
+		}
+		if (((((!rewardOptions.isOnline() || rewardOptions.getServer() != null) && !user.isOnline()) || allowOffline)
+				&& (!isForceOffline() && !rewardOptions.isForceOffline()))) {
+			if (rewardOptions.isGiveOffline()) {
+				checkRewardFile();
+				user.addOfflineRewards(this, rewardOptions.getPlaceholders());
+			}
+			return CompletableFuture.completedFuture(null);
+		}
+		if (canGive || isForceOffline() || rewardOptions.isForceOffline()) {
+			plugin.debug(name + ": Passed requirements, attempting to give to " + user.getPlayerName() + "/"
+					+ user.getUUID());
+			if (hasAsyncRewardInjection()) return giveRewardUserAsync(user, rewardOptions.getPlaceholders(), rewardOptions);
+			try {
+				giveRewardUser(user, rewardOptions.getPlaceholders(), rewardOptions);
+				return CompletableFuture.completedFuture(null);
+			} catch (Throwable failure) {
+				return CompletableFuture.failedFuture(failure);
+			}
+		}
+		return CompletableFuture.completedFuture(null);
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardBuilder.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardBuilder.java
@@ -6,6 +6,8 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
@@ -87,6 +89,16 @@ public class RewardBuilder {
 		} else {
 			handler.giveReward(user, reward, rewardOptions);
 		}
+	}
+
+	/** Sends this builder's reward and completes when its async injection chain finishes. */
+	public CompletionStage<Void> sendAsync(AdvancedCoreUser user) {
+		RewardHandler handler = user.getPlugin().getRewardHandler();
+		if (reward == null) {
+			return data == null ? CompletableFuture.completedFuture(null)
+					: handler.giveRewardAsync(user, data, path, rewardOptions);
+		}
+		return handler.giveRewardAsync(user, reward, rewardOptions);
 	}
 
 	public void send(AdvancedCoreUser... users) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletionException;
 
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.Configuration;
@@ -120,12 +121,26 @@ public class RewardExecutor {
             String parentReplayKey = options.getAsyncReplayKey();
             if (parentReplayKey == null) parentReplayKey = Reward.currentReplayKey();
             if (parentReplayKey == null) parentReplayKey = "list:" + path;
+            final String stableParentReplayKey = parentReplayKey;
             int rewardIndex = 0;
             for (String nestedReward : new ArrayList<>(data.getStringList(path))) {
-                RewardOptions nestedOptions = options.copyForNestedDispatch(
-                        parentReplayKey + "/" + nestedReward + ":" + rewardIndex++);
-                nestedOptions.setAsyncReplayState(replayState);
-                sequence = sequence.thenCompose(ignored -> giveRewardAsync(user, nestedReward, nestedOptions));
+                final int nestedIndex = rewardIndex++;
+                sequence = sequence.thenCompose(ignored -> {
+                    // Clone only when this child is actually reached. This lets
+                    // metadata from earlier children be merged before a later
+                    // child receives its isolated ordinary placeholders.
+                    RewardOptions nestedOptions = options.copyForNestedDispatch(
+                            stableParentReplayKey + "/" + nestedReward + ":" + nestedIndex);
+                    nestedOptions.setAsyncReplayState(replayState);
+                    return giveRewardAsync(user, nestedReward, nestedOptions).handle((childResult, failure) -> {
+                        // Child options stay isolated for normal placeholders. Replay
+                        // markers are shared lazily so an earlier child remains durable
+                        // when a later child fails and the list is restarted.
+                        replayState.mergeReplayMetadataInto(options.getPlaceholders());
+                        if (failure != null) throw new CompletionException(failure);
+                        return childResult;
+                    });
+                });
             }
             return sequence;
         }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -204,36 +204,9 @@ public class RewardExecutor {
         if (options.getAsyncReplayOccurrenceId() == null && activeOccurrenceId != null) {
             options.setAsyncReplayOccurrenceId(activeOccurrenceId);
         }
-        boolean primaryThread = false;
-        try {
-            primaryThread = Bukkit.isPrimaryThread();
-        } catch (IllegalStateException | NullPointerException ignored) {
-            // Unit tests and early bootstrap have no primary server thread.
-        }
-        if (primaryThread) {
-            CompletableFuture<Void> dispatched = new CompletableFuture<>();
-            try {
-                plugin.getBukkitScheduler().runTaskAsynchronously(plugin, () -> {
-                    try {
-                        CompletionStage<Void> result = reward.giveRewardAsync(user, options);
-                        if (result == null) {
-                            dispatched.completeExceptionally(
-                                    new IllegalStateException("Asynchronous reward dispatch returned no completion stage"));
-                        } else {
-                            result.whenComplete((ignored, failure) -> {
-                                if (failure == null) dispatched.complete(null);
-                                else dispatched.completeExceptionally(failure);
-                            });
-                        }
-                    } catch (Throwable failure) {
-                        dispatched.completeExceptionally(failure);
-                    }
-                });
-            } catch (Throwable failure) {
-                dispatched.completeExceptionally(failure);
-            }
-            return dispatched;
-        }
+        // Reward setup fires Bukkit events and resolves live player state. Keep that
+        // work on the caller's owner thread; individual injectors explicitly hand
+        // off only the portions that are safe to execute asynchronously.
         return reward.giveRewardAsync(user, options);
     }
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -176,11 +176,14 @@ public class RewardExecutor {
     public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         if (reward == null || reward.isEmpty()) return CompletableFuture.completedFuture(null);
-        if (!plugin.isEnabled()) return disabledDispatch();
-        if (reward.startsWith("/")) {
-            return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), reward,
-                    context.getPlaceholders());
-        }
+		if (!plugin.isEnabled()) return disabledDispatch();
+		if (reward.startsWith("/")) {
+			RewardOptions options = context.getOptions();
+			return Reward.replayCommandSequence(plugin, context.getPlaceholders(), "direct", java.util.List.of(reward),
+					Reward.replayStateFor(options), options.getAsyncReplayKey(),
+					(command, ignoredIndex) -> MiscUtils.getInstance().executeConsoleCommandsAsync(
+							user.getPlayerName(), command, context.getPlaceholders()));
+		}
         return giveRewardAsync(user, handler.getReward(reward), context.getOptions());
     }
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -111,7 +111,8 @@ public class RewardExecutor {
             RewardOptions rewardOptions) {
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         RewardOptions options = context.getOptions();
-        if (path == null || data == null || !plugin.isEnabled()) return CompletableFuture.completedFuture(null);
+        if (path == null || data == null) return CompletableFuture.completedFuture(null);
+        if (!plugin.isEnabled()) return disabledDispatch();
 
         if (data.isList(path)) {
             CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
@@ -152,7 +153,8 @@ public class RewardExecutor {
     }
 
     public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, Reward reward, RewardOptions rewardOptions) {
-        if (reward == null || !plugin.isEnabled()) return CompletableFuture.completedFuture(null);
+        if (reward == null) return CompletableFuture.completedFuture(null);
+        if (!plugin.isEnabled()) return disabledDispatch();
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         return reward.giveRewardAsync(user, context.getOptions());
     }
@@ -174,6 +176,7 @@ public class RewardExecutor {
     public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         if (reward == null || reward.isEmpty()) return CompletableFuture.completedFuture(null);
+        if (!plugin.isEnabled()) return disabledDispatch();
         if (reward.startsWith("/")) {
             return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), reward,
                     context.getPlaceholders());
@@ -233,6 +236,7 @@ public class RewardExecutor {
             RewardOptions rewardOptions) {
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         if (reward == null || reward.isEmpty()) return CompletableFuture.completedFuture(null);
+        if (!plugin.isEnabled()) return disabledDispatch();
 
         String rewardName = reward;
         Boolean generatedSnapshot = null;
@@ -263,6 +267,11 @@ public class RewardExecutor {
             if (resolved == null) resolved = handler.getReward(rewardName);
         }
         return giveRewardAsync(user, resolved, context.getOptions());
+    }
+
+    private CompletionStage<Void> disabledDispatch() {
+        return CompletableFuture.failedFuture(
+                new IllegalStateException("Plugin disabled before asynchronous reward dispatch"));
     }
 
     public void updateReward(Configuration data, String path, RewardOptions rewardOptions) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -115,8 +115,16 @@ public class RewardExecutor {
 
         if (data.isList(path)) {
             CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+            Reward.ReplayState replayState = Reward.replayStateFor(options);
+            String parentReplayKey = options.getAsyncReplayKey();
+            if (parentReplayKey == null) parentReplayKey = Reward.currentReplayKey();
+            if (parentReplayKey == null) parentReplayKey = "list:" + path;
+            int rewardIndex = 0;
             for (String nestedReward : new ArrayList<>(data.getStringList(path))) {
-                sequence = sequence.thenCompose(ignored -> giveRewardAsync(user, nestedReward, options));
+                RewardOptions nestedOptions = options.copyForNestedDispatch(
+                        parentReplayKey + "/" + nestedReward + ":" + rewardIndex++);
+                nestedOptions.setAsyncReplayState(replayState);
+                sequence = sequence.thenCompose(ignored -> giveRewardAsync(user, nestedReward, nestedOptions));
             }
             return sequence;
         }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -115,34 +115,42 @@ public class RewardExecutor {
         if (path == null || data == null) return CompletableFuture.completedFuture(null);
         if (!plugin.isEnabled()) return disabledDispatch();
 
-        if (data.isList(path)) {
-            CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
-            Reward.ReplayState replayState = Reward.replayStateFor(options);
-            String parentReplayKey = options.getAsyncReplayKey();
-            if (parentReplayKey == null) parentReplayKey = Reward.currentReplayKey();
-            if (parentReplayKey == null) parentReplayKey = "list:" + path;
+        Reward.ReplayState replayState = Reward.replayStateFor(options);
+        String parentReplayKey = options.getAsyncReplayKey();
+        if (parentReplayKey == null) parentReplayKey = Reward.currentReplayKey();
+        if (parentReplayKey == null) parentReplayKey = "list:" + path;
+        String nestedLane = "nested-list:" + path;
+        if (data.isList(path)
+                || Reward.hasReplayNestedRewardSnapshot(options.getPlaceholders(), nestedLane, replayState,
+                        parentReplayKey)) {
             final String stableParentReplayKey = parentReplayKey;
-            int rewardIndex = 0;
-            for (String nestedReward : new ArrayList<>(data.getStringList(path))) {
-                final int nestedIndex = rewardIndex++;
-                sequence = sequence.thenCompose(ignored -> {
-                    // Clone only when this child is actually reached. This lets
-                    // metadata from earlier children be merged before a later
-                    // child receives its isolated ordinary placeholders.
-                    RewardOptions nestedOptions = options.copyForNestedDispatch(
-                            stableParentReplayKey + "/" + nestedReward + ":" + nestedIndex);
-                    nestedOptions.setAsyncReplayState(replayState);
-                    return giveRewardAsync(user, nestedReward, nestedOptions).handle((childResult, failure) -> {
-                        // Child options stay isolated for normal placeholders. Replay
-                        // markers are shared lazily so an earlier child remains durable
-                        // when a later child fails and the list is restarted.
-                        replayState.mergeReplayMetadataInto(options.getPlaceholders());
-                        if (failure != null) throw new CompletionException(failure);
-                        return childResult;
-                    });
-                });
-            }
-            return sequence;
+			return Reward.replayNestedRewardSnapshot(plugin, options.getPlaceholders(), nestedLane,
+					data.isList(path) ? new ArrayList<>(data.getStringList(path)) : java.util.List.of(), replayState,
+					stableParentReplayKey)
+					.thenCompose(rewards -> {
+						CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+						for (int index = 0; index < rewards.size(); index++) {
+							String nestedReward = rewards.get(index);
+							int nestedIndex = index;
+							sequence = sequence.thenCompose(ignored -> {
+								// Clone only when this child is actually reached. This lets
+								// metadata from earlier children be merged before a later
+								// child receives its isolated ordinary placeholders.
+								RewardOptions nestedOptions = options.copyForNestedDispatch(
+										stableParentReplayKey + "/" + nestedReward + ":" + nestedIndex);
+								nestedOptions.setAsyncReplayState(replayState);
+								return giveRewardAsync(user, nestedReward, nestedOptions).handle((childResult, failure) -> {
+									// Child options stay isolated for normal placeholders. Replay
+									// markers are shared lazily so an earlier child remains durable
+									// when a later child fails and the list is restarted.
+									replayState.mergeReplayMetadataInto(options.getPlaceholders());
+									if (failure != null) throw new CompletionException(failure);
+									return childResult;
+								});
+							});
+						}
+						return sequence;
+					});
         }
         if (data.isConfigurationSection(path)) {
             return giveSectionRewardAsync(user, data, path, context);
@@ -283,6 +291,10 @@ public class RewardExecutor {
         } else {
             resolved = handler.getQueuedGeneratedReward(rewardName, user.getUUID());
             if (resolved == null) resolved = handler.getReward(rewardName);
+        }
+        if (resolved == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("Persisted queued reward could not be resolved: " + rewardName));
         }
         return giveRewardAsync(user, resolved, context.getOptions());
     }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -175,8 +175,8 @@ public class RewardExecutor {
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         if (reward == null || reward.isEmpty()) return CompletableFuture.completedFuture(null);
         if (reward.startsWith("/")) {
-            MiscUtils.getInstance().executeConsoleCommands(user.getPlayerName(), reward, context.getPlaceholders());
-            return CompletableFuture.completedFuture(null);
+            return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), reward,
+                    context.getPlaceholders());
         }
         return giveRewardAsync(user, handler.getReward(reward), context.getOptions());
     }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -155,9 +155,12 @@ public class RewardExecutor {
         if (data.isConfigurationSection(path)) {
             return giveSectionRewardAsync(user, data, path, context);
         }
-        String nestedReward = data.getString(path, "");
-        return nestedReward.isEmpty() ? CompletableFuture.completedFuture(null)
-                : giveRewardAsync(user, nestedReward, options);
+		String nestedReward = data.getString(path, "");
+		if (nestedReward.isEmpty()) {
+			return CompletableFuture.failedFuture(
+					new IllegalStateException("Nested replay configuration could not be resolved: " + path));
+		}
+		return giveRewardAsync(user, nestedReward, options);
     }
 
     public void giveReward(AdvancedCoreUser user, Reward reward, RewardOptions rewardOptions) {
@@ -207,7 +210,12 @@ public class RewardExecutor {
 					(command, ignoredIndex) -> MiscUtils.getInstance().executeConsoleCommandsAsync(
 							user.getPlayerName(), command, context.getPlaceholders()));
 		}
-        return giveRewardAsync(user, handler.getReward(reward), context.getOptions());
+		Reward resolved = handler.getReward(reward);
+		if (resolved == null && context.getOptions().getAsyncReplayState() != null) {
+			return CompletableFuture.failedFuture(
+					new IllegalStateException("Nested replay reward could not be resolved: " + reward));
+		}
+		return giveRewardAsync(user, resolved, context.getOptions());
     }
 
     public void givePersistedQueueReward(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -116,6 +116,10 @@ public class RewardExecutor {
         if (!plugin.isEnabled()) return disabledDispatch();
 
         Reward.ReplayState replayState = Reward.replayStateFor(options);
+        if (options.getAsyncReplayOccurrenceId() == null) {
+            String activeOccurrenceId = Reward.currentReplayOccurrenceId();
+            if (activeOccurrenceId != null) options.setAsyncReplayOccurrenceId(activeOccurrenceId);
+        }
         String parentReplayKey = options.getAsyncReplayKey();
         if (parentReplayKey == null) parentReplayKey = Reward.currentReplayKey();
         if (parentReplayKey == null) parentReplayKey = "list:" + path;
@@ -170,7 +174,14 @@ public class RewardExecutor {
             return;
         }
 
-        if (Bukkit.isPrimaryThread()) {
+        boolean primaryThread = false;
+        try {
+            primaryThread = Bukkit.isPrimaryThread();
+        } catch (IllegalStateException | NullPointerException ignored) {
+            // Unit tests and early bootstrap can call this facade before Bukkit has
+            // installed a server. There is no primary server thread to leave then.
+        }
+        if (primaryThread) {
             plugin.getBukkitScheduler().runTaskAsynchronously(plugin,
                     () -> reward.giveReward(user, context.getOptions()));
         } else {
@@ -182,7 +193,48 @@ public class RewardExecutor {
         if (reward == null) return CompletableFuture.completedFuture(null);
         if (!plugin.isEnabled()) return disabledDispatch();
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
-        return reward.giveRewardAsync(user, context.getOptions());
+        RewardOptions options = context.getOptions();
+        Reward.ReplayState activeState = Reward.currentReplayState();
+        if (options.getAsyncReplayState() == null && activeState != null) options.setAsyncReplayState(activeState);
+        String activeKey = Reward.currentReplayKey();
+        if (options.getAsyncReplayKey() == null && activeKey != null) {
+            options.setAsyncReplayKey(activeKey + "/" + reward.getRewardName());
+        }
+        String activeOccurrenceId = Reward.currentReplayOccurrenceId();
+        if (options.getAsyncReplayOccurrenceId() == null && activeOccurrenceId != null) {
+            options.setAsyncReplayOccurrenceId(activeOccurrenceId);
+        }
+        boolean primaryThread = false;
+        try {
+            primaryThread = Bukkit.isPrimaryThread();
+        } catch (IllegalStateException | NullPointerException ignored) {
+            // Unit tests and early bootstrap have no primary server thread.
+        }
+        if (primaryThread) {
+            CompletableFuture<Void> dispatched = new CompletableFuture<>();
+            try {
+                plugin.getBukkitScheduler().runTaskAsynchronously(plugin, () -> {
+                    try {
+                        CompletionStage<Void> result = reward.giveRewardAsync(user, options);
+                        if (result == null) {
+                            dispatched.completeExceptionally(
+                                    new IllegalStateException("Asynchronous reward dispatch returned no completion stage"));
+                        } else {
+                            result.whenComplete((ignored, failure) -> {
+                                if (failure == null) dispatched.complete(null);
+                                else dispatched.completeExceptionally(failure);
+                            });
+                        }
+                    } catch (Throwable failure) {
+                        dispatched.completeExceptionally(failure);
+                    }
+                });
+            } catch (Throwable failure) {
+                dispatched.completeExceptionally(failure);
+            }
+            return dispatched;
+        }
+        return reward.giveRewardAsync(user, options);
     }
 
     public void giveReward(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -205,10 +205,33 @@ public class RewardExecutor {
         if (options.getAsyncReplayOccurrenceId() == null && activeOccurrenceId != null) {
             options.setAsyncReplayOccurrenceId(activeOccurrenceId);
         }
-        // Reward setup fires Bukkit events and resolves live player state. Keep that
-        // work on the caller's owner thread; individual injectors explicitly hand
-        // off only the portions that are safe to execute asynchronously.
-        return reward.giveRewardAsync(user, options);
+        // PlayerRewardEvent is explicitly asynchronous, so Bukkit rejects it when
+        // a nested reward reaches this dispatcher from an owner thread. Hand only
+        // reward setup to the async scheduler; injectors marshal their player/world
+        // work back to the appropriate owner thread and the flattened stage keeps
+        // the parent replay waiting for the complete child reward.
+        boolean primaryThread = false;
+        try {
+            primaryThread = Bukkit.isPrimaryThread();
+        } catch (IllegalStateException | NullPointerException ignored) {
+            // Unit tests and early bootstrap can call this facade before Bukkit has
+            // installed a server. There is no primary server thread to leave then.
+        }
+        if (!primaryThread) return reward.giveRewardAsync(user, options);
+
+        CompletableFuture<CompletionStage<Void>> handoff = new CompletableFuture<>();
+        try {
+            plugin.getBukkitScheduler().runTaskAsynchronously(plugin, () -> {
+                try {
+                    handoff.complete(reward.giveRewardAsync(user, options));
+                } catch (Throwable failure) {
+                    handoff.completeExceptionally(failure);
+                }
+            });
+        } catch (Throwable failure) {
+            handoff.completeExceptionally(failure);
+        }
+        return handoff.thenCompose(stage -> stage);
     }
 
     public void giveReward(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -3,6 +3,8 @@ package com.bencodez.advancedcore.api.rewards;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.Configuration;
@@ -101,6 +103,31 @@ public class RewardExecutor {
         }
     }
 
+    /**
+     * Asynchronous counterpart for nested rewards that must preserve injection
+     * ordering. The legacy void dispatch methods intentionally remain unchanged.
+     */
+    public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, ConfigurationSection data, String path,
+            RewardOptions rewardOptions) {
+        RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
+        RewardOptions options = context.getOptions();
+        if (path == null || data == null || !plugin.isEnabled()) return CompletableFuture.completedFuture(null);
+
+        if (data.isList(path)) {
+            CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+            for (String nestedReward : new ArrayList<>(data.getStringList(path))) {
+                sequence = sequence.thenCompose(ignored -> giveRewardAsync(user, nestedReward, options));
+            }
+            return sequence;
+        }
+        if (data.isConfigurationSection(path)) {
+            return giveSectionRewardAsync(user, data, path, context);
+        }
+        String nestedReward = data.getString(path, "");
+        return nestedReward.isEmpty() ? CompletableFuture.completedFuture(null)
+                : giveRewardAsync(user, nestedReward, options);
+    }
+
     public void giveReward(AdvancedCoreUser user, Reward reward, RewardOptions rewardOptions) {
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         if (reward == null) {
@@ -116,6 +143,12 @@ public class RewardExecutor {
         }
     }
 
+    public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, Reward reward, RewardOptions rewardOptions) {
+        if (reward == null || !plugin.isEnabled()) return CompletableFuture.completedFuture(null);
+        RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
+        return reward.giveRewardAsync(user, context.getOptions());
+    }
+
     public void giveReward(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {
         RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
         if (reward == null || reward.isEmpty()) {
@@ -128,6 +161,16 @@ public class RewardExecutor {
         }
 
         giveReward(user, handler.getReward(reward), context.getOptions());
+    }
+
+    public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {
+        RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
+        if (reward == null || reward.isEmpty()) return CompletableFuture.completedFuture(null);
+        if (reward.startsWith("/")) {
+            MiscUtils.getInstance().executeConsoleCommands(user.getPlayerName(), reward, context.getPlaceholders());
+            return CompletableFuture.completedFuture(null);
+        }
+        return giveRewardAsync(user, handler.getReward(reward), context.getOptions());
     }
 
     public void givePersistedQueueReward(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {
@@ -175,6 +218,43 @@ public class RewardExecutor {
             }
         }
         giveReward(user, resolved, context.getOptions());
+    }
+
+    /** Resolves and awaits a persisted queue item so a failed async injection can be requeued. */
+    public CompletionStage<Void> givePersistedQueueRewardAsync(AdvancedCoreUser user, String reward,
+            RewardOptions rewardOptions) {
+        RewardExecutionContext context = new RewardExecutionContext(rewardOptions).initializeOnlineState(user);
+        if (reward == null || reward.isEmpty()) return CompletableFuture.completedFuture(null);
+
+        String rewardName = reward;
+        Boolean generatedSnapshot = null;
+        if (reward.startsWith(QUEUED_REFERENCE_PREFIX)) {
+            String encoded = reward.substring(QUEUED_REFERENCE_PREFIX.length());
+            int modeEnd = encoded.indexOf('/');
+            if (modeEnd > 0) {
+                String mode = encoded.substring(0, modeEnd);
+                String encodedName = encoded.substring(modeEnd + 1);
+                if ((mode.equals("snapshot") || mode.equals("normal")) && !encodedName.isEmpty()) {
+                    try {
+                        rewardName = new String(Base64.getUrlDecoder().decode(encodedName), StandardCharsets.UTF_8);
+                        generatedSnapshot = Boolean.valueOf(mode.equals("snapshot"));
+                    } catch (IllegalArgumentException ignored) {
+                        rewardName = reward;
+                    }
+                }
+            }
+        }
+        Reward resolved;
+        if (generatedSnapshot != null) {
+            resolved = generatedSnapshot.booleanValue() ? handler.getQueuedGeneratedReward(rewardName, user.getUUID())
+                    : handler.getReward(rewardName);
+        } else if (handler.rewardExist(rewardName) || handler.hasDirectRewardHandle(rewardName)) {
+            resolved = handler.getReward(rewardName);
+        } else {
+            resolved = handler.getQueuedGeneratedReward(rewardName, user.getUUID());
+            if (resolved == null) resolved = handler.getReward(rewardName);
+        }
+        return giveRewardAsync(user, resolved, context.getOptions());
     }
 
     public void updateReward(Configuration data, String path, RewardOptions rewardOptions) {
@@ -227,5 +307,22 @@ public class RewardExecutor {
         plugin.debug("Giving reward " + path + ", Options: " + options + " to " + user.getPlayerName() + "/"
                 + user.getUUID());
         giveReward(user, reward, options);
+    }
+
+    private CompletionStage<Void> giveSectionRewardAsync(AdvancedCoreUser user, ConfigurationSection data, String path,
+            RewardExecutionContext context) {
+        RewardOptions options = context.getOptions();
+        String rewardName = context.buildRewardName(path);
+        DirectlyDefinedReward direct = handler.getDirectlyDefined(path);
+        SubDirectlyDefinedReward sub = handler.getSubDirectlyDefined(rewardName);
+        SubRewardResolver resolver = handler.getSubRewardResolver();
+        SubDirectlyDefinedReward fileSub = resolver == null ? null : resolver.getFileBackedSubReward(rewardName);
+        if (context.supportsDirectDispatch() && (direct != null || sub != null || fileSub != null)) {
+            Reward selected = direct != null ? direct.getReward() : (sub != null ? sub : fileSub).getReward();
+            return giveRewardAsync(user, selected, options);
+        }
+        Reward selected = new Reward(rewardName, data.getConfigurationSection(path));
+        selected.checkRewardFile();
+        return giveRewardAsync(user, selected, options);
     }
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardExecutor.java
@@ -143,7 +143,8 @@ public class RewardExecutor {
 								RewardOptions nestedOptions = options.copyForNestedDispatch(
 										stableParentReplayKey + "/" + nestedReward + ":" + nestedIndex);
 								nestedOptions.setAsyncReplayState(replayState);
-								return giveRewardAsync(user, nestedReward, nestedOptions).handle((childResult, failure) -> {
+								return Reward.continueOnServerThread(plugin, user,
+										() -> giveRewardAsync(user, nestedReward, nestedOptions)).handle((childResult, failure) -> {
 									// Child options stay isolated for normal placeholders. Replay
 									// markers are shared lazily so an earlier child remains durable
 									// when a later child fails and the list is restarted.

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardHandler.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardHandler.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -184,12 +185,25 @@ public class RewardHandler {
         rewardExecutor.giveReward(user, data, path, rewardOptions);
     }
 
+    public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, ConfigurationSection data, String path,
+            RewardOptions rewardOptions) {
+        return rewardExecutor.giveRewardAsync(user, data, path, rewardOptions);
+    }
+
     public void giveReward(AdvancedCoreUser user, Reward reward, RewardOptions rewardOptions) {
         rewardExecutor.giveReward(user, reward, rewardOptions);
     }
 
+    public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, Reward reward, RewardOptions rewardOptions) {
+        return rewardExecutor.giveRewardAsync(user, reward, rewardOptions);
+    }
+
     public void giveReward(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {
         rewardExecutor.giveReward(user, reward, rewardOptions);
+    }
+
+    public CompletionStage<Void> giveRewardAsync(AdvancedCoreUser user, String reward, RewardOptions rewardOptions) {
+        return rewardExecutor.giveRewardAsync(user, reward, rewardOptions);
     }
 
     public void givePersistedQueueReward(AdvancedCoreUser user, PersistedQueueReference rewardReference,
@@ -198,6 +212,14 @@ public class RewardHandler {
             return;
         }
         rewardExecutor.givePersistedQueueReward(user, rewardReference.getReference(), rewardOptions);
+    }
+
+    public CompletionStage<Void> givePersistedQueueRewardAsync(AdvancedCoreUser user,
+            PersistedQueueReference rewardReference, RewardOptions rewardOptions) {
+        if (rewardReference == null) {
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        }
+        return rewardExecutor.givePersistedQueueRewardAsync(user, rewardReference.getReference(), rewardOptions);
     }
 
     public boolean hasDirectRewardHandle(String reward) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardOptions.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardOptions.java
@@ -93,6 +93,11 @@ public class RewardOptions {
 	@Setter
 	private Consumer<Reward.ReplayCheckpoint> asyncReplayCheckpointConsumer;
 
+	/** True while replaying an entry that must remain in the timed queue on deferral. */
+	@Getter
+	@Setter
+	private boolean timedQueueReplay;
+
 	public RewardOptions() {
 	}
 
@@ -247,6 +252,7 @@ public class RewardOptions {
 		copy.setAsyncReplayKey(replayKey);
 		copy.setAsyncReplayOccurrenceId(asyncReplayOccurrenceId);
 		copy.setAsyncReplayCheckpointConsumer(asyncReplayCheckpointConsumer);
+		copy.setTimedQueueReplay(timedQueueReplay);
 		return copy;
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardOptions.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardOptions.java
@@ -61,6 +61,15 @@ public class RewardOptions {
 
 	@Getter
 	@Setter
+	private Map<String, String> asyncReplayRegistryFingerprints = new HashMap<>();
+
+	/** True when this queued entry used the old count-only replay format. */
+	@Getter
+	@Setter
+	private boolean legacyAsyncReplayCheckpoint;
+
+	@Getter
+	@Setter
 	private Reward.ReplayState asyncReplayState;
 
 	/**
@@ -70,6 +79,15 @@ public class RewardOptions {
 	@Getter
 	@Setter
 	private String asyncReplayKey;
+
+	/**
+	 * Stable identity for one logical queued reward occurrence. It is distinct
+	 * from {@link #asyncReplayKey}, which identifies a stage path shared by
+	 * independent executions of the same reward definition.
+	 */
+	@Getter
+	@Setter
+	private String asyncReplayOccurrenceId;
 
 	@Getter
 	@Setter
@@ -224,7 +242,10 @@ public class RewardOptions {
 		if (onlineSet) copy.setOnline(online);
 		if (!server.isEmpty()) copy.setServer(server);
 		copy.setAsyncReplayState(asyncReplayState);
+		copy.setAsyncReplayRegistryFingerprints(new HashMap<>(asyncReplayRegistryFingerprints));
+		copy.setLegacyAsyncReplayCheckpoint(legacyAsyncReplayCheckpoint);
 		copy.setAsyncReplayKey(replayKey);
+		copy.setAsyncReplayOccurrenceId(asyncReplayOccurrenceId);
 		copy.setAsyncReplayCheckpointConsumer(asyncReplayCheckpointConsumer);
 		return copy;
 	}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardOptions.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/RewardOptions.java
@@ -1,7 +1,9 @@
 package com.bencodez.advancedcore.api.rewards;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.simpleapi.array.ArrayUtils;
@@ -43,6 +45,35 @@ public class RewardOptions {
 
 	@Getter
 	private long orginalTrigger = -1;
+
+	/**
+	 * Number of completed injection stages recorded for a persisted replay. This
+	 * is intentionally internal queue metadata: normal reward dispatch always
+	 * starts at zero.
+	 */
+	@Getter
+	@Setter
+	private int completedAsyncInjections;
+
+	@Getter
+	@Setter
+	private Map<String, Integer> asyncReplayProgress = new HashMap<>();
+
+	@Getter
+	@Setter
+	private Reward.ReplayState asyncReplayState;
+
+	/**
+	 * Stable execution path for a nested asynchronous reward. The path is queue
+	 * metadata only; callers that do not participate in replay leave it unset.
+	 */
+	@Getter
+	@Setter
+	private String asyncReplayKey;
+
+	@Getter
+	@Setter
+	private Consumer<Reward.ReplayCheckpoint> asyncReplayCheckpointConsumer;
 
 	public RewardOptions() {
 	}
@@ -177,6 +208,25 @@ public class RewardOptions {
 			placeholders.put(entry.getKey(), entry.getValue());
 		}
 		return this;
+	}
+
+	/**
+	 * Makes an isolated option object for one member of an asynchronously
+	 * dispatched list. Mutable placeholders and replay metadata must not leak
+	 * from one list member into the next.
+	 */
+	RewardOptions copyForNestedDispatch(String replayKey) {
+		RewardOptions copy = new RewardOptions().setCheckTimed(checkTimed).setGiveOffline(giveOffline)
+				.setIgnoreChance(ignoreChance).setIgnoreRequirements(ignoreRequirements).setPrefix(prefix).setSuffix(suffix)
+				.orginalTrigger(orginalTrigger).setPlaceholders(new HashMap<>(placeholders));
+		if (forceOffline) copy.forceOffline();
+		if (!useDefaultWorlds) copy.disableDefaultWorlds();
+		if (onlineSet) copy.setOnline(online);
+		if (!server.isEmpty()) copy.setServer(server);
+		copy.setAsyncReplayState(asyncReplayState);
+		copy.setAsyncReplayKey(replayKey);
+		copy.setAsyncReplayCheckpointConsumer(asyncReplayCheckpointConsumer);
+		return copy;
 	}
 
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardActionBar.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardActionBar.java
@@ -34,7 +34,7 @@ public final class RewardActionBar {
                         section.getInt("Delay", 30));
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueInventory("ActionBar") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueInventory("ActionBar") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
@@ -2,6 +2,8 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -29,6 +31,15 @@ public final class RewardAdvancedPriority {
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("AdvancedPriority") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
+            @Override
             public String onRewardRequested(Reward sourceReward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
                 for (String key : section.getKeys(false)) {
@@ -44,6 +55,30 @@ public final class RewardAdvancedPriority {
                     plugin.extraDebug("AdvancedPriority: Can't give reward " + key);
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward sourceReward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+				String selectedKey = Reward.replaySelection(placeholders, () -> {
+                for (String key : section.getKeys(false)) {
+                    RewardOptions namingOptions = new RewardOptions()
+                            .setPrefix(sourceReward.getName() + "_AdvancedPriority");
+                    Reward reward = handler.getReward(section, key, namingOptions);
+                    if (reward != null && reward.canGiveReward(user,
+                            new RewardOptions().withPlaceHolder(placeholders))) {
+						return key;
+                    }
+                }
+					return null;
+				});
+				if (selectedKey == null) return CompletableFuture.completedFuture(null);
+				Reward selected = handler.getReward(section, selectedKey, new RewardOptions()
+						.setPrefix(sourceReward.getName() + "_AdvancedPriority"));
+				return selected == null ? CompletableFuture.completedFuture(null)
+						: handler.giveRewardAsync(user, selected, new RewardOptions().setIgnoreChance(true)
+								.setIgnoreRequirements(true).setPrefix(sourceReward.getName() + "_AdvancedPriority")
+								.withPlaceHolder(placeholders)).thenApply(ignored -> selected.getName());
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
@@ -36,6 +36,11 @@ public final class RewardAdvancedPriority {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -79,8 +84,11 @@ public final class RewardAdvancedPriority {
 						.setIgnoreRequirements(true).setPrefix(sourceReward.getName() + "_AdvancedPriority")
 						.withPlaceHolder(placeholders), Reward.currentReplayState(), Reward.currentReplayKey(),
 						"selected:" + selectedKey, Reward.currentReplayOccurrenceId());
-				return selected == null ? CompletableFuture.completedFuture(null)
-						: handler.giveRewardAsync(user, selected, childOptions).thenApply(ignored -> selected.getName());
+				if (selected == null) return CompletableFuture.failedFuture(
+						new IllegalStateException("Selected advanced priority reward could not be resolved: " + selectedKey));
+				return Reward.persistReplayMetadataAsync(plugin, placeholders)
+						.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+						.thenApply(ignored -> selected.getName());
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
@@ -87,7 +87,8 @@ public final class RewardAdvancedPriority {
 				if (selected == null) return CompletableFuture.failedFuture(
 						new IllegalStateException("Selected advanced priority reward could not be resolved: " + selectedKey));
 				return Reward.persistReplayMetadataAsync(plugin, placeholders)
-						.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+						.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> handler.giveRewardAsync(user, selected, childOptions)))
 						.thenApply(ignored -> selected.getName());
             }
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedPriority.java
@@ -75,10 +75,12 @@ public final class RewardAdvancedPriority {
 				if (selectedKey == null) return CompletableFuture.completedFuture(null);
 				Reward selected = handler.getReward(section, selectedKey, new RewardOptions()
 						.setPrefix(sourceReward.getName() + "_AdvancedPriority"));
+				RewardOptions childOptions = Reward.withReplayState(new RewardOptions().setIgnoreChance(true)
+						.setIgnoreRequirements(true).setPrefix(sourceReward.getName() + "_AdvancedPriority")
+						.withPlaceHolder(placeholders), Reward.currentReplayState(), Reward.currentReplayKey(),
+						"selected:" + selectedKey, Reward.currentReplayOccurrenceId());
 				return selected == null ? CompletableFuture.completedFuture(null)
-						: handler.giveRewardAsync(user, selected, new RewardOptions().setIgnoreChance(true)
-								.setIgnoreRequirements(true).setPrefix(sourceReward.getName() + "_AdvancedPriority")
-								.withPlaceHolder(placeholders)).thenApply(ignored -> selected.getName());
+						: handler.giveRewardAsync(user, selected, childOptions).thenApply(ignored -> selected.getName());
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -32,6 +34,15 @@ public final class RewardAdvancedRandomReward {
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("AdvancedRandomReward") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
+            @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
                 Set<String> keys = section.getKeys(false);
@@ -43,6 +54,17 @@ public final class RewardAdvancedRandomReward {
                     return selected;
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+                ArrayList<String> rewards = ArrayUtils.convert(section.getKeys(false));
+                if (rewards.isEmpty()) return CompletableFuture.completedFuture(null);
+                String selected = Reward.replaySelection(placeholders,
+                        () -> rewards.get(ThreadLocalRandom.current().nextInt(rewards.size())));
+                return handler.giveRewardAsync(user, section, selected, new RewardOptions().setPlaceholders(placeholders)
+                        .setPrefix(reward.getRewardName() + "_AdvancedRandomReward")).thenApply(ignored -> selected);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
@@ -63,8 +63,11 @@ public final class RewardAdvancedRandomReward {
                 if (rewards.isEmpty()) return CompletableFuture.completedFuture(null);
                 String selected = Reward.replaySelection(placeholders,
                         () -> rewards.get(ThreadLocalRandom.current().nextInt(rewards.size())));
-                return handler.giveRewardAsync(user, section, selected, new RewardOptions().setPlaceholders(placeholders)
-                        .setPrefix(reward.getRewardName() + "_AdvancedRandomReward")).thenApply(ignored -> selected);
+                RewardOptions childOptions = Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders),
+                        Reward.currentReplayState(), Reward.currentReplayKey(), "selected:" + selected,
+                        Reward.currentReplayOccurrenceId())
+                        .setPrefix(reward.getRewardName() + "_AdvancedRandomReward");
+                return handler.giveRewardAsync(user, section, selected, childOptions).thenApply(ignored -> selected);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
@@ -75,7 +75,8 @@ public final class RewardAdvancedRandomReward {
                         Reward.currentReplayOccurrenceId())
                         .setPrefix(reward.getRewardName() + "_AdvancedRandomReward");
 				return Reward.persistReplayMetadataAsync(plugin, placeholders)
-						.thenCompose(ignored -> handler.giveRewardAsync(user, section, selected, childOptions))
+						.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> handler.giveRewardAsync(user, section, selected, childOptions)))
 						.thenApply(ignored -> selected);
             }
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRandomReward.java
@@ -39,6 +39,11 @@ public final class RewardAdvancedRandomReward {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -58,16 +63,20 @@ public final class RewardAdvancedRandomReward {
 
             @Override
             public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
-                    ConfigurationSection section, HashMap<String, String> placeholders) {
-                ArrayList<String> rewards = ArrayUtils.convert(section.getKeys(false));
-                if (rewards.isEmpty()) return CompletableFuture.completedFuture(null);
+					ConfigurationSection section, HashMap<String, String> placeholders) {
+				ArrayList<String> rewards = ArrayUtils.convert(section.getKeys(false));
+				if (rewards.isEmpty() && !hasPendingReplayWork(placeholders)) {
+					return CompletableFuture.completedFuture(null);
+				}
                 String selected = Reward.replaySelection(placeholders,
                         () -> rewards.get(ThreadLocalRandom.current().nextInt(rewards.size())));
                 RewardOptions childOptions = Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders),
                         Reward.currentReplayState(), Reward.currentReplayKey(), "selected:" + selected,
                         Reward.currentReplayOccurrenceId())
                         .setPrefix(reward.getRewardName() + "_AdvancedRandomReward");
-                return handler.giveRewardAsync(user, section, selected, childOptions).thenApply(ignored -> selected);
+				return Reward.persistReplayMetadataAsync(plugin, placeholders)
+						.thenCompose(ignored -> handler.giveRewardAsync(user, section, selected, childOptions))
+						.thenApply(ignored -> selected);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
@@ -43,6 +43,11 @@ public final class RewardAdvancedRewards {
 			}
 
 			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayNestedRewardSnapshot(placeholders, "advanced-rewards:" + getPath());
+			}
+
+			@Override
 			public boolean supportsAsyncSynchronization() {
 				// This injector awaits nested rewards, which can invoke this same
 				// shared instance. Serializing that recursive chain would deadlock.
@@ -66,23 +71,36 @@ public final class RewardAdvancedRewards {
 					ConfigurationSection data, HashMap<String, String> placeholders) {
 				if (!data.isConfigurationSection(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true))
 						&& !isAlwaysForceNoData()) {
-					return CompletableFuture.completedFuture(null);
+					return hasPendingReplayWork(placeholders)
+							? CompletableFuture.failedFuture(new IllegalStateException(
+									"Pending reward replay configuration is missing: " + getPath()))
+							: CompletableFuture.completedFuture(null);
 				}
-				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
 				String parentReplayKey = Reward.currentReplayKey();
 				String parentOccurrenceId = Reward.currentReplayOccurrenceId();
-				int rewardIndex = 0;
-				for (String rewardName : ArrayUtils.convert(data.getConfigurationSection(getPath()).getKeys(false))) {
-					final int childIndex = rewardIndex++;
-					sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user,
-							data.getConfigurationSection(getPath()), rewardName,
-							Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders), replayState,
-									parentReplayKey,
-									rewardName + ":" + childIndex, parentOccurrenceId)
-									.setPrefix(reward.getRewardName() + "_AdvancedRewards")));
-				}
-				return sequence.thenApply(ignored -> null);
+				ConfigurationSection section = data.getConfigurationSection(getPath());
+				ArrayList<String> configured = ArrayUtils.convert(section.getKeys(false));
+				return Reward.replayNestedRewardSnapshot(plugin, placeholders, "advanced-rewards:" + getPath(),
+						configured, replayState, parentReplayKey).thenCompose(rewards -> {
+					for (String rewardName : rewards) {
+						if (!section.contains(rewardName, true)) {
+							return CompletableFuture.failedFuture(new IllegalStateException(
+									"Pending nested reward configuration is missing: " + rewardName));
+						}
+					}
+					CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+					for (int index = 0; index < rewards.size(); index++) {
+						String rewardName = rewards.get(index);
+						int childIndex = index;
+						sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user,
+								section, rewardName,
+								Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders), replayState,
+										parentReplayKey, rewardName + ":" + childIndex, parentOccurrenceId)
+										.setPrefix(reward.getRewardName() + "_AdvancedRewards")));
+					}
+					return sequence.thenApply(ignored -> (Object) null);
+				});
 			}
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
@@ -69,10 +69,16 @@ public final class RewardAdvancedRewards {
 					return CompletableFuture.completedFuture(null);
 				}
 				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
+				String parentReplayKey = Reward.currentReplayKey();
+				int rewardIndex = 0;
 				for (String rewardName : ArrayUtils.convert(data.getConfigurationSection(getPath()).getKeys(false))) {
+					final int childIndex = rewardIndex++;
 					sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user,
 							data.getConfigurationSection(getPath()), rewardName,
-							new RewardOptions().setPlaceholders(placeholders)
+							Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders), replayState,
+									parentReplayKey,
+									rewardName + ":" + childIndex)
 									.setPrefix(reward.getRewardName() + "_AdvancedRewards")));
 				}
 				return sequence.thenApply(ignored -> null);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
@@ -93,11 +93,11 @@ public final class RewardAdvancedRewards {
 					for (int index = 0; index < rewards.size(); index++) {
 						String rewardName = rewards.get(index);
 						int childIndex = index;
-						sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user,
-								section, rewardName,
-								Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders), replayState,
-										parentReplayKey, rewardName + ":" + childIndex, parentOccurrenceId)
-										.setPrefix(reward.getRewardName() + "_AdvancedRewards")));
+						sequence = sequence.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> handler.giveRewardAsync(user, section, rewardName,
+										Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders), replayState,
+												parentReplayKey, rewardName + ":" + childIndex, parentOccurrenceId)
+												.setPrefix(reward.getRewardName() + "_AdvancedRewards"))));
 					}
 					return sequence.thenApply(ignored -> (Object) null);
 				});

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
@@ -71,6 +71,7 @@ public final class RewardAdvancedRewards {
 				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
 				String parentReplayKey = Reward.currentReplayKey();
+				String parentOccurrenceId = Reward.currentReplayOccurrenceId();
 				int rewardIndex = 0;
 				for (String rewardName : ArrayUtils.convert(data.getConfigurationSection(getPath()).getKeys(false))) {
 					final int childIndex = rewardIndex++;
@@ -78,7 +79,7 @@ public final class RewardAdvancedRewards {
 							data.getConfigurationSection(getPath()), rewardName,
 							Reward.withReplayState(new RewardOptions().setPlaceholders(placeholders), replayState,
 									parentReplayKey,
-									rewardName + ":" + childIndex)
+									rewardName + ":" + childIndex, parentOccurrenceId)
 									.setPrefix(reward.getRewardName() + "_AdvancedRewards")));
 				}
 				return sequence.thenApply(ignored -> null);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedRewards.java
@@ -3,6 +3,8 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -30,6 +32,23 @@ public final class RewardAdvancedRewards {
 
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("AdvancedRewards") {
+			@Override
+			public boolean supportsAsyncRequest() {
+				return true;
+			}
+
+			@Override
+			public boolean requiresConfiguredDataForAsync() {
+				return true;
+			}
+
+			@Override
+			public boolean supportsAsyncSynchronization() {
+				// This injector awaits nested rewards, which can invoke this same
+				// shared instance. Serializing that recursive chain would deadlock.
+				return false;
+			}
+
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
@@ -41,6 +60,23 @@ public final class RewardAdvancedRewards {
                 }
                 return null;
             }
+
+			@Override
+			public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+					ConfigurationSection data, HashMap<String, String> placeholders) {
+				if (!data.isConfigurationSection(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true))
+						&& !isAlwaysForceNoData()) {
+					return CompletableFuture.completedFuture(null);
+				}
+				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+				for (String rewardName : ArrayUtils.convert(data.getConfigurationSection(getPath()).getKeys(false))) {
+					sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user,
+							data.getConfigurationSection(getPath()), rewardName,
+							new RewardOptions().setPlaceholders(placeholders)
+									.setPrefix(reward.getRewardName() + "_AdvancedRewards")));
+				}
+				return sequence.thenApply(ignored -> null);
+			}
 
             @Override
             public ArrayList<SubDirectlyDefinedReward> subRewards(DefinedReward direct) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
@@ -76,10 +76,11 @@ public final class RewardAdvancedWorld {
 						String key = worlds.get(index);
 						int childIndex = index;
 						section.set(key + ".Worlds", ArrayUtils.convert(new String[] { key }));
-						sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user, section, key,
-								Reward.withReplayState(new RewardOptions().withPlaceHolder(placeholders), replayState,
-										parentReplayKey, key + ":" + childIndex, parentOccurrenceId)
-										.setPrefix(sourceReward.getRewardName() + "_AdvancedWorld")));
+						sequence = sequence.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> handler.giveRewardAsync(user, section, key,
+										Reward.withReplayState(new RewardOptions().withPlaceHolder(placeholders), replayState,
+												parentReplayKey, key + ":" + childIndex, parentOccurrenceId)
+												.setPrefix(sourceReward.getRewardName() + "_AdvancedWorld"))));
 					}
 					return sequence.thenApply(ignored -> (String) null);
 				});

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
@@ -64,7 +64,8 @@ public final class RewardAdvancedWorld {
 				String parentReplayKey = Reward.currentReplayKey();
 				String parentOccurrenceId = Reward.currentReplayOccurrenceId();
 				return Reward.replayNestedRewardSnapshot(plugin, placeholders, "advanced-world:" + getPath(),
-						new ArrayList<>(section.getKeys(false)), replayState, parentReplayKey).thenCompose(worlds -> {
+						new ArrayList<>(section.getKeys(false)), replayState, parentReplayKey)
+						.thenCompose(worlds -> Reward.continueOnServerThread(plugin, user, () -> {
 					for (String key : worlds) {
 						if (!section.contains(key, true)) {
 							return CompletableFuture.failedFuture(new IllegalStateException(
@@ -83,7 +84,7 @@ public final class RewardAdvancedWorld {
 												.setPrefix(sourceReward.getRewardName() + "_AdvancedWorld"))));
 					}
 					return sequence.thenApply(ignored -> (String) null);
-				});
+				}));
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
@@ -2,6 +2,8 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -30,15 +32,43 @@ public final class RewardAdvancedWorld {
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("AdvancedWorld") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
+            @Override
             public String onRewardRequested(Reward sourceReward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
-                for (String key : section.getKeys(false)) {
+				for (String key : section.getKeys(false)) {
                     plugin.extraDebug("AdvancedWorld: Giving reward " + sourceReward.getName() + "_AdvancedWorld");
                     section.set(key + ".Worlds", ArrayUtils.convert(new String[] { key }));
                     handler.giveReward(user, section, key, new RewardOptions().withPlaceHolder(placeholders)
                             .setPrefix(sourceReward.getName() + "_AdvancedWorld"));
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward sourceReward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
+				String parentReplayKey = Reward.currentReplayKey();
+				int worldIndex = 0;
+                for (String key : section.getKeys(false)) {
+					final int childIndex = worldIndex++;
+                    section.set(key + ".Worlds", ArrayUtils.convert(new String[] { key }));
+                    sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user, section, key,
+							Reward.withReplayState(new RewardOptions().withPlaceHolder(placeholders), replayState,
+									parentReplayKey,
+									key + ":" + childIndex)
+                                    .setPrefix(sourceReward.getRewardName() + "_AdvancedWorld")));
+                }
+                return sequence.thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
@@ -37,6 +37,11 @@ public final class RewardAdvancedWorld {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayNestedRewardSnapshot(placeholders, "advanced-world:" + getPath());
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -55,21 +60,29 @@ public final class RewardAdvancedWorld {
             @Override
             public CompletionStage<String> onRewardRequestedAsync(Reward sourceReward, AdvancedCoreUser user,
                     ConfigurationSection section, HashMap<String, String> placeholders) {
-				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
 				String parentReplayKey = Reward.currentReplayKey();
 				String parentOccurrenceId = Reward.currentReplayOccurrenceId();
-				int worldIndex = 0;
-                for (String key : section.getKeys(false)) {
-					final int childIndex = worldIndex++;
-                    section.set(key + ".Worlds", ArrayUtils.convert(new String[] { key }));
-                    sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user, section, key,
-							Reward.withReplayState(new RewardOptions().withPlaceHolder(placeholders), replayState,
-									parentReplayKey,
-									key + ":" + childIndex, parentOccurrenceId)
-                                    .setPrefix(sourceReward.getRewardName() + "_AdvancedWorld")));
-                }
-                return sequence.thenApply(ignored -> null);
+				return Reward.replayNestedRewardSnapshot(plugin, placeholders, "advanced-world:" + getPath(),
+						new ArrayList<>(section.getKeys(false)), replayState, parentReplayKey).thenCompose(worlds -> {
+					for (String key : worlds) {
+						if (!section.contains(key, true)) {
+							return CompletableFuture.failedFuture(new IllegalStateException(
+									"Pending nested reward configuration is missing: " + key));
+						}
+					}
+					CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+					for (int index = 0; index < worlds.size(); index++) {
+						String key = worlds.get(index);
+						int childIndex = index;
+						section.set(key + ".Worlds", ArrayUtils.convert(new String[] { key }));
+						sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user, section, key,
+								Reward.withReplayState(new RewardOptions().withPlaceHolder(placeholders), replayState,
+										parentReplayKey, key + ":" + childIndex, parentOccurrenceId)
+										.setPrefix(sourceReward.getRewardName() + "_AdvancedWorld")));
+					}
+					return sequence.thenApply(ignored -> (String) null);
+				});
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardAdvancedWorld.java
@@ -58,6 +58,7 @@ public final class RewardAdvancedWorld {
 				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
 				String parentReplayKey = Reward.currentReplayKey();
+				String parentOccurrenceId = Reward.currentReplayOccurrenceId();
 				int worldIndex = 0;
                 for (String key : section.getKeys(false)) {
 					final int childIndex = worldIndex++;
@@ -65,7 +66,7 @@ public final class RewardAdvancedWorld {
                     sequence = sequence.thenCompose(ignored -> handler.giveRewardAsync(user, section, key,
 							Reward.withReplayState(new RewardOptions().withPlaceHolder(placeholders), replayState,
 									parentReplayKey,
-									key + ":" + childIndex)
+									key + ":" + childIndex, parentOccurrenceId)
                                     .setPrefix(sourceReward.getRewardName() + "_AdvancedWorld")));
                 }
                 return sequence.thenApply(ignored -> null);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardBossBar.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardBossBar.java
@@ -34,7 +34,7 @@ public final class RewardBossBar {
                 }
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder("DRAGON_HEAD"), new EditGUIValueInventory("BossBar") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder("DRAGON_HEAD"), new EditGUIValueInventory("BossBar") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
@@ -69,8 +69,10 @@ public final class RewardChoices {
 				String choice = Reward.replaySelection(placeholders,
 						() -> value ? user.getChoicePreference(reward.getName()) : null);
 				if (choice == null || choice.isEmpty() || choice.equalsIgnoreCase("none")) {
-					user.addUnClaimedChoiceReward(reward.getName());
-					return CompletableFuture.completedFuture(null);
+					return Reward.persistReplayMetadataAsync(plugin, placeholders).thenApply(ignored -> {
+						user.addUnClaimedChoiceReward(reward.getName());
+						return null;
+					});
 				}
 				RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(),
 						reward.getConfig().getChoicesRewardsPath(choice)).withPrefix(reward.getName())

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
@@ -70,10 +70,11 @@ public final class RewardChoices {
 				String choice = Reward.replaySelection(placeholders,
 						() -> value ? user.getChoicePreference(reward.getName()) : null);
 				if (choice == null || choice.isEmpty() || choice.equalsIgnoreCase("none")) {
-					return Reward.persistReplayMetadataAsync(plugin, placeholders).thenApply(ignored -> {
-						user.addUnClaimedChoiceReward(reward.getName(), occurrenceId);
-						return null;
-					});
+					return Reward.persistReplayMetadataAsync(plugin, placeholders)
+							.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user, () -> {
+								user.addUnClaimedChoiceReward(reward.getName(), occurrenceId);
+								return CompletableFuture.completedFuture(null);
+							}));
 				}
 				RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(),
 						reward.getConfig().getChoicesRewardsPath(choice)).withPrefix(reward.getName())
@@ -81,7 +82,8 @@ public final class RewardChoices {
 				Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
 						Reward.currentReplayKey(), "choice:" + choice, Reward.currentReplayOccurrenceId());
 				return Reward.persistReplayMetadataAsync(plugin, placeholders)
-						.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> choice);
+						.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> builder.sendAsync(user))).thenApply(ignored -> choice);
 			}
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
@@ -2,6 +2,8 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -13,6 +15,7 @@ import com.bencodez.advancedcore.api.inventory.editgui.valuetypes.EditGUIValueIn
 import com.bencodez.advancedcore.api.item.ItemBuilder;
 import com.bencodez.advancedcore.api.rewards.DefinedReward;
 import com.bencodez.advancedcore.api.rewards.Reward;
+import com.bencodez.advancedcore.api.rewards.RewardBuilder;
 import com.bencodez.advancedcore.api.rewards.RewardEditData;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.SubDirectlyDefinedReward;
@@ -29,6 +32,20 @@ public final class RewardChoices {
 
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectBoolean("EnableChoices") {
+			@Override
+			public boolean supportsAsyncRequest() { return true; }
+
+			@Override
+			public boolean requiresConfiguredDataForAsync() { return true; }
+
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
+			@Override
+			public boolean supportsAsyncSynchronization() { return false; }
+
             @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, boolean value,
                     HashMap<String, String> placeholders) {
@@ -44,6 +61,25 @@ public final class RewardChoices {
                 }
                 return null;
             }
+
+			@Override
+			public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user, boolean value,
+					HashMap<String, String> placeholders) {
+				if (!value && !hasPendingReplayWork(placeholders)) return CompletableFuture.completedFuture(null);
+				String choice = Reward.replaySelection(placeholders,
+						() -> value ? user.getChoicePreference(reward.getName()) : null);
+				if (choice == null || choice.isEmpty() || choice.equalsIgnoreCase("none")) {
+					user.addUnClaimedChoiceReward(reward.getName());
+					return CompletableFuture.completedFuture(null);
+				}
+				RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(),
+						reward.getConfig().getChoicesRewardsPath(choice)).withPrefix(reward.getName())
+						.withPlaceHolder(placeholders).withPlaceHolder("choice", choice);
+				Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
+						Reward.currentReplayKey(), "choice:" + choice, Reward.currentReplayOccurrenceId());
+				return Reward.persistReplayMetadataAsync(plugin, placeholders)
+						.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> choice);
+			}
 
             @Override
             public ArrayList<SubDirectlyDefinedReward> subRewards(DefinedReward direct) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardChoices.java
@@ -66,11 +66,12 @@ public final class RewardChoices {
 			public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user, boolean value,
 					HashMap<String, String> placeholders) {
 				if (!value && !hasPendingReplayWork(placeholders)) return CompletableFuture.completedFuture(null);
+				String occurrenceId = Reward.currentReplayOccurrenceId();
 				String choice = Reward.replaySelection(placeholders,
 						() -> value ? user.getChoicePreference(reward.getName()) : null);
 				if (choice == null || choice.isEmpty() || choice.equalsIgnoreCase("none")) {
 					return Reward.persistReplayMetadataAsync(plugin, placeholders).thenApply(ignored -> {
-						user.addUnClaimedChoiceReward(reward.getName());
+						user.addUnClaimedChoiceReward(reward.getName(), occurrenceId);
 						return null;
 					});
 				}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
@@ -212,13 +212,14 @@ public final class RewardCommands {
                     ConfigurationSection section, HashMap<String, String> placeholders) {
                 ArrayList<String> consoleCommands = (ArrayList<String>) section.getList("Console", new ArrayList<>());
                 ArrayList<String> userCommands = (ArrayList<String>) section.getList("Player", new ArrayList<>());
-                CompletionStage<Void> player = user.preformCommandAsync(userCommands, placeholders);
-                // Player availability is a prerequisite for the mixed section. Do not
-                // schedule console side effects until that prerequisite has completed,
-                // otherwise a disconnect can fail the replay after grants already ran.
-				return player.thenCompose(ignored -> consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
+				CompletionStage<Void> availability = userCommands.isEmpty() ? CompletableFuture.completedFuture(null)
+						: user.validatePlayerCommandAvailabilityAsync();
+				// Validate the player before any mixed-section side effect, then preserve
+				// the established console-before-player command order.
+				return availability.thenCompose(ignored -> consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
 						: MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), consoleCommands,
 								placeholders, section.getBoolean("Stagger", true)))
+						.thenCompose(ignored -> user.preformCommandAsync(userCommands, placeholders))
                         .thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("Commands.Console", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
@@ -212,11 +212,13 @@ public final class RewardCommands {
                     ConfigurationSection section, HashMap<String, String> placeholders) {
                 ArrayList<String> consoleCommands = (ArrayList<String>) section.getList("Console", new ArrayList<>());
                 ArrayList<String> userCommands = (ArrayList<String>) section.getList("Player", new ArrayList<>());
-                CompletionStage<Void> console = consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
-                        : MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), consoleCommands,
-                                placeholders, section.getBoolean("Stagger", true));
                 CompletionStage<Void> player = user.preformCommandAsync(userCommands, placeholders);
-                return CompletableFuture.allOf(console.toCompletableFuture(), player.toCompletableFuture())
+                // Player availability is a prerequisite for the mixed section. Do not
+                // schedule console side effects until that prerequisite has completed,
+                // otherwise a disconnect can fail the replay after grants already ran.
+                return player.thenCompose(ignored -> consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
+                        : MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), consoleCommands,
+                                placeholders, section.getBoolean("Stagger", true)))
                         .thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("Commands.Console", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
@@ -155,8 +155,8 @@ public final class RewardCommands {
             @Override
             public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
                     ArrayList<String> list, HashMap<String, String> placeholders) {
-                return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), list, placeholders, true)
-                        .thenApply(ignored -> null);
+				return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), list, placeholders, true)
+						.thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder("COMMAND_BLOCK"), new EditGUIValueList("Commands", null) {
             @Override
@@ -216,9 +216,9 @@ public final class RewardCommands {
                 // Player availability is a prerequisite for the mixed section. Do not
                 // schedule console side effects until that prerequisite has completed,
                 // otherwise a disconnect can fail the replay after grants already ran.
-                return player.thenCompose(ignored -> consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
-                        : MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), consoleCommands,
-                                placeholders, section.getBoolean("Stagger", true)))
+				return player.thenCompose(ignored -> consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
+						: MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), consoleCommands,
+								placeholders, section.getBoolean("Stagger", true)))
                         .thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("Commands.Console", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
@@ -3,6 +3,8 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Material;
@@ -45,6 +47,12 @@ public final class RewardCommands {
     public static void registerNumberCommand(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("NumberCommand") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
                 int min = section.getInt("Min", 0);
@@ -53,6 +61,19 @@ public final class RewardCommands {
                 String command = section.getString("Command", "").replace("%number%", String.valueOf(number));
                 MiscUtils.getInstance().executeConsoleCommands(user.getPlayerName(), command, placeholders);
                 return String.valueOf(number);
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+                int min = section.getInt("Min", 0);
+                int max = section.getInt("Max", 100);
+                String number = Reward.replaySelection(placeholders,
+                        () -> String.valueOf(ThreadLocalRandom.current().nextInt(min, max + 1)));
+                if (number == null) return CompletableFuture.completedFuture(null);
+                String command = section.getString("Command", "").replace("%number%", number);
+                return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), command, placeholders)
+                        .thenApply(ignored -> number);
             }
         }.asPlaceholder("Number").priority(100).validator(new RewardInjectValidator() {
             @Override
@@ -77,10 +98,23 @@ public final class RewardCommands {
     public static void registerCommand(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectString("Command") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, String value,
                     HashMap<String, String> placeholders) {
                 MiscUtils.getInstance().executeConsoleCommands(user.getPlayerName(), value, placeholders);
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user, String value,
+                    HashMap<String, String> placeholders) {
+                return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), value, placeholders)
+                        .thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder("COMMAND_BLOCK"), new EditGUIValueString("Command", null) {
             @Override
@@ -104,12 +138,25 @@ public final class RewardCommands {
     public static void registerCommands(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectStringList("Commands") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> list,
                     HashMap<String, String> placeholders) {
                 if (!list.isEmpty()) {
                     MiscUtils.getInstance().executeConsoleCommands(user.getPlayerName(), list, placeholders, true);
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+                    ArrayList<String> list, HashMap<String, String> placeholders) {
+                return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), list, placeholders, true)
+                        .thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder("COMMAND_BLOCK"), new EditGUIValueList("Commands", null) {
             @Override
@@ -137,6 +184,12 @@ public final class RewardCommands {
         }));
 
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("Commands") {
+            @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
             @SuppressWarnings("unchecked")
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
@@ -151,6 +204,20 @@ public final class RewardCommands {
                     user.preformCommand(userCommands, placeholders);
                 }
                 return null;
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+                ArrayList<String> consoleCommands = (ArrayList<String>) section.getList("Console", new ArrayList<>());
+                ArrayList<String> userCommands = (ArrayList<String>) section.getList("Player", new ArrayList<>());
+                CompletionStage<Void> console = consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
+                        : MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), consoleCommands,
+                                placeholders, section.getBoolean("Stagger", true));
+                CompletionStage<Void> player = user.preformCommandAsync(userCommands, placeholders);
+                return CompletableFuture.allOf(console.toCompletableFuture(), player.toCompletableFuture())
+                        .thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("Commands.Console", null) {
             @Override
@@ -175,6 +242,12 @@ public final class RewardCommands {
     public static void registerRandomCommand(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectStringList("RandomCommand") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> list,
                     HashMap<String, String> placeholders) {
                 if (!list.isEmpty()) {
@@ -182,6 +255,16 @@ public final class RewardCommands {
                             list.get(ThreadLocalRandom.current().nextInt(list.size())), placeholders);
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+                ArrayList<String> list, HashMap<String, String> placeholders) {
+                if (list.isEmpty()) return CompletableFuture.completedFuture(null);
+                String command = Reward.replaySelection(placeholders,
+                        () -> list.get(ThreadLocalRandom.current().nextInt(list.size())));
+                return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), command, placeholders)
+                        .thenApply(ignored -> null);
             }
         }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("RandomCommand", null) {
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardCommands.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
@@ -51,6 +52,18 @@ public final class RewardCommands {
 
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
+
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayCommandSnapshot(placeholders, "console");
+			}
+
+			@Override
+			protected CompletionStage<Object> onMissingConfiguredDataAsync(Reward reward, AdvancedCoreUser user,
+					HashMap<String, String> placeholders) {
+				return onRewardRequestedAsync(reward, user, new YamlConfiguration(), placeholders)
+						.thenApply(result -> result);
+			}
 
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
@@ -103,6 +116,11 @@ public final class RewardCommands {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayCommandSnapshot(placeholders, "console");
+			}
+
             @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, String value,
                     HashMap<String, String> placeholders) {
@@ -142,6 +160,11 @@ public final class RewardCommands {
 
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
+
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayCommandSnapshot(placeholders, "console");
+			}
 
             @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> list,
@@ -190,6 +213,19 @@ public final class RewardCommands {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayCommandSnapshot(placeholders, "console")
+						|| Reward.hasReplayCommandSnapshot(placeholders, "player");
+			}
+
+			@Override
+			protected CompletionStage<Object> onMissingConfiguredDataAsync(Reward reward, AdvancedCoreUser user,
+					HashMap<String, String> placeholders) {
+				return onRewardRequestedAsync(reward, user, new YamlConfiguration(), placeholders)
+						.thenApply(result -> result);
+			}
+
             @SuppressWarnings("unchecked")
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
@@ -212,13 +248,18 @@ public final class RewardCommands {
                     ConfigurationSection section, HashMap<String, String> placeholders) {
                 ArrayList<String> consoleCommands = (ArrayList<String>) section.getList("Console", new ArrayList<>());
                 ArrayList<String> userCommands = (ArrayList<String>) section.getList("Player", new ArrayList<>());
-				CompletionStage<Void> availability = userCommands.isEmpty() ? CompletableFuture.completedFuture(null)
+				boolean stagger = section.getBoolean("Stagger", true);
+				CompletionStage<Void> availability = userCommands.isEmpty()
+						&& !Reward.hasReplayCommandSnapshot(placeholders, "player")
+						? CompletableFuture.completedFuture(null)
 						: user.validatePlayerCommandAvailabilityAsync();
 				// Validate the player before any mixed-section side effect, then preserve
 				// the established console-before-player command order.
-				return availability.thenCompose(ignored -> consoleCommands.isEmpty() ? CompletableFuture.completedFuture(null)
+				return availability.thenCompose(ignored -> consoleCommands.isEmpty()
+						&& !Reward.hasReplayCommandSnapshot(placeholders, "console")
+						? CompletableFuture.completedFuture(null)
 						: MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), consoleCommands,
-								placeholders, section.getBoolean("Stagger", true)))
+								placeholders, stagger))
 						.thenCompose(ignored -> user.preformCommandAsync(userCommands, placeholders))
                         .thenApply(ignored -> null);
             }
@@ -250,6 +291,11 @@ public final class RewardCommands {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayCommandSnapshot(placeholders, "console");
+			}
+
             @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> list,
                     HashMap<String, String> placeholders) {
@@ -263,7 +309,9 @@ public final class RewardCommands {
             @Override
             public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
                 ArrayList<String> list, HashMap<String, String> placeholders) {
-                if (list.isEmpty()) return CompletableFuture.completedFuture(null);
+				if (list.isEmpty() && !hasPendingReplayWork(placeholders)) {
+					return CompletableFuture.completedFuture(null);
+				}
                 String command = Reward.replaySelection(placeholders,
                         () -> list.get(ThreadLocalRandom.current().nextInt(list.size())));
                 return MiscUtils.getInstance().executeConsoleCommandsAsync(user.getPlayerName(), command, placeholders)

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardEffect.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardEffect.java
@@ -33,7 +33,7 @@ public final class RewardEffect {
                 }
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder(Material.DIAMOND), new EditGUIValueInventory("Effect") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder(Material.DIAMOND), new EditGUIValueInventory("Effect") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardExp.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardExp.java
@@ -34,7 +34,7 @@ public final class RewardExp {
                 user.giveExp(num);
                 return null;
             }
-        }.asPlaceholder("EXP").priority(100).addEditButton(
+		}.requiresPlayer().asPlaceholder("EXP").priority(100).addEditButton(
                 new EditGUIButton(new ItemBuilder("EXPERIENCE_BOTTLE"), new EditGUIValueInventory("EXP") {
                     @Override
                     public void openInventory(ClickEvent clickEvent) {
@@ -57,7 +57,7 @@ public final class RewardExp {
                 user.giveExpLevels(num);
                 return null;
             }
-        }.asPlaceholder("EXP").priority(100).addEditButton(
+		}.requiresPlayer().asPlaceholder("EXP").priority(100).addEditButton(
                 new EditGUIButton(new ItemBuilder("EXPERIENCE_BOTTLE"), new EditGUIValueInventory("EXPLevels") {
                     @Override
                     public void openInventory(ClickEvent clickEvent) {
@@ -83,7 +83,7 @@ public final class RewardExp {
                 user.giveExp(value);
                 return "" + value;
             }
-        }.asPlaceholder("EXP").priority(100).validator(rangeValidator("EXP")));
+		}.requiresPlayer().asPlaceholder("EXP").priority(100).validator(rangeValidator("EXP")));
 
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("EXPLevels") {
             @Override
@@ -95,7 +95,7 @@ public final class RewardExp {
                 user.giveExpLevels(value);
                 return "" + value;
             }
-        }.asPlaceholder("EXP").priority(100).validator(rangeValidator("EXPLevels")));
+		}.requiresPlayer().asPlaceholder("EXP").priority(100).validator(rangeValidator("EXPLevels")));
     }
 
     private static RewardInjectValidator zeroValidator(String message) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardFirework.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardFirework.java
@@ -40,7 +40,7 @@ public final class RewardFirework {
                 }
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder("FIREWORK_ROCKET"), new EditGUIValueInventory("Firework") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder("FIREWORK_ROCKET"), new EditGUIValueInventory("Firework") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardItems.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardItems.java
@@ -48,7 +48,7 @@ public final class RewardItems {
                 user.giveItem(builder);
                 return null;
             }
-        }.validator(itemValidator()));
+		}.requiresPlayer().validator(itemValidator()));
     }
 
     public static void registerRandomItem(RewardHandler handler, AdvancedCorePlugin plugin) {
@@ -65,7 +65,7 @@ public final class RewardItems {
                 }
                 return null;
             }
-        }.asPlaceholder("RandomItem").priority(90).validator(randomItemValidator()));
+		}.requiresPlayer().asPlaceholder("RandomItem").priority(90).validator(randomItemValidator()));
     }
 
     public static void registerItems(RewardHandler handler, AdvancedCorePlugin plugin) {
@@ -87,7 +87,7 @@ public final class RewardItems {
                 }
                 return "";
             }
-        }.priority(90).asPlaceholder("Item").validator(itemsValidator().addPath("OnlyOneItemChance"))
+		}.requiresPlayer().priority(90).asPlaceholder("Item").validator(itemsValidator().addPath("OnlyOneItemChance"))
                 .addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueInventory("Items") {
                     @Override
                     public void openInventory(ClickEvent clickEvent) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
@@ -99,7 +99,8 @@ public final class RewardJavascript {
                 Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
                         Reward.currentReplayKey(), "path:" + path, Reward.currentReplayOccurrenceId());
 				return Reward.persistReplayMetadataAsync(plugin, placeholders)
-						.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> null);
+						.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> builder.sendAsync(user))).thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -56,6 +57,15 @@ public final class RewardJavascript {
 
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("Javascript") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
+            @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
                 if (section.getBoolean("Enabled")) {
@@ -68,6 +78,17 @@ public final class RewardJavascript {
                     }
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+                if (!section.getBoolean("Enabled")) return java.util.concurrent.CompletableFuture.completedFuture(null);
+                String path = Reward.replaySelection(placeholders,
+                        () -> new JavascriptEngine().addPlayer(user.getOfflinePlayer()).addPlaceholders(placeholders)
+                                .getBooleanValue(section.getString("Expression")) ? "TrueRewards" : "FalseRewards");
+                return new RewardBuilder(section, path).withPrefix(reward.getName() + ".Javascript").sendAsync(user)
+                        .thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
@@ -62,6 +62,11 @@ public final class RewardJavascript {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -91,7 +96,8 @@ public final class RewardJavascript {
                         .withPlaceHolder(placeholders);
                 Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
                         Reward.currentReplayKey(), "path:" + path, Reward.currentReplayOccurrenceId());
-                return builder.sendAsync(user).thenApply(ignored -> null);
+				return Reward.persistReplayMetadataAsync(plugin, placeholders)
+						.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
@@ -87,8 +87,11 @@ public final class RewardJavascript {
                 String path = Reward.replaySelection(placeholders,
                         () -> new JavascriptEngine().addPlayer(user.getOfflinePlayer()).addPlaceholders(placeholders)
                                 .getBooleanValue(section.getString("Expression")) ? "TrueRewards" : "FalseRewards");
-                return new RewardBuilder(section, path).withPrefix(reward.getName() + ".Javascript").sendAsync(user)
-                        .thenApply(ignored -> null);
+                RewardBuilder builder = new RewardBuilder(section, path).withPrefix(reward.getName() + ".Javascript")
+                        .withPlaceHolder(placeholders);
+                Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
+                        Reward.currentReplayKey(), "path:" + path, Reward.currentReplayOccurrenceId());
+                return builder.sendAsync(user).thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardJavascript.java
@@ -88,7 +88,9 @@ public final class RewardJavascript {
             @Override
             public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
                     ConfigurationSection section, HashMap<String, String> placeholders) {
-                if (!section.getBoolean("Enabled")) return java.util.concurrent.CompletableFuture.completedFuture(null);
+                if (!section.getBoolean("Enabled") && !hasPendingReplayWork(placeholders)) {
+					return java.util.concurrent.CompletableFuture.completedFuture(null);
+				}
                 String path = Reward.replaySelection(placeholders,
                         () -> new JavascriptEngine().addPlayer(user.getOfflinePlayer()).addPlaceholders(placeholders)
                                 .getBooleanValue(section.getString("Expression")) ? "TrueRewards" : "FalseRewards");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
@@ -108,6 +108,7 @@ public final class RewardLucky {
 				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
 				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
 				String parentReplayKey = Reward.currentReplayKey();
+				String parentOccurrenceId = Reward.currentReplayOccurrenceId();
 				int luckyIndex = 0;
 				for (String path : choices.split("\\n")) {
 					final int childIndex = luckyIndex++;
@@ -115,7 +116,7 @@ public final class RewardLucky {
 						RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(), path)
 								.withPrefix(reward.getName()).withPlaceHolder(placeholders);
 						Reward.withReplayState(builder.getRewardOptions(), replayState, parentReplayKey,
-								path + ":" + childIndex);
+								path + ":" + childIndex, parentOccurrenceId);
 						return builder.sendAsync(user);
 					});
                 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
@@ -117,13 +117,13 @@ public final class RewardLucky {
 				int luckyIndex = 0;
 				for (String path : choices.split("\\n")) {
 					final int childIndex = luckyIndex++;
-					sequence = sequence.thenCompose(ignored -> {
+					sequence = sequence.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user, () -> {
 						RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(), path)
 								.withPrefix(reward.getName()).withPlaceHolder(placeholders);
 						Reward.withReplayState(builder.getRewardOptions(), replayState, parentReplayKey,
 								path + ":" + childIndex, parentOccurrenceId);
 						return builder.sendAsync(user);
-					});
+					}));
                 }
                 return sequence.thenApply(ignored -> null);
             }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
@@ -43,6 +43,11 @@ public final class RewardLucky {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -105,7 +110,7 @@ public final class RewardLucky {
 					return paths.isEmpty() ? null : String.join("\n", paths);
 				});
 				if (choices == null) return CompletableFuture.completedFuture(null);
-				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+				CompletionStage<Void> sequence = Reward.persistReplayMetadataAsync(plugin, placeholders);
 				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
 				String parentReplayKey = Reward.currentReplayKey();
 				String parentOccurrenceId = Reward.currentReplayOccurrenceId();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardLucky.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -35,6 +37,15 @@ public final class RewardLucky {
 
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("Lucky") {
+            @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
@@ -69,6 +80,46 @@ public final class RewardLucky {
                     }
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+                HashMap<Integer, String> luckyRewards = new HashMap<>();
+                for (String key : section.getKeys(false)) {
+                    if (MessageAPI.isInt(key)) {
+                        int num = Integer.parseInt(key);
+                        if (num > 0) luckyRewards.put(num, "Lucky." + num);
+                    }
+                }
+				String choices = Reward.replaySelection(placeholders, () -> {
+					HashMap<String, Integer> selected = new LinkedHashMap<>();
+					for (Entry<Integer, String> entry : luckyRewards.entrySet()) {
+						if (MiscUtils.getInstance().checkChance(1, entry.getKey())) selected.put(entry.getValue(), entry.getKey());
+					}
+					selected = ArrayUtils.sortByValuesStr(selected, false);
+					ArrayList<String> paths = new ArrayList<>(selected.keySet());
+					if (reward.getConfig().getConfigData().getBoolean("OnlyOneLucky", false) && paths.size() > 1) {
+						paths.subList(1, paths.size()).clear();
+					}
+					return paths.isEmpty() ? null : String.join("\n", paths);
+				});
+				if (choices == null) return CompletableFuture.completedFuture(null);
+				CompletionStage<Void> sequence = CompletableFuture.completedFuture(null);
+				com.bencodez.advancedcore.api.rewards.Reward.ReplayState replayState = Reward.currentReplayState();
+				String parentReplayKey = Reward.currentReplayKey();
+				int luckyIndex = 0;
+				for (String path : choices.split("\\n")) {
+					final int childIndex = luckyIndex++;
+					sequence = sequence.thenCompose(ignored -> {
+						RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(), path)
+								.withPrefix(reward.getName()).withPlaceHolder(placeholders);
+						Reward.withReplayState(builder.getRewardOptions(), replayState, parentReplayKey,
+								path + ":" + childIndex);
+						return builder.sendAsync(user);
+					});
+                }
+                return sequence.thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardMessages.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardMessages.java
@@ -36,7 +36,7 @@ public final class RewardMessages {
                 user.sendMessage(value, placeholders);
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder("OAK_SIGN"), new EditGUIValueInventory("Messages") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder("OAK_SIGN"), new EditGUIValueInventory("Messages") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");
@@ -56,27 +56,27 @@ public final class RewardMessages {
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> value,
                     HashMap<String, String> placeholders) {
                 user.sendMessage(value, placeholders);
-                return null;
-            }
-        });
+				return null;
+			}
+		}.requiresPlayer());
 
-        handler.getInjectedRewards().add(new RewardInjectStringList("Message") {
+		handler.getInjectedRewards().add(new RewardInjectStringList("Message") {
             @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> value,
                     HashMap<String, String> placeholders) {
                 user.sendMessage(value, placeholders);
-                return null;
-            }
-        });
+				return null;
+			}
+		}.requiresPlayer());
 
         handler.getInjectedRewards().add(new RewardInjectStringList("RandomMessage") {
             @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> value,
                     HashMap<String, String> placeholders) {
                 user.sendMessage(value.get(ThreadLocalRandom.current().nextInt(0, value.size())), placeholders);
-                return null;
-            }
-        });
+				return null;
+			}
+		}.requiresPlayer());
 
         handler.getInjectedRewards().add(new RewardInjectString("Messages.Player") {
             @Override
@@ -85,7 +85,7 @@ public final class RewardMessages {
                 user.sendMessage(value, placeholders);
                 return null;
             }
-        }.validator(new RewardInjectValidator() {
+		}.requiresPlayer().validator(new RewardInjectValidator() {
             @Override
             public void onValidate(Reward reward, RewardInject inject, ConfigurationSection data) {
                 if (data.isString(inject.getPath()) && data.getString(inject.getPath()).isEmpty()) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPotions.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPotions.java
@@ -33,7 +33,7 @@ public final class RewardPotions {
                 }
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAINTING), new EditGUIValueInventory("Potions") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder(Material.PAINTING), new EditGUIValueInventory("Potions") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
@@ -33,6 +33,11 @@ public final class RewardPriority {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -70,8 +75,11 @@ public final class RewardPriority {
 								.setIgnoreRequirements(true),
 						Reward.currentReplayState(), Reward.currentReplayKey(), "selected:" + selectedName,
 						Reward.currentReplayOccurrenceId());
-				return selected == null ? CompletableFuture.completedFuture(null)
-						: handler.giveRewardAsync(user, selected, childOptions).thenApply(ignored -> selected.getName());
+				if (selected == null) return CompletableFuture.failedFuture(
+						new IllegalStateException("Selected priority reward could not be resolved: " + selectedName));
+				return Reward.persistReplayMetadataAsync(plugin, placeholders)
+						.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+						.thenApply(ignored -> selected.getName());
             }
         }.asPlaceholder("Priority").addEditButton(
                 new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("Priority", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
@@ -65,9 +65,13 @@ public final class RewardPriority {
 				});
 				if (selectedName == null) return CompletableFuture.completedFuture(null);
 				Reward selected = handler.getReward(selectedName);
+				RewardOptions childOptions = Reward.withReplayState(
+						new RewardOptions().withPlaceHolder(placeholders).setIgnoreChance(true)
+								.setIgnoreRequirements(true),
+						Reward.currentReplayState(), Reward.currentReplayKey(), "selected:" + selectedName,
+						Reward.currentReplayOccurrenceId());
 				return selected == null ? CompletableFuture.completedFuture(null)
-						: handler.giveRewardAsync(user, selected, new RewardOptions().withPlaceHolder(placeholders)
-								.setIgnoreChance(true).setIgnoreRequirements(true)).thenApply(ignored -> selected.getName());
+						: handler.giveRewardAsync(user, selected, childOptions).thenApply(ignored -> selected.getName());
             }
         }.asPlaceholder("Priority").addEditButton(
                 new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("Priority", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
@@ -2,6 +2,8 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -26,6 +28,15 @@ public final class RewardPriority {
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectStringList("Priority") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
+            @Override
             public String onRewardRequest(Reward source, AdvancedCoreUser user, ArrayList<String> list,
                     HashMap<String, String> placeholders) {
                 for (String rewardName : list) {
@@ -37,6 +48,26 @@ public final class RewardPriority {
                     }
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestAsync(Reward source, AdvancedCoreUser user,
+                    ArrayList<String> list, HashMap<String, String> placeholders) {
+				String selectedName = Reward.replaySelection(placeholders, () -> {
+                for (String rewardName : list) {
+                    Reward reward = handler.getReward(rewardName);
+                    if (reward != null && reward.canGiveReward(user,
+                            new RewardOptions().withPlaceHolder(placeholders))) {
+						return rewardName;
+                    }
+                }
+					return null;
+				});
+				if (selectedName == null) return CompletableFuture.completedFuture(null);
+				Reward selected = handler.getReward(selectedName);
+				return selected == null ? CompletableFuture.completedFuture(null)
+						: handler.giveRewardAsync(user, selected, new RewardOptions().withPlaceHolder(placeholders)
+								.setIgnoreChance(true).setIgnoreRequirements(true)).thenApply(ignored -> selected.getName());
             }
         }.asPlaceholder("Priority").addEditButton(
                 new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("Priority", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardPriority.java
@@ -78,7 +78,8 @@ public final class RewardPriority {
 				if (selected == null) return CompletableFuture.failedFuture(
 						new IllegalStateException("Selected priority reward could not be resolved: " + selectedName));
 				return Reward.persistReplayMetadataAsync(plugin, placeholders)
-						.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+						.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> handler.giveRewardAsync(user, selected, childOptions)))
 						.thenApply(ignored -> selected.getName());
             }
         }.asPlaceholder("Priority").addEditButton(

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
@@ -3,6 +3,8 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -24,6 +26,15 @@ public final class RewardRandom {
 
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("Random") {
+            @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
             @SuppressWarnings("unchecked")
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
@@ -46,6 +57,29 @@ public final class RewardRandom {
                             .withPrefix(reward.getName()).withPlaceHolder(placeholders).send(user);
                 }
                 return null;
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+                String selection = Reward.replaySelection(placeholders, () -> {
+                    if (!MiscUtils.getInstance().checkChance(section.getDouble("Chance", 100), 100)) return "fallback";
+                    if (!section.getBoolean("PickRandom", true)) return "rewards";
+                    ArrayList<String> rewards = (ArrayList<String>) section.getList("Rewards", new ArrayList<>());
+                    return rewards == null || rewards.isEmpty() ? "none"
+                            : "pick:" + rewards.get(ThreadLocalRandom.current().nextInt(rewards.size()));
+                });
+                if (selection == null || selection.equals("none")) return CompletableFuture.completedFuture(null);
+                if (selection.startsWith("pick:")) {
+                    String selected = selection.substring("pick:".length());
+                    return selected.isEmpty() ? CompletableFuture.completedFuture(null)
+                            : handler.giveRewardAsync(user, selected,
+                                    new RewardOptions().setPlaceholders(placeholders)).thenApply(ignored -> null);
+                }
+                String path = selection.equals("rewards") ? "Random.Rewards" : "Random.FallBack";
+                return new RewardBuilder(reward.getConfig().getConfigData(), path).withPrefix(reward.getName())
+                        .withPlaceHolder(placeholders).sendAsync(user).thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
@@ -32,6 +32,11 @@ public final class RewardRandom {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -76,15 +81,18 @@ public final class RewardRandom {
                     RewardOptions childOptions = Reward.withReplayState(
                             new RewardOptions().setPlaceholders(placeholders), Reward.currentReplayState(),
                             Reward.currentReplayKey(), "selected:" + selected, Reward.currentReplayOccurrenceId());
-                    return selected.isEmpty() ? CompletableFuture.completedFuture(null)
-                            : handler.giveRewardAsync(user, selected, childOptions).thenApply(ignored -> null);
+					return selected.isEmpty() ? CompletableFuture.completedFuture(null)
+							: Reward.persistReplayMetadataAsync(plugin, placeholders)
+									.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+									.thenApply(ignored -> null);
                 }
                 String path = selection.equals("rewards") ? "Random.Rewards" : "Random.FallBack";
                 RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(), path)
                         .withPrefix(reward.getName()).withPlaceHolder(placeholders);
                 Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
                         Reward.currentReplayKey(), "path:" + path, Reward.currentReplayOccurrenceId());
-                return builder.sendAsync(user).thenApply(ignored -> null);
+				return Reward.persistReplayMetadataAsync(plugin, placeholders)
+						.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
@@ -83,7 +83,8 @@ public final class RewardRandom {
                             Reward.currentReplayKey(), "selected:" + selected, Reward.currentReplayOccurrenceId());
 					return selected.isEmpty() ? CompletableFuture.completedFuture(null)
 							: Reward.persistReplayMetadataAsync(plugin, placeholders)
-									.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+									.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+											() -> handler.giveRewardAsync(user, selected, childOptions)))
 									.thenApply(ignored -> null);
                 }
                 String path = selection.equals("rewards") ? "Random.Rewards" : "Random.FallBack";
@@ -92,7 +93,8 @@ public final class RewardRandom {
                 Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
                         Reward.currentReplayKey(), "path:" + path, Reward.currentReplayOccurrenceId());
 				return Reward.persistReplayMetadataAsync(plugin, placeholders)
-						.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> null);
+						.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> builder.sendAsync(user))).thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandom.java
@@ -73,13 +73,18 @@ public final class RewardRandom {
                 if (selection == null || selection.equals("none")) return CompletableFuture.completedFuture(null);
                 if (selection.startsWith("pick:")) {
                     String selected = selection.substring("pick:".length());
+                    RewardOptions childOptions = Reward.withReplayState(
+                            new RewardOptions().setPlaceholders(placeholders), Reward.currentReplayState(),
+                            Reward.currentReplayKey(), "selected:" + selected, Reward.currentReplayOccurrenceId());
                     return selected.isEmpty() ? CompletableFuture.completedFuture(null)
-                            : handler.giveRewardAsync(user, selected,
-                                    new RewardOptions().setPlaceholders(placeholders)).thenApply(ignored -> null);
+                            : handler.giveRewardAsync(user, selected, childOptions).thenApply(ignored -> null);
                 }
                 String path = selection.equals("rewards") ? "Random.Rewards" : "Random.FallBack";
-                return new RewardBuilder(reward.getConfig().getConfigData(), path).withPrefix(reward.getName())
-                        .withPlaceHolder(placeholders).sendAsync(user).thenApply(ignored -> null);
+                RewardBuilder builder = new RewardBuilder(reward.getConfig().getConfigData(), path)
+                        .withPrefix(reward.getName()).withPlaceHolder(placeholders);
+                Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
+                        Reward.currentReplayKey(), "path:" + path, Reward.currentReplayOccurrenceId());
+                return builder.sendAsync(user).thenApply(ignored -> null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Material;
@@ -26,6 +27,15 @@ public final class RewardRandomReward {
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectStringList("RandomReward") {
             @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
+            @Override
             public String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> list,
                     HashMap<String, String> placeholders) {
                 if (!list.isEmpty()) {
@@ -34,6 +44,16 @@ public final class RewardRandomReward {
                     return selected;
                 }
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+                    ArrayList<String> list, HashMap<String, String> placeholders) {
+                if (list.isEmpty()) return java.util.concurrent.CompletableFuture.completedFuture(null);
+                String selected = Reward.replaySelection(placeholders,
+                        () -> list.get(ThreadLocalRandom.current().nextInt(list.size())));
+                return handler.giveRewardAsync(user, selected, new RewardOptions().setPlaceholders(placeholders))
+                        .thenApply(ignored -> selected);
             }
         }.asPlaceholder("RandomReward").priority(20).addEditButton(
                 new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("RandomReward", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
@@ -63,7 +63,8 @@ public final class RewardRandomReward {
 						new RewardOptions().setPlaceholders(placeholders), Reward.currentReplayState(),
 						Reward.currentReplayKey(), "selected:" + selected, Reward.currentReplayOccurrenceId());
 				return Reward.persistReplayMetadataAsync(plugin, placeholders)
-						.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+						.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+								() -> handler.giveRewardAsync(user, selected, childOptions)))
 						.thenApply(ignored -> selected);
             }
         }.asPlaceholder("RandomReward").priority(20).addEditButton(

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
@@ -32,6 +32,11 @@ public final class RewardRandomReward {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -49,14 +54,17 @@ public final class RewardRandomReward {
             @Override
             public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
                     ArrayList<String> list, HashMap<String, String> placeholders) {
-                if (list.isEmpty()) return java.util.concurrent.CompletableFuture.completedFuture(null);
+				if (list.isEmpty() && !hasPendingReplayWork(placeholders)) {
+					return java.util.concurrent.CompletableFuture.completedFuture(null);
+				}
                 String selected = Reward.replaySelection(placeholders,
                         () -> list.get(ThreadLocalRandom.current().nextInt(list.size())));
-                RewardOptions childOptions = Reward.withReplayState(
-                        new RewardOptions().setPlaceholders(placeholders), Reward.currentReplayState(),
-                        Reward.currentReplayKey(), "selected:" + selected, Reward.currentReplayOccurrenceId());
-                return handler.giveRewardAsync(user, selected, childOptions)
-                        .thenApply(ignored -> selected);
+				RewardOptions childOptions = Reward.withReplayState(
+						new RewardOptions().setPlaceholders(placeholders), Reward.currentReplayState(),
+						Reward.currentReplayKey(), "selected:" + selected, Reward.currentReplayOccurrenceId());
+				return Reward.persistReplayMetadataAsync(plugin, placeholders)
+						.thenCompose(ignored -> handler.giveRewardAsync(user, selected, childOptions))
+						.thenApply(ignored -> selected);
             }
         }.asPlaceholder("RandomReward").priority(20).addEditButton(
                 new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueList("RandomReward", null) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardRandomReward.java
@@ -52,7 +52,10 @@ public final class RewardRandomReward {
                 if (list.isEmpty()) return java.util.concurrent.CompletableFuture.completedFuture(null);
                 String selected = Reward.replaySelection(placeholders,
                         () -> list.get(ThreadLocalRandom.current().nextInt(list.size())));
-                return handler.giveRewardAsync(user, selected, new RewardOptions().setPlaceholders(placeholders))
+                RewardOptions childOptions = Reward.withReplayState(
+                        new RewardOptions().setPlaceholders(placeholders), Reward.currentReplayState(),
+                        Reward.currentReplayKey(), "selected:" + selected, Reward.currentReplayOccurrenceId());
+                return handler.giveRewardAsync(user, selected, childOptions)
                         .thenApply(ignored -> selected);
             }
         }.asPlaceholder("RandomReward").priority(20).addEditButton(

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSound.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSound.java
@@ -37,7 +37,7 @@ public final class RewardSound {
                 }
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder(Material.NOTE_BLOCK), new EditGUIValueInventory("Sound") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder(Material.NOTE_BLOCK), new EditGUIValueInventory("Sound") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
@@ -42,6 +42,11 @@ public final class RewardSpecialChance {
             @Override
             public boolean requiresConfiguredDataForAsync() { return true; }
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplaySelection(placeholders);
+			}
+
             @Override
             public boolean supportsAsyncSynchronization() { return false; }
 
@@ -116,12 +121,15 @@ public final class RewardSpecialChance {
                 if (selected.length != 2) return CompletableFuture.completedFuture(null);
                 for (Entry<Double, String> entry : map.entrySet()) {
                     if (entry.getValue().equals(selected[0])) {
-                        return new RewardBuilder(section, entry.getValue())
-                                .withPrefix(reward.getName() + "_SpecialChance").withPlaceHolder(placeholders)
-                                .withPlaceHolder("chance", selected[1]).sendAsync(user).thenApply(ignored -> null);
-                    }
-                }
-                return CompletableFuture.completedFuture(null);
+						RewardBuilder builder = new RewardBuilder(section, entry.getValue())
+								.withPrefix(reward.getName() + "_SpecialChance").withPlaceHolder(placeholders)
+								.withPlaceHolder("chance", selected[1]);
+						return Reward.persistReplayMetadataAsync(plugin, placeholders)
+								.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> null);
+					}
+				}
+				return CompletableFuture.failedFuture(
+						new IllegalStateException("Selected special-chance reward could not be resolved: " + selected[0]));
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
@@ -127,7 +127,8 @@ public final class RewardSpecialChance {
 						Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
 								Reward.currentReplayKey(), "path:" + entry.getValue(), Reward.currentReplayOccurrenceId());
 						return Reward.persistReplayMetadataAsync(plugin, placeholders)
-								.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> null);
+								.thenCompose(ignored -> Reward.continueOnServerThread(plugin, user,
+										() -> builder.sendAsync(user))).thenApply(ignored -> null);
 					}
 				}
 				return CompletableFuture.failedFuture(

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
@@ -124,6 +124,8 @@ public final class RewardSpecialChance {
 						RewardBuilder builder = new RewardBuilder(section, entry.getValue())
 								.withPrefix(reward.getName() + "_SpecialChance").withPlaceHolder(placeholders)
 								.withPlaceHolder("chance", selected[1]);
+						Reward.withReplayState(builder.getRewardOptions(), Reward.currentReplayState(),
+								Reward.currentReplayKey(), "path:" + entry.getValue(), Reward.currentReplayOccurrenceId());
 						return Reward.persistReplayMetadataAsync(plugin, placeholders)
 								.thenCompose(ignored -> builder.sendAsync(user)).thenApply(ignored -> null);
 					}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSpecialChance.java
@@ -7,6 +7,8 @@ import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -34,6 +36,15 @@ public final class RewardSpecialChance {
 
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("SpecialChance") {
+            @Override
+            public boolean supportsAsyncRequest() { return true; }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() { return true; }
+
+            @Override
+            public boolean supportsAsyncSynchronization() { return false; }
+
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
@@ -69,6 +80,48 @@ public final class RewardSpecialChance {
                 }
                 plugin.debug("Failed to give special chance");
                 return null;
+            }
+
+            @Override
+            public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+                    ConfigurationSection section, HashMap<String, String> placeholders) {
+                double totalChance = 0;
+                LinkedHashMap<Double, String> map = new LinkedHashMap<>();
+                for (String key : section.getKeys(false)) {
+                    String path = key;
+                    key = key.replaceAll("_", ".");
+                    if (MessageAPI.isDouble(key)) {
+                        double chance = Double.valueOf(key);
+                        totalChance += chance;
+                        map.put(chance, path);
+                    }
+                }
+                Set<Entry<Double, String>> copy = new HashSet<>(map.entrySet());
+                double currentNum = 0;
+                map.clear();
+                for (Entry<Double, String> entry : copy) {
+                    currentNum += entry.getKey();
+                    map.put(currentNum, entry.getValue());
+                }
+                final double chanceTotal = totalChance;
+                String selection = Reward.replaySelection(placeholders, () -> {
+                    double randomNum = ThreadLocalRandom.current().nextDouble(chanceTotal);
+                    for (Entry<Double, String> entry : map.entrySet()) {
+                        if (randomNum <= entry.getKey()) return entry.getValue() + "\n" + entry.getKey();
+                    }
+                    return null;
+                });
+                if (selection == null) return CompletableFuture.completedFuture(null);
+                String[] selected = selection.split("\n", 2);
+                if (selected.length != 2) return CompletableFuture.completedFuture(null);
+                for (Entry<Double, String> entry : map.entrySet()) {
+                    if (entry.getValue().equals(selected[0])) {
+                        return new RewardBuilder(section, entry.getValue())
+                                .withPrefix(reward.getName() + "_SpecialChance").withPlaceHolder(placeholders)
+                                .withPlaceHolder("chance", selected[1]).sendAsync(user).thenApply(ignored -> null);
+                    }
+                }
+                return CompletableFuture.completedFuture(null);
             }
 
             @Override

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSubRewards.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSubRewards.java
@@ -38,6 +38,11 @@ public final class RewardSubRewards {
 				return true;
 			}
 
+			@Override
+			public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+				return Reward.hasReplayNestedRewardSnapshot(placeholders, "nested-list:" + getPath());
+			}
+
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
@@ -52,7 +57,10 @@ public final class RewardSubRewards {
 					ConfigurationSection data, HashMap<String, String> placeholders) {
 				if (!data.isConfigurationSection(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true))
 						&& !isAlwaysForceNoData()) {
-					return java.util.concurrent.CompletableFuture.completedFuture(null);
+					return hasPendingReplayWork(placeholders)
+							? java.util.concurrent.CompletableFuture.failedFuture(new IllegalStateException(
+									"Pending reward replay configuration is missing: " + getPath()))
+							: java.util.concurrent.CompletableFuture.completedFuture(null);
 				}
 				return new RewardBuilder(reward.getConfig().getConfigData(), "Rewards").withPrefix(reward.getName())
 						.withPlaceHolder(placeholders).sendAsync(user).thenApply(ignored -> null);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSubRewards.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardSubRewards.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.api.rewards.builtin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -27,6 +28,16 @@ public final class RewardSubRewards {
 
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("Rewards") {
+			@Override
+			public boolean supportsAsyncRequest() {
+				return true;
+			}
+
+			@Override
+			public boolean requiresConfiguredDataForAsync() {
+				return true;
+			}
+
             @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
@@ -35,6 +46,17 @@ public final class RewardSubRewards {
                         .withPlaceHolder(placeholders).send(user);
                 return null;
             }
+
+			@Override
+			public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+					ConfigurationSection data, HashMap<String, String> placeholders) {
+				if (!data.isConfigurationSection(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true))
+						&& !isAlwaysForceNoData()) {
+					return java.util.concurrent.CompletableFuture.completedFuture(null);
+				}
+				return new RewardBuilder(reward.getConfig().getConfigData(), "Rewards").withPrefix(reward.getName())
+						.withPlaceHolder(placeholders).sendAsync(user).thenApply(ignored -> null);
+			}
 
             @Override
             public ArrayList<SubDirectlyDefinedReward> subRewards(DefinedReward direct) {

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardTempPermission.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardTempPermission.java
@@ -25,12 +25,26 @@ public final class RewardTempPermission {
     public static void register(RewardHandler handler, AdvancedCorePlugin plugin) {
         handler.getInjectedRewards().add(new RewardInjectConfigurationSection("TempPermission") {
             @Override
+            public boolean supportsAsyncRequest() {
+                return true;
+            }
+
+            @Override
+            public boolean requiresConfiguredDataForAsync() {
+                return true;
+            }
+
+            @Override
             public String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
                     HashMap<String, String> placeholders) {
                 String permission = section.getString("Permission", "");
                 int time = section.getInt("Expiration");
                 if (!permission.isEmpty()) {
                     if (time > 0) {
+                        if (user.getPlayer() == null) {
+                            throw new IllegalStateException(
+                                    "Player became unavailable before temporary permission delivery");
+                        }
                         user.addPermission(permission, time);
                     } else {
                         extraDebug("Time is 0");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardTempPermission.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardTempPermission.java
@@ -54,7 +54,7 @@ public final class RewardTempPermission {
                 }
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueInventory("TempPermission") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder(Material.PAPER), new EditGUIValueInventory("TempPermission") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardTitle.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/builtin/RewardTitle.java
@@ -35,7 +35,7 @@ public final class RewardTitle {
                 }
                 return null;
             }
-        }.addEditButton(new EditGUIButton(new ItemBuilder(Material.PAINTING), new EditGUIValueInventory("Title") {
+		}.requiresPlayer().addEditButton(new EditGUIButton(new ItemBuilder(Material.PAINTING), new EditGUIValueInventory("Title") {
             @Override
             public void openInventory(ClickEvent clickEvent) {
                 RewardEditData reward = (RewardEditData) getInv().getData("Reward");

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
@@ -114,6 +114,14 @@ public abstract class RewardInject extends Inject {
 	}
 
 	/**
+	 * Whether durable replay metadata requires this injection to run even when its
+	 * configured path was removed or changed while the reward was queued.
+	 */
+	public boolean hasPendingReplayWork(HashMap<String, String> placeholders) {
+		return false;
+	}
+
+	/**
 	 * Whether asynchronous dispatch may serialize this injection across reward
 	 * chains. Nested reward injectors opt out because awaiting a child that uses
 	 * the same shared injection would otherwise wait on its own unfinished tail.

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
@@ -2,6 +2,9 @@ package com.bencodez.advancedcore.api.rewards.injected;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -17,6 +20,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 public abstract class RewardInject extends Inject {
+	private CompletableFuture<Void> synchronizedAsyncTail = CompletableFuture.completedFuture(null);
 
 	@Getter
 	private boolean addAsPlaceholder = false;
@@ -89,12 +93,64 @@ public abstract class RewardInject extends Inject {
 		return getValidate() != null;
 	}
 
+	/**
+	 * Whether this injection has an asynchronous implementation. Existing
+	 * injections remain synchronous by default.
+	 *
+	 * @return true when {@link #onRewardRequestAsync(Reward, AdvancedCoreUser,
+	 *         ConfigurationSection, HashMap)} should be used
+	 */
+	public boolean supportsAsyncRequest() {
+		return false;
+	}
+
 	public boolean isEditable() {
 		return !getEditButtons().isEmpty();
 	}
 
 	public abstract Object onRewardRequest(Reward reward, AdvancedCoreUser user, ConfigurationSection data,
 			HashMap<String, String> placeholders);
+
+	/**
+	 * Asynchronously evaluates this injection. The default implementation keeps
+	 * the compatibility behavior by wrapping the existing synchronous callback.
+	 *
+	 * @param reward       reward being given
+	 * @param user         receiving user
+	 * @param data         reward configuration
+	 * @param placeholders current placeholders
+	 * @return completion stage containing the injection result
+	 */
+	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+			ConfigurationSection data, HashMap<String, String> placeholders) {
+		try {
+			return CompletableFuture.completedFuture(onRewardRequest(reward, user, data, placeholders));
+		} catch (Throwable throwable) {
+			return CompletableFuture.failedFuture(throwable);
+		}
+	}
+
+	/** Serializes a synchronized asynchronous injection through completion, not just invocation. */
+	public synchronized CompletionStage<Object> runSynchronizedAsync(Supplier<CompletionStage<Object>> request) {
+		CompletableFuture<Object> result = new CompletableFuture<>();
+		synchronizedAsyncTail = synchronizedAsyncTail.handle((ignored, previousFailure) -> null)
+				.thenCompose(ignored -> {
+					CompletionStage<Object> stage;
+					try {
+						stage = request.get();
+						if (stage == null) throw new IllegalStateException("Asynchronous reward injection returned null");
+					} catch (Throwable failure) {
+						result.completeExceptionally(failure);
+						return CompletableFuture.<Void>completedFuture(null);
+					}
+					return stage.handle((value, failure) -> {
+						if (failure == null) result.complete(value);
+						else result.completeExceptionally(failure);
+						return (Void) null;
+					});
+				}).toCompletableFuture();
+		return result;
+	}
 
 	public RewardInject postReward() {
 		postReward = true;

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
@@ -104,6 +104,24 @@ public abstract class RewardInject extends Inject {
 		return false;
 	}
 
+	/**
+	 * Whether this asynchronous implementation is relevant only when its
+	 * configured path exists. Existing third-party injectors keep the historic
+	 * always-async opt-in behavior unless they explicitly opt into this guard.
+	 */
+	public boolean requiresConfiguredDataForAsync() {
+		return false;
+	}
+
+	/**
+	 * Whether asynchronous dispatch may serialize this injection across reward
+	 * chains. Nested reward injectors opt out because awaiting a child that uses
+	 * the same shared injection would otherwise wait on its own unfinished tail.
+	 */
+	public boolean supportsAsyncSynchronization() {
+		return true;
+	}
+
 	public boolean isEditable() {
 		return !getEditButtons().isEmpty();
 	}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
@@ -48,6 +48,9 @@ public abstract class RewardInject extends Inject {
 	private boolean alwaysValid = false;
 
 	@Getter
+	private boolean playerRequired;
+
+	@Getter
 	private RewardInjectValidator validate;
 
 	public RewardInject(String path) {
@@ -198,6 +201,12 @@ public abstract class RewardInject extends Inject {
 
 	public RewardInject postReward() {
 		postReward = true;
+		return this;
+	}
+
+	/** Marks a legacy injection whose side effect cannot succeed without a live player. */
+	public RewardInject requiresPlayer() {
+		playerRequired = true;
 		return this;
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInject.java
@@ -148,6 +148,24 @@ public abstract class RewardInject extends Inject {
 		}
 	}
 
+	/**
+	 * Notifies this injection after its replay progress has been durably persisted.
+	 * Implementations may use the stable occurrence and injection identities to
+	 * retire their own idempotency records. A failed callback keeps the replay
+	 * pending, but the persisted checkpoint prevents the injection itself from
+	 * running again; recovery retries only this callback. Implementations must be
+	 * idempotent because recovery can repeat a notification that already succeeded.
+	 *
+	 * @param reward reward being given
+	 * @param user receiving user
+	 * @param occurrenceId stable identity of this logical reward occurrence
+	 * @param injectionKey stable replay path for this injection
+	 */
+	public CompletionStage<Void> onReplayCheckpointPersisted(Reward reward, AdvancedCoreUser user, String occurrenceId,
+			String injectionKey) {
+		return CompletableFuture.completedFuture(null);
+	}
+
 	/** Serializes a synchronized asynchronous injection through completion, not just invocation. */
 	public synchronized CompletionStage<Object> runSynchronizedAsync(Supplier<CompletionStage<Object>> request) {
 		CompletableFuture<Object> result = new CompletableFuture<>();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectBoolean.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectBoolean.java
@@ -1,6 +1,8 @@
 package com.bencodez.advancedcore.api.rewards.injected;
 
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -29,6 +31,16 @@ public abstract class RewardInjectBoolean extends RewardInject {
 	public abstract String onRewardRequest(Reward reward, AdvancedCoreUser user, boolean num,
 			HashMap<String, String> placeholders);
 
+	/** Completion-aware counterpart for boolean injections. */
+	public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user, boolean value,
+			HashMap<String, String> placeholders) {
+		try {
+			return CompletableFuture.completedFuture(onRewardRequest(reward, user, value, placeholders));
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
+		}
+	}
+
 	@Override
 	public String onRewardRequest(Reward reward, AdvancedCoreUser user, ConfigurationSection data,
 			HashMap<String, String> placeholders) {
@@ -43,6 +55,20 @@ public abstract class RewardInjectBoolean extends RewardInject {
 			return re;
 		}
 		return null;
+	}
+
+	@Override
+	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+			ConfigurationSection data, HashMap<String, String> placeholders) {
+		if (!(data.isBoolean(getPath()) || (isAlwaysForce() && data.contains(getPath(), true))
+				|| isAlwaysForceNoData())) {
+			if (!hasPendingReplayWork(placeholders)) return CompletableFuture.completedFuture(null);
+		}
+		boolean value = data.getBoolean(getPath(), isDefaultValue());
+		CompletionStage<String> result = onRewardRequestAsync(reward, user, value, placeholders);
+		if (result == null) return CompletableFuture.failedFuture(new IllegalStateException(
+				"Reward injection returned a null asynchronous result: " + getPath()));
+		return result.thenApply(valueResult -> (Object) (valueResult == null ? String.valueOf(value) : valueResult));
 	}
 
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectConfigurationSection.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectConfigurationSection.java
@@ -40,12 +40,21 @@ public abstract class RewardInjectConfigurationSection extends RewardInject {
 		}
 	}
 
+	/** Fails closed when a durable section replay can no longer read its payload. */
+	protected CompletionStage<Object> onMissingConfiguredDataAsync(Reward reward, AdvancedCoreUser user,
+			HashMap<String, String> placeholders) {
+		return CompletableFuture.failedFuture(
+				new IllegalStateException("Pending reward replay configuration is missing: " + getPath()));
+	}
+
 	@Override
 	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
 			ConfigurationSection data, HashMap<String, String> placeholders) {
 		if (!data.isConfigurationSection(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true))
 				&& !isAlwaysForceNoData()) {
-			return CompletableFuture.completedFuture(null);
+			return hasPendingReplayWork(placeholders)
+					? onMissingConfiguredDataAsync(reward, user, placeholders)
+					: CompletableFuture.completedFuture(null);
 		}
 		return onRewardRequestedAsync(reward, user, data.getConfigurationSection(getPath()), placeholders)
 				.thenApply(result -> result);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectConfigurationSection.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectConfigurationSection.java
@@ -1,6 +1,8 @@
 package com.bencodez.advancedcore.api.rewards.injected;
 
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -27,5 +29,26 @@ public abstract class RewardInjectConfigurationSection extends RewardInject {
 
 	public abstract String onRewardRequested(Reward reward, AdvancedCoreUser user, ConfigurationSection section,
 			HashMap<String, String> placeholders);
+
+	/** Completion-aware counterpart for section injections. */
+	public CompletionStage<String> onRewardRequestedAsync(Reward reward, AdvancedCoreUser user,
+			ConfigurationSection section, HashMap<String, String> placeholders) {
+		try {
+			return CompletableFuture.completedFuture(onRewardRequested(reward, user, section, placeholders));
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
+		}
+	}
+
+	@Override
+	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+			ConfigurationSection data, HashMap<String, String> placeholders) {
+		if (!data.isConfigurationSection(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true))
+				&& !isAlwaysForceNoData()) {
+			return CompletableFuture.completedFuture(null);
+		}
+		return onRewardRequestedAsync(reward, user, data.getConfigurationSection(getPath()), placeholders)
+				.thenApply(result -> result);
+	}
 
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectInt.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectInt.java
@@ -1,6 +1,8 @@
 package com.bencodez.advancedcore.api.rewards.injected;
 
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -42,7 +44,48 @@ public abstract class RewardInjectInt extends RewardInject {
 		return null;
 	}
 
+	@Override
+	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+			ConfigurationSection data, HashMap<String, String> placeholders) {
+		if (data.isInt(getPath()) || (isAlwaysForce() && data.contains(getPath(), true)) || isAlwaysForceNoData()) {
+			int value = data.getInt(getPath(), getDefaultValue());
+			AdvancedCorePlugin.getInstance()
+					.extraDebug(reward.getRewardName() + ": Giving " + getPath() + ", value: " + value);
+			try {
+				CompletionStage<String> result = onRewardRequestAsync(reward, user, value, placeholders);
+				if (result == null) {
+					return CompletableFuture.failedFuture(new IllegalStateException(
+							"Reward injection returned a null asynchronous result: " + getPath()));
+				}
+				return result.thenApply(valueResult -> valueResult == null ? "" + value : valueResult)
+						.thenApply(valueResult -> (Object) valueResult);
+			} catch (Throwable throwable) {
+				return CompletableFuture.failedFuture(throwable);
+			}
+		}
+		return CompletableFuture.completedFuture(null);
+	}
+
 	public abstract String onRewardRequest(Reward reward, AdvancedCoreUser user, int num,
 			HashMap<String, String> placeholders);
+
+	/**
+	 * Typed asynchronous hook for integer injections. Subclasses can override it
+	 * without reimplementing configuration parsing.
+	 *
+	 * @param reward       reward being given
+	 * @param user         receiving user
+	 * @param num          configured integer value
+	 * @param placeholders current placeholders
+	 * @return completion stage containing the typed result
+	 */
+	public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user, int num,
+			HashMap<String, String> placeholders) {
+		try {
+			return CompletableFuture.completedFuture(onRewardRequest(reward, user, num, placeholders));
+		} catch (Throwable throwable) {
+			return CompletableFuture.failedFuture(throwable);
+		}
+	}
 
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectString.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectString.java
@@ -1,6 +1,8 @@
 package com.bencodez.advancedcore.api.rewards.injected;
 
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -45,5 +47,26 @@ public abstract class RewardInjectString extends RewardInject {
 
 	public abstract String onRewardRequest(Reward reward, AdvancedCoreUser user, String value,
 			HashMap<String, String> placeholders);
+
+	/** Completion-aware counterpart for string injections. */
+	public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user, String value,
+			HashMap<String, String> placeholders) {
+		try {
+			return CompletableFuture.completedFuture(onRewardRequest(reward, user, value, placeholders));
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
+		}
+	}
+
+	@Override
+	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+			ConfigurationSection data, HashMap<String, String> placeholders) {
+		if (!((data.isString(getPath()) && !data.getString(getPath(), "").isEmpty())
+				|| (isAlwaysForce() && data.contains(getPath(), true)) || isAlwaysForceNoData())) {
+			return CompletableFuture.completedFuture(null);
+		}
+		String value = data.getString(getPath(), getDefaultValue());
+		return onRewardRequestAsync(reward, user, value, placeholders).thenApply(result -> result);
+	}
 
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectString.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectString.java
@@ -66,7 +66,12 @@ public abstract class RewardInjectString extends RewardInject {
 			return CompletableFuture.completedFuture(null);
 		}
 		String value = data.getString(getPath(), getDefaultValue());
-		return onRewardRequestAsync(reward, user, value, placeholders).thenApply(result -> result);
+		CompletionStage<String> result = onRewardRequestAsync(reward, user, value, placeholders);
+		if (result == null) {
+			return CompletableFuture.failedFuture(new IllegalStateException(
+					"Reward injection returned a null asynchronous result: " + getPath()));
+		}
+		return result.thenApply(valueResult -> (Object) (valueResult == null ? value : valueResult));
 	}
 
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectString.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectString.java
@@ -63,7 +63,7 @@ public abstract class RewardInjectString extends RewardInject {
 			ConfigurationSection data, HashMap<String, String> placeholders) {
 		if (!((data.isString(getPath()) && !data.getString(getPath(), "").isEmpty())
 				|| (isAlwaysForce() && data.contains(getPath(), true)) || isAlwaysForceNoData())) {
-			return CompletableFuture.completedFuture(null);
+			if (!hasPendingReplayWork(placeholders)) return CompletableFuture.completedFuture(null);
 		}
 		String value = data.getString(getPath(), getDefaultValue());
 		CompletionStage<String> result = onRewardRequestAsync(reward, user, value, placeholders);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectStringList.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectStringList.java
@@ -67,7 +67,9 @@ public abstract class RewardInjectStringList extends RewardInject {
 	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
 			ConfigurationSection data, HashMap<String, String> placeholders) {
 		if (!data.isList(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true)) && !isAlwaysForceNoData()) {
-			return CompletableFuture.completedFuture(null);
+			return hasPendingReplayWork(placeholders)
+					? onRewardRequestAsync(reward, user, new ArrayList<>(), placeholders).thenApply(result -> result)
+					: CompletableFuture.completedFuture(null);
 		}
 		List<?> stored = data.getList(getPath(), getDefaultValue());
 		ArrayList<String> value = new ArrayList<>();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectStringList.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/rewards/injected/RewardInjectStringList.java
@@ -2,6 +2,9 @@ package com.bencodez.advancedcore.api.rewards.injected;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -31,6 +34,20 @@ public abstract class RewardInjectStringList extends RewardInject {
 	public abstract String onRewardRequest(Reward reward, AdvancedCoreUser user, ArrayList<String> num,
 			HashMap<String, String> placeholders);
 
+	/**
+	 * Completion-aware counterpart for list injections. Existing list injections
+	 * retain their synchronous behavior unless they opt in by overriding this
+	 * method.
+	 */
+	public CompletionStage<String> onRewardRequestAsync(Reward reward, AdvancedCoreUser user, ArrayList<String> value,
+			HashMap<String, String> placeholders) {
+		try {
+			return CompletableFuture.completedFuture(onRewardRequest(reward, user, value, placeholders));
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public String onRewardRequest(Reward reward, AdvancedCoreUser user, ConfigurationSection data,
@@ -43,6 +60,19 @@ public abstract class RewardInjectStringList extends RewardInject {
 
 		}
 		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+			ConfigurationSection data, HashMap<String, String> placeholders) {
+		if (!data.isList(getPath()) && !(isAlwaysForce() && data.contains(getPath(), true)) && !isAlwaysForceNoData()) {
+			return CompletableFuture.completedFuture(null);
+		}
+		List<?> stored = data.getList(getPath(), getDefaultValue());
+		ArrayList<String> value = new ArrayList<>();
+		for (Object entry : stored) value.add(String.valueOf(entry));
+		return onRewardRequestAsync(reward, user, value, placeholders).thenApply(result -> result);
 	}
 
 }

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -2207,6 +2207,14 @@ public class AdvancedCoreUser {
 		}
 	}
 
+	/** Fails before mixed reward sections run console commands for an unavailable player. */
+	public CompletionStage<Void> validatePlayerCommandAvailabilityAsync() {
+		return getPlayer() == null || !plugin.isEnabled()
+				? CompletableFuture.failedFuture(
+						new IllegalStateException("Player command could not run because the player or plugin is unavailable"))
+				: CompletableFuture.completedFuture(null);
+	}
+
 	private CompletableFuture<Void> runPlayerCommandAsync(Player player, String command) {
 		CompletableFuture<Void> completion = new CompletableFuture<>();
 		AtomicBoolean claimed = new AtomicBoolean();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -762,6 +762,49 @@ public class AdvancedCoreUser {
 				: ASYNC_OCCURRENCE_DELIMITER + replay.asyncReplayOccurrenceId);
 	}
 
+	private static String withAsyncOccurrence(String rewardEntry, String occurrenceId) {
+		int placeholders = rewardEntry.indexOf("%placeholders%");
+		String reference = placeholders < 0 ? rewardEntry : rewardEntry.substring(0, placeholders);
+		String suffix = placeholders < 0 ? "" : rewardEntry.substring(placeholders);
+		return stripAsyncOccurrenceMarker(reference) + ASYNC_OCCURRENCE_DELIMITER + occurrenceId + suffix;
+	}
+
+	private String ensureOfflineRewardOccurrence(String rewardEntry) {
+		if (occurrenceId(rewardEntry) != null) return rewardEntry;
+		synchronized (plugin) {
+			ArrayList<String> pending = getOfflineRewards();
+			int index = pending.indexOf(rewardEntry);
+			if (index < 0) throw new IllegalStateException("Claimed offline reward disappeared before migration");
+			String updated = withAsyncOccurrence(rewardEntry, UUID.randomUUID().toString());
+			pending.set(index, updated);
+			setOfflineRewardsDurably(pending, updated);
+			ReplayClaims claims = replayClaims();
+			int claimed = claims.offline.getOrDefault(rewardEntry, 0);
+			if (claimed <= 1) claims.offline.remove(rewardEntry);
+			else claims.offline.put(rewardEntry, claimed - 1);
+			claims.offline.put(updated, claims.offline.getOrDefault(updated, 0) + 1);
+			return updated;
+		}
+	}
+
+	private String ensureTimedRewardOccurrence(String rewardEntry, long time) {
+		if (occurrenceId(stripTimedExecutionMarker(rewardEntry)) != null) return rewardEntry;
+		synchronized (plugin) {
+			HashMap<String, Long> pending = getTimedRewards();
+			if (!Long.valueOf(time).equals(pending.get(rewardEntry))) {
+				throw new IllegalStateException("Claimed timed reward disappeared before migration");
+			}
+			String updated = withAsyncOccurrence(rewardEntry, UUID.randomUUID().toString());
+			pending.remove(rewardEntry);
+			pending.put(updated, time);
+			setTimedRewardsDurably(pending);
+			ReplayClaims claims = replayClaims();
+			claims.timed.remove(rewardEntry);
+			claims.timed.add(updated);
+			return updated;
+		}
+	}
+
 	private static String encodeAsyncReplayProgress(Map<String, Integer> progress) {
 		if (progress.isEmpty()) return "";
 		StringBuilder encoded = new StringBuilder();
@@ -960,7 +1003,14 @@ public class AdvancedCoreUser {
 			if (time != 0) {
 				Date timeDate = new Date(time);
 				if (new Date().after(timeDate) && claimTimedReward(entry.getKey(), time)) {
-					String[] data = entry.getKey().split("%placeholders%", 2);
+					String migratedEntry;
+					try {
+						migratedEntry = ensureTimedRewardOccurrence(entry.getKey(), time);
+					} catch (Throwable failure) {
+						restoreTimedReward(entry.getKey(), time, failure);
+						continue;
+					}
+					String[] data = migratedEntry.split("%placeholders%", 2);
 					QueuedReplay queuedReplay = parseQueuedReplay(stripTimedExecutionMarker(data[0]));
 					String rewardReference = queuedReplay.rewardReference;
 					String placeholders = "";
@@ -980,7 +1030,7 @@ public class AdvancedCoreUser {
 					// checkpoint can change its serialized key (for example by adding the
 					// v2 progress marker), so completion and failure must follow this
 					// reference rather than the original entry key.
-					AtomicReference<String> currentEntry = new AtomicReference<>(entry.getKey());
+					AtomicReference<String> currentEntry = new AtomicReference<>(migratedEntry);
 					replayOptions.setAsyncReplayCheckpointConsumer(
 							checkpoint -> checkpointTimedReward(currentEntry, time, checkpoint));
 					enqueuePersistedReplay(() -> {
@@ -1029,6 +1079,12 @@ public class AdvancedCoreUser {
 				continue;
 			}
 			if (!claimOfflineReward(rewardEntry)) continue;
+			try {
+				rewardEntry = ensureOfflineRewardOccurrence(rewardEntry);
+			} catch (Throwable failure) {
+				restoreOfflineReward(rewardEntry, failure);
+				continue;
+			}
 
 			String[] parts = rewardEntry.split("%placeholders%", 2);
 			QueuedReplay queuedReplay = parseQueuedReplay(parts[0]);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -15,7 +15,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeoutException;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
@@ -1566,6 +1570,55 @@ public class AdvancedCoreUser {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Completion-aware player-command dispatch used by durable asynchronous reward
+	 * replay. It completes only after each queued player command has run.
+	 */
+	public CompletionStage<Void> preformCommandAsync(ArrayList<String> commands, HashMap<String, String> placeholders) {
+		if (commands == null || commands.isEmpty()) return CompletableFuture.completedFuture(null);
+		try {
+			final ArrayList<String> cmds = PlaceholderUtils.replaceJavascript(getPlayer(),
+					PlaceholderUtils.replacePlaceHolder(commands, placeholders));
+			final Player player = getPlayer();
+			if (player == null || !plugin.isEnabled()) return CompletableFuture.completedFuture(null);
+			ArrayList<CompletableFuture<Void>> completions = new ArrayList<>();
+			for (String command : cmds) {
+				plugin.debug("Executing player command for " + getPlayerName() + ": " + command);
+				completions.add(runPlayerCommandAsync(player, command));
+			}
+			return CompletableFuture.allOf(completions.toArray(new CompletableFuture[0]));
+		} catch (Throwable failure) {
+			return CompletableFuture.failedFuture(failure);
+		}
+	}
+
+	private CompletableFuture<Void> runPlayerCommandAsync(Player player, String command) {
+		CompletableFuture<Void> completion = new CompletableFuture<>();
+		AtomicBoolean claimed = new AtomicBoolean();
+		Runnable dispatch = () -> {
+			if (!claimed.compareAndSet(false, true)) return;
+			try {
+				player.chat("/" + command);
+				completion.complete(null);
+			} catch (Throwable failure) {
+				completion.completeExceptionally(failure);
+			}
+		};
+		try {
+			getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
+		} catch (Throwable failure) {
+			claimed.set(true);
+			completion.completeExceptionally(failure);
+			return completion;
+		}
+		CompletableFuture.delayedExecutor(30, TimeUnit.SECONDS).execute(() -> {
+			if (claimed.compareAndSet(false, true)) {
+				completion.completeExceptionally(new TimeoutException("Timed out waiting for scheduled player command"));
+			}
+		});
+		return completion;
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -301,6 +301,21 @@ public class AdvancedCoreUser {
 		}
 	}
 
+	/** Internal cross-package signal for a replay action proven not to have begun. */
+	public static RuntimeException replayActionNotStarted(String message) {
+		return new LegacyActionNotStartedException(message);
+	}
+
+	/** Internal cross-package signal for scheduler rejection before a replay action began. */
+	public static RuntimeException replayActionNotStarted(String message, Throwable cause) {
+		return new LegacyActionNotStartedException(message, cause);
+	}
+
+	/** Returns whether a completion failed before its replay-aware action began. */
+	public static boolean isReplayActionNotStarted(Throwable failure) {
+		return AsyncActionCollection.unwrapCompletionFailure(failure) instanceof LegacyActionNotStartedException;
+	}
+
 	/**
 	 * Explicitly carries an async injector's originating action scope into a
 	 * completion callback. Injectors capture this while their request method is

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -1705,7 +1705,7 @@ public class AdvancedCoreUser {
 			descriptor.append('\n').append(itemDescriptor(current));
 		}
 		if (collectAsyncAction(() -> player == null ? CompletableFuture.failedFuture(
-				new IllegalStateException("Player became unavailable before item reward delivery"))
+				replayActionNotStarted("Player became unavailable before item reward delivery"))
 				: plugin.getFullInventoryHandler().giveItemAsync(player, item), descriptor.toString())) {
 			return;
 		}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -66,8 +67,13 @@ public class AdvancedCoreUser {
 	private static final String ASYNC_PROGRESS_DELIMITER = "%asyncprogress%";
 	private static final String ASYNC_RETRY_DELIMITER = "%asyncretry%";
 	private static final String ASYNC_OCCURRENCE_DELIMITER = "%asyncoccurrence%";
-	private final HashMap<String, Integer> offlineReplayInFlight = new HashMap<>();
-	private final HashSet<String> timedReplayInFlight = new HashSet<>();
+	private static final Object REPLAY_CLAIMS_LOCK = new Object();
+	private static final WeakHashMap<AdvancedCorePlugin, HashMap<String, ReplayClaims>> REPLAY_CLAIMS = new WeakHashMap<>();
+
+	private static final class ReplayClaims {
+		private final HashMap<String, Integer> offline = new HashMap<>();
+		private final HashSet<String> timed = new HashSet<>();
+	}
 
 	/**
 	 * User data fetch mode for this user.
@@ -618,19 +624,20 @@ public class AdvancedCoreUser {
 
 	private void checkpointOfflineReward(AtomicReference<String> currentEntry, Reward.ReplayCheckpoint checkpoint) {
 		synchronized (plugin) {
+			ReplayClaims claims = replayClaims();
 			String current = currentEntry.get();
 			String updated = withAsyncReplayProgress(current, checkpoint);
 			ArrayList<String> pending = getOfflineRewards();
 			int index = pending.indexOf(current);
 			if (index >= 0) {
 				pending.set(index, updated);
-				int claimed = offlineReplayInFlight.getOrDefault(current, 0);
+				int claimed = claims.offline.getOrDefault(current, 0);
 				// Migrate this occurrence only. Identical legacy queue entries share a
 				// serialized key, but may each already be executing; moving the whole
 				// count would make the remaining old entry appear unclaimed.
-				if (claimed <= 1) offlineReplayInFlight.remove(current);
-				else offlineReplayInFlight.put(current, claimed - 1);
-				offlineReplayInFlight.put(updated, offlineReplayInFlight.getOrDefault(updated, 0) + 1);
+				if (claimed <= 1) claims.offline.remove(current);
+				else claims.offline.put(current, claimed - 1);
+				claims.offline.put(updated, claims.offline.getOrDefault(updated, 0) + 1);
 				currentEntry.set(updated);
 				setOfflineRewardsDurably(pending);
 			}
@@ -639,11 +646,12 @@ public class AdvancedCoreUser {
 
 	private boolean claimOfflineReward(String rewardEntry) {
 		synchronized (plugin) {
+			ReplayClaims claims = replayClaims();
 			int occurrences = 0;
 			for (String pending : getOfflineRewards()) if (rewardEntry.equals(pending)) occurrences++;
-			int claimed = offlineReplayInFlight.getOrDefault(rewardEntry, 0);
+			int claimed = claims.offline.getOrDefault(rewardEntry, 0);
 			if (claimed >= occurrences) return false;
-			offlineReplayInFlight.put(rewardEntry, claimed + 1);
+			claims.offline.put(rewardEntry, claimed + 1);
 			return true;
 		}
 	}
@@ -673,26 +681,35 @@ public class AdvancedCoreUser {
 	}
 
 	private void releaseOfflineReward(String rewardEntry) {
-		int claimed = offlineReplayInFlight.getOrDefault(rewardEntry, 0);
-		if (claimed <= 1) offlineReplayInFlight.remove(rewardEntry);
-		else offlineReplayInFlight.put(rewardEntry, claimed - 1);
+		ReplayClaims claims = replayClaims();
+		int claimed = claims.offline.getOrDefault(rewardEntry, 0);
+		if (claimed <= 1) claims.offline.remove(rewardEntry);
+		else claims.offline.put(rewardEntry, claimed - 1);
+		releaseReplayClaimsIfEmpty(claims);
 	}
 
-	private synchronized boolean claimTimedReward(String rewardEntry, long time) {
-		if (timedReplayInFlight.contains(rewardEntry) || !Long.valueOf(time).equals(getTimedRewards().get(rewardEntry))) {
-			return false;
+	private boolean claimTimedReward(String rewardEntry, long time) {
+		synchronized (plugin) {
+			ReplayClaims claims = replayClaims();
+			if (claims.timed.contains(rewardEntry) || !Long.valueOf(time).equals(getTimedRewards().get(rewardEntry))) {
+				return false;
+			}
+			claims.timed.add(rewardEntry);
+			return true;
 		}
-		timedReplayInFlight.add(rewardEntry);
-		return true;
 	}
 
-	private synchronized void completeTimedReward(String rewardEntry, long time) {
-		HashMap<String, Long> pending = getTimedRewards();
-		if (Long.valueOf(time).equals(pending.get(rewardEntry))) {
-			pending.remove(rewardEntry);
-			setTimedRewards(pending);
+	private void completeTimedReward(String rewardEntry, long time) {
+		synchronized (plugin) {
+			ReplayClaims claims = replayClaims();
+			HashMap<String, Long> pending = getTimedRewards();
+			if (Long.valueOf(time).equals(pending.get(rewardEntry))) {
+				pending.remove(rewardEntry);
+				setTimedRewards(pending);
+			}
+			claims.timed.remove(rewardEntry);
+			releaseReplayClaimsIfEmpty(claims);
 		}
-		timedReplayInFlight.remove(rewardEntry);
 	}
 
 	/**
@@ -700,36 +717,61 @@ public class AdvancedCoreUser {
 	 * Timed reward keys are map keys, so migrate the exact current key while
 	 * retaining its execution time and its in-flight claim.
 	 */
-	private synchronized void checkpointTimedReward(AtomicReference<String> currentEntry, long time,
+	private void checkpointTimedReward(AtomicReference<String> currentEntry, long time,
 			Reward.ReplayCheckpoint checkpoint) {
-		String current = currentEntry.get();
-		String updated = withAsyncReplayProgress(current, checkpoint);
-		if (current.equals(updated)) return;
-		HashMap<String, Long> pending = getTimedRewards();
-		if (!Long.valueOf(time).equals(pending.get(current))) return;
-		pending.remove(current);
-		pending.put(updated, time);
-		setTimedRewardsDurably(pending);
-		timedReplayInFlight.remove(current);
-		timedReplayInFlight.add(updated);
-		currentEntry.set(updated);
+		synchronized (plugin) {
+			ReplayClaims claims = replayClaims();
+			String current = currentEntry.get();
+			String updated = withAsyncReplayProgress(current, checkpoint);
+			if (current.equals(updated)) return;
+			HashMap<String, Long> pending = getTimedRewards();
+			if (!Long.valueOf(time).equals(pending.get(current))) return;
+			pending.remove(current);
+			pending.put(updated, time);
+			setTimedRewardsDurably(pending);
+			claims.timed.remove(current);
+			claims.timed.add(updated);
+			currentEntry.set(updated);
+		}
 	}
 
 	/** Restores a due timed entry after an asynchronous replay fails. */
-	private synchronized void restoreTimedReward(String rewardEntry, long time, Throwable failure) {
-		HashMap<String, Long> pending = getTimedRewards();
-		int retry = Math.min(8, asyncRetryCount(rewardEntry) + 1);
-		long retryDelay = Math.min(TimeUnit.MINUTES.toMillis(5), TimeUnit.SECONDS.toMillis(1L << retry));
-		long retryTime = System.currentTimeMillis() + retryDelay;
-		pending.remove(rewardEntry);
-		pending.put(withAsyncRetryCount(withAsyncReplayProgress(rewardEntry, failure), retry), retryTime);
-		setTimedRewards(pending);
-		timedReplayInFlight.remove(rewardEntry);
+	private void restoreTimedReward(String rewardEntry, long time, Throwable failure) {
+		long retryTime;
+		synchronized (plugin) {
+			ReplayClaims claims = replayClaims();
+			HashMap<String, Long> pending = getTimedRewards();
+			int retry = Math.min(8, asyncRetryCount(rewardEntry) + 1);
+			long retryDelay = Math.min(TimeUnit.MINUTES.toMillis(5), TimeUnit.SECONDS.toMillis(1L << retry));
+			retryTime = System.currentTimeMillis() + retryDelay;
+			pending.remove(rewardEntry);
+			pending.put(withAsyncRetryCount(withAsyncReplayProgress(rewardEntry, failure), retry), retryTime);
+			setTimedRewards(pending);
+			claims.timed.remove(rewardEntry);
+			releaseReplayClaimsIfEmpty(claims);
+		}
 		// A due entry restored after its original timer fired needs its own retry
 		// timer; waiting for reconnect would strand it indefinitely.
 		loadTimedDelayedTimer(retryTime);
 		plugin.getLogger().warning("Could not deliver queued timed reward for " + getPlayerName()
 				+ "; it will be retried: " + failure.getMessage());
+	}
+
+	private ReplayClaims replayClaims() {
+		synchronized (REPLAY_CLAIMS_LOCK) {
+			return REPLAY_CLAIMS.computeIfAbsent(plugin, ignored -> new HashMap<>())
+					.computeIfAbsent(getUUID(), ignored -> new ReplayClaims());
+		}
+	}
+
+	private void releaseReplayClaimsIfEmpty(ReplayClaims claims) {
+		if (!claims.offline.isEmpty() || !claims.timed.isEmpty()) return;
+		synchronized (REPLAY_CLAIMS_LOCK) {
+			HashMap<String, ReplayClaims> byUser = REPLAY_CLAIMS.get(plugin);
+			if (byUser == null || byUser.get(getUUID()) != claims) return;
+			byUser.remove(getUUID());
+			if (byUser.isEmpty()) REPLAY_CLAIMS.remove(plugin);
+		}
 	}
 
 	/**
@@ -1582,7 +1624,10 @@ public class AdvancedCoreUser {
 			final ArrayList<String> cmds = PlaceholderUtils.replaceJavascript(getPlayer(),
 					PlaceholderUtils.replacePlaceHolder(commands, placeholders));
 			final Player player = getPlayer();
-			if (player == null || !plugin.isEnabled()) return CompletableFuture.completedFuture(null);
+			if (player == null || !plugin.isEnabled()) {
+				return CompletableFuture.failedFuture(
+						new IllegalStateException("Player command could not run because the player or plugin is unavailable"));
+			}
 			ArrayList<CompletableFuture<Void>> completions = new ArrayList<>();
 			for (String command : cmds) {
 				plugin.debug("Executing player command for " + getPlayerName() + ": " + command);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -266,13 +266,15 @@ public class AdvancedCoreUser {
 	 * @param epochMilli   the epoch time in milliseconds when the reward should be
 	 *                     given
 	 */
-	public synchronized void addTimedReward(Reward reward, HashMap<String, String> placeholders, long epochMilli) {
-		HashMap<String, Long> timed = new HashMap<>(getTimedRewards());
-		String rewardName = queuedRewardReference(reward);
-		rewardName += "%extime%" + System.currentTimeMillis();
+	public void addTimedReward(Reward reward, HashMap<String, String> placeholders, long epochMilli) {
+		synchronized (plugin) {
+			HashMap<String, Long> timed = new HashMap<>(getTimedRewards());
+			String rewardName = queuedRewardReference(reward);
+			rewardName += "%extime%" + System.currentTimeMillis();
 
-		timed.put(rewardName + "%placeholders%" + ArrayUtils.makeString(placeholders), epochMilli);
-		setTimedRewards(timed);
+			timed.put(rewardName + "%placeholders%" + ArrayUtils.makeString(placeholders), epochMilli);
+			setTimedRewards(timed);
+		}
 		loadTimedDelayedTimer(epochMilli);
 	}
 
@@ -1628,12 +1630,10 @@ public class AdvancedCoreUser {
 				return CompletableFuture.failedFuture(
 						new IllegalStateException("Player command could not run because the player or plugin is unavailable"));
 			}
-			ArrayList<CompletableFuture<Void>> completions = new ArrayList<>();
-			for (String command : cmds) {
+			return Reward.replayCommandSequence(plugin, placeholders, "player", cmds, command -> {
 				plugin.debug("Executing player command for " + getPlayerName() + ": " + command);
-				completions.add(runPlayerCommandAsync(player, command));
-			}
-			return CompletableFuture.allOf(completions.toArray(new CompletableFuture[0]));
+				return runPlayerCommandAsync(player, command);
+			});
 		} catch (Throwable failure) {
 			return CompletableFuture.failedFuture(failure);
 		}
@@ -2036,7 +2036,9 @@ public class AdvancedCoreUser {
 	 * @param timed the timed rewards
 	 */
 	public void setTimedRewards(HashMap<String, Long> timed) {
-		setTimedRewards(timed, true);
+		synchronized (plugin) {
+			setTimedRewards(timed, true);
+		}
 	}
 
 	/** Writes an async replay checkpoint before the next stage can execute. */

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -159,13 +159,26 @@ public class AdvancedCoreUser {
 				recordReplayValue(snapshotKey, encodeSnapshot(persistedSnapshot));
 				result = checkpoint();
 			}
+			HashMap<String, String> snapshotLedger = persistedSnapshot;
 			for (ReplayAction action : actions) {
 				if (completed.contains(action.identity)) continue;
 				result = result.thenCompose(ignored -> {
 					try {
 						CompletionStage<Void> stage = action.action.get();
-						return stage == null ? CompletableFuture.failedFuture(
-								new IllegalStateException("Scheduled reward action returned null")) : stage;
+						if (stage == null) return CompletableFuture.failedFuture(
+								new IllegalStateException("Scheduled reward action returned null"));
+						return stage.exceptionallyCompose(failure -> {
+							Throwable cause = unwrapCompletionFailure(failure);
+							if (!(cause instanceof LegacyActionNotStartedException)) {
+								return CompletableFuture.failedFuture(cause);
+							}
+							// Scheduler rejection, shutdown-before-dispatch, and the bounded
+							// pre-dispatch timeout all prove the action never began. Release its
+							// reservation so a retry may safely regenerate a random payload.
+							snapshotLedger.remove(action.identity);
+							recordReplayValue(snapshotKey, encodeSnapshot(snapshotLedger));
+							return checkpoint().thenCompose(unused -> CompletableFuture.failedFuture(cause));
+						});
 					} catch (Throwable failure) {
 						return CompletableFuture.failedFuture(failure);
 					}
@@ -177,6 +190,15 @@ public class AdvancedCoreUser {
 				});
 			}
 			return result;
+		}
+
+		private static Throwable unwrapCompletionFailure(Throwable failure) {
+			Throwable current = failure;
+			while ((current instanceof java.util.concurrent.CompletionException
+					|| current instanceof java.util.concurrent.ExecutionException) && current.getCause() != null) {
+				current = current.getCause();
+			}
+			return current;
 		}
 
 		private String readReplayValue(String key) {
@@ -263,6 +285,19 @@ public class AdvancedCoreUser {
 				this.action = action;
 				this.durable = durable;
 			}
+		}
+	}
+
+	/** Signals a replay-aware legacy action that was conclusively never started. */
+	private static final class LegacyActionNotStartedException extends IllegalStateException {
+		private static final long serialVersionUID = 1L;
+
+		private LegacyActionNotStartedException(String message) {
+			super(message);
+		}
+
+		private LegacyActionNotStartedException(String message, Throwable cause) {
+			super(message, cause);
 		}
 	}
 
@@ -1773,7 +1808,8 @@ public class AdvancedCoreUser {
 			Runnable dispatch = () -> {
 				if (!claimed.compareAndSet(false, true)) return;
 				if (!plugin.isEnabled()) {
-					completion.completeExceptionally(new IllegalStateException("Plugin disabled before scheduled reward action ran"));
+					completion.completeExceptionally(new LegacyActionNotStartedException(
+							"Plugin disabled before scheduled reward action ran"));
 					return;
 				}
 				try {
@@ -1796,11 +1832,13 @@ public class AdvancedCoreUser {
 				else getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
 			} catch (Throwable failure) {
 				claimed.set(true);
-				completion.completeExceptionally(failure);
+				completion.completeExceptionally(new LegacyActionNotStartedException(
+						"Scheduler rejected reward action before dispatch", failure));
 			}
 			CompletableFuture.delayedExecutor(30, TimeUnit.SECONDS).execute(() -> {
 				if (claimed.compareAndSet(false, true)) {
-					completion.completeExceptionally(new TimeoutException("Timed out waiting for scheduled reward action"));
+					completion.completeExceptionally(new LegacyActionNotStartedException(
+							"Timed out waiting for scheduled reward action", new TimeoutException()));
 				}
 			});
 			return completion;

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -310,6 +310,8 @@ public class AdvancedCoreUser {
 		plugin.debug("Checking timed/delayed for " + getPlayerName());
 		HashMap<String, Long> timed = getTimedRewards();
 		HashMap<String, Long> newTimed = new HashMap<>();
+		HashMap<String, Long> replayingTimed = new HashMap<>();
+		HashMap<String, java.util.concurrent.CompletionStage<Void>> replayCompletions = new HashMap<>();
 		for (Entry<String, Long> entry : timed.entrySet()) {
 			long time = entry.getValue();
 
@@ -326,7 +328,9 @@ public class AdvancedCoreUser {
 							.withPlaceHolder(ArrayUtils.fromString(placeholders));
 					replayOptions.addPlaceholder("date",
 							"" + new SimpleDateFormat("EEE, d MMM yyyy HH:mm").format(new Date(time)));
-					plugin.getRewardHandler().givePersistedQueueReward(this, new PersistedQueueReference(rewardReference), replayOptions);
+					replayingTimed.put(entry.getKey(), time);
+					replayCompletions.put(entry.getKey(), plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
+							new PersistedQueueReference(rewardReference), replayOptions));
 					String rewardName = rewardReference;
 					plugin.debug("Giving timed/delayed reward " + rewardName + " for " + getPlayerName()
 							+ " with placeholders " + ArrayUtils.fromString(placeholders));
@@ -337,6 +341,14 @@ public class AdvancedCoreUser {
 
 		}
 		setTimedRewards(newTimed);
+		for (Entry<String, java.util.concurrent.CompletionStage<Void>> replay : replayCompletions.entrySet()) {
+			String rewardEntry = replay.getKey();
+			long time = replayingTimed.get(rewardEntry);
+			replay.getValue().exceptionally(failure -> {
+				restoreTimedReward(rewardEntry, time, failure);
+				return null;
+			});
+		}
 	}
 
 	/**
@@ -371,9 +383,37 @@ public class AdvancedCoreUser {
 			RewardOptions options = new RewardOptions().setOnline(false).setCheckTimed(false)
 					.withPlaceHolder(ArrayUtils.fromString(placeholderStr));
 
-			rewardHandler.givePersistedQueueReward(user, new PersistedQueueReference(rewardReference), options);
+			rewardHandler.givePersistedQueueRewardAsync(user, new PersistedQueueReference(rewardReference), options)
+					.exceptionally(failure -> {
+						restoreOfflineReward(rewardEntry, failure);
+						return null;
+					});
 		}
 
+	}
+
+	/** Restores a queue entry only after an asynchronous replay fails. */
+	private void restoreOfflineReward(String rewardEntry, Throwable failure) {
+		// Match addOfflineRewards' lock so a newly queued reward cannot be lost
+		// while a failed replay is being restored.
+		synchronized (plugin) {
+			ArrayList<String> pending = getOfflineRewards();
+			// Queue entries are allowed to repeat; each failed replay must restore
+			// its own occurrence rather than collapsing identical rewards.
+			pending.add(rewardEntry);
+			setOfflineRewards(pending);
+		}
+		plugin.getLogger().warning("Could not deliver queued offline reward for " + getPlayerName()
+				+ "; it will be retried: " + failure.getMessage());
+	}
+
+	/** Restores a due timed entry after an asynchronous replay fails. */
+	private synchronized void restoreTimedReward(String rewardEntry, long time, Throwable failure) {
+		HashMap<String, Long> pending = getTimedRewards();
+		pending.putIfAbsent(rewardEntry, time);
+		setTimedRewards(pending);
+		plugin.getLogger().warning("Could not deliver queued timed reward for " + getPlayerName()
+				+ "; it will be retried: " + failure.getMessage());
 	}
 
 	/**
@@ -452,7 +492,11 @@ public class AdvancedCoreUser {
 			RewardOptions options = new RewardOptions().setOnline(false).setGiveOffline(false).forceOffline()
 					.setCheckTimed(false).withPlaceHolder(ArrayUtils.fromString(placeholderStr));
 
-			rewardHandler.givePersistedQueueReward(user, new PersistedQueueReference(rewardReference), options);
+			rewardHandler.givePersistedQueueRewardAsync(user, new PersistedQueueReference(rewardReference), options)
+					.exceptionally(failure -> {
+						restoreOfflineReward(rewardEntry, failure);
+						return null;
+					});
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -1,5 +1,6 @@
 package com.bencodez.advancedcore.api.user;
 
+import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -32,6 +33,7 @@ import org.bukkit.Particle;
 import org.bukkit.Registry;
 import org.bukkit.Sound;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
@@ -75,13 +77,17 @@ public class AdvancedCoreUser {
 
 	/** Internal completion scope used by asynchronous reward dispatch. */
 	public static final class AsyncActionCollection {
+		private static final String ACTION_SNAPSHOT_SUFFIX = "_snapshot";
+		private static final String ACTION_COMPLETION_VERSION = "v2:";
+		private static final String ACTION_SNAPSHOT_VERSION = "v1:";
 		private final AsyncActionCollection previous;
 		private final AdvancedCoreUser owner;
-		private final ArrayList<Supplier<CompletionStage<Void>>> actions = new ArrayList<>();
+		private final ArrayList<ReplayAction> actions = new ArrayList<>();
+		private final HashMap<String, Integer> actionOccurrences = new HashMap<>();
 		private final Reward.ReplayState replayState;
 		private final HashMap<String, String> placeholders;
 		private final String checkpointKey;
-		private final int completedActions;
+		private final String snapshotKey;
 		private final AdvancedCorePlugin plugin;
 		private boolean closed;
 
@@ -92,13 +98,16 @@ public class AdvancedCoreUser {
 			this.replayState = replayState;
 			this.placeholders = placeholders;
 			this.checkpointKey = Reward.legacyActionReplayKey(injectionKey);
-			this.completedActions = Reward.completedLegacyActions(replayState, placeholders, checkpointKey);
+			this.snapshotKey = checkpointKey + ACTION_SNAPSHOT_SUFFIX;
 			this.plugin = plugin;
 		}
 
-		private synchronized boolean add(Supplier<CompletionStage<Void>> action) {
+		private synchronized boolean add(Supplier<CompletionStage<Void>> action, String descriptor) {
 			if (closed) return false;
-			actions.add(action);
+			String fingerprint = Reward.legacyActionFingerprint(descriptor);
+			int occurrence = actionOccurrences.getOrDefault(fingerprint, 0);
+			actionOccurrences.put(fingerprint, occurrence + 1);
+			actions.add(new ReplayAction(fingerprint + "/" + occurrence, fingerprint, action));
 			return true;
 		}
 
@@ -108,30 +117,138 @@ public class AdvancedCoreUser {
 
 		private synchronized CompletionStage<Void> closeAndAwait() {
 			closed = true;
+			HashMap<String, String> currentSnapshot = new HashMap<>();
+			for (ReplayAction action : actions) currentSnapshot.put(action.identity, action.fingerprint);
+			HashMap<String, String> persistedSnapshot;
+			HashSet<String> completed;
+			try {
+				persistedSnapshot = snapshot(readReplayValue(snapshotKey));
+				completed = completed(readReplayValue(checkpointKey));
+				for (String identity : completed) {
+					if (!persistedSnapshot.containsKey(identity)) {
+						return CompletableFuture.failedFuture(new IllegalStateException(
+								"Legacy action checkpoint does not match its persisted action snapshot"));
+					}
+				}
+			} catch (IllegalArgumentException failure) {
+				return CompletableFuture.failedFuture(new IllegalStateException(
+						"Cannot safely resume legacy reward actions from an ordinal-only or malformed checkpoint", failure));
+			}
+			boolean snapshotChanged = persistedSnapshot.isEmpty();
+			if (snapshotChanged) persistedSnapshot = new HashMap<>(currentSnapshot);
+			else if (!persistedSnapshot.equals(currentSnapshot)) {
+				// The actions are deliberately matched individually below. Retaining the
+				// original snapshot lets a reordered, shortened, or extended config skip
+				// only the exact effects known to have completed. New actions are added
+				// before they can receive a completion marker.
+				persistedSnapshot.putAll(currentSnapshot);
+				snapshotChanged = true;
+			}
 			CompletionStage<Void> result = CompletableFuture.completedFuture(null);
-			for (int index = 0; index < actions.size(); index++) {
-				if (index < completedActions) continue;
-				Supplier<CompletionStage<Void>> action = actions.get(index);
-				int checkpoint = index + 1;
+			if (snapshotChanged) {
+				recordReplayValue(snapshotKey, encodeSnapshot(persistedSnapshot));
+				result = checkpoint();
+			}
+			for (ReplayAction action : actions) {
+				if (completed.contains(action.identity)) continue;
 				result = result.thenCompose(ignored -> {
 					try {
-						CompletionStage<Void> stage = action.get();
+						CompletionStage<Void> stage = action.action.get();
 						return stage == null ? CompletableFuture.failedFuture(
 								new IllegalStateException("Scheduled reward action returned null")) : stage;
 					} catch (Throwable failure) {
 						return CompletableFuture.failedFuture(failure);
 					}
-				}).thenCompose(ignored -> checkpoint(checkpoint));
+				}).thenCompose(ignored -> {
+					completed.add(action.identity);
+					recordReplayValue(checkpointKey, encodeCompleted(completed));
+					return checkpoint();
+				});
 			}
 			return result;
 		}
 
-		private CompletionStage<Void> checkpoint(int completed) {
+		private String readReplayValue(String key) {
+			String value = placeholders == null ? null : placeholders.get(key);
+			return value == null && replayState != null ? replayState.replayMetadata(key) : value;
+		}
+
+		private void recordReplayValue(String key, String value) {
+			if (placeholders != null) placeholders.put(key, value);
+			if (replayState != null) replayState.recordReplayMetadata(key, value);
+		}
+
+		private CompletionStage<Void> checkpoint() {
 			if (replayState == null || placeholders == null) return CompletableFuture.completedFuture(null);
-			String value = String.valueOf(completed);
-			placeholders.put(checkpointKey, value);
-			replayState.recordReplayMetadata(checkpointKey, value);
 			return replayState.persistCheckpointAsync(plugin, placeholders);
+		}
+
+		private static HashSet<String> completed(String encoded) {
+			HashSet<String> values = new HashSet<>();
+			if (encoded == null || encoded.isEmpty()) return values;
+			if (!encoded.startsWith(ACTION_COMPLETION_VERSION)) {
+				throw new IllegalArgumentException("Unknown legacy action checkpoint version");
+			}
+			for (String value : encoded.substring(ACTION_COMPLETION_VERSION.length()).split("\\.", -1)) {
+				if (value.isEmpty()) continue;
+				values.add(new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8));
+			}
+			return values;
+		}
+
+		private static String encodeCompleted(HashSet<String> completed) {
+			ArrayList<String> values = new ArrayList<>(completed);
+			java.util.Collections.sort(values);
+			StringBuilder encoded = new StringBuilder(ACTION_COMPLETION_VERSION);
+			for (String value : values) {
+				if (encoded.length() > ACTION_COMPLETION_VERSION.length()) encoded.append('.');
+				encoded.append(Base64.getUrlEncoder().withoutPadding()
+						.encodeToString(value.getBytes(StandardCharsets.UTF_8)));
+			}
+			return encoded.toString();
+		}
+
+		private static HashMap<String, String> snapshot(String encoded) {
+			HashMap<String, String> values = new HashMap<>();
+			if (encoded == null || encoded.isEmpty()) return values;
+			if (!encoded.startsWith(ACTION_SNAPSHOT_VERSION)) {
+				throw new IllegalArgumentException("Unknown legacy action snapshot version");
+			}
+			for (String entry : encoded.substring(ACTION_SNAPSHOT_VERSION.length()).split("\\.", -1)) {
+				if (entry.isEmpty()) continue;
+				String[] pair = entry.split("~", 2);
+				if (pair.length != 2 || values.put(new String(Base64.getUrlDecoder().decode(pair[0]), StandardCharsets.UTF_8),
+						new String(Base64.getUrlDecoder().decode(pair[1]), StandardCharsets.UTF_8)) != null) {
+					throw new IllegalArgumentException("Malformed legacy action snapshot");
+				}
+			}
+			return values;
+		}
+
+		private static String encodeSnapshot(HashMap<String, String> snapshot) {
+			ArrayList<String> identities = new ArrayList<>(snapshot.keySet());
+			java.util.Collections.sort(identities);
+			StringBuilder encoded = new StringBuilder(ACTION_SNAPSHOT_VERSION);
+			for (String identity : identities) {
+				if (encoded.length() > ACTION_SNAPSHOT_VERSION.length()) encoded.append('.');
+				encoded.append(Base64.getUrlEncoder().withoutPadding()
+						.encodeToString(identity.getBytes(StandardCharsets.UTF_8))).append('~')
+						.append(Base64.getUrlEncoder().withoutPadding().encodeToString(
+								snapshot.get(identity).getBytes(StandardCharsets.UTF_8)));
+			}
+			return encoded.toString();
+		}
+
+		private static final class ReplayAction {
+			private final String identity;
+			private final String fingerprint;
+			private final Supplier<CompletionStage<Void>> action;
+
+			private ReplayAction(String identity, String fingerprint, Supplier<CompletionStage<Void>> action) {
+				this.identity = identity;
+				this.fingerprint = fingerprint;
+				this.action = action;
+			}
 		}
 	}
 
@@ -222,12 +339,12 @@ public class AdvancedCoreUser {
 	}
 
 	private boolean collectAsyncAction(CompletionStage<Void> action) {
-		return collectAsyncAction(() -> action);
+		return collectAsyncAction(() -> action, "failure:" + action.getClass().getName());
 	}
 
-	private boolean collectAsyncAction(Supplier<CompletionStage<Void>> action) {
+	private boolean collectAsyncAction(Supplier<CompletionStage<Void>> action, String descriptor) {
 		AsyncActionCollection collection = ASYNC_ACTION_COLLECTION.get();
-		if (collection != null && collection.belongsTo(this) && collection.add(action)) return true;
+		if (collection != null && collection.belongsTo(this) && collection.add(action, descriptor)) return true;
 		// Do not infer ownership from another pending collection. A normal synchronous
 		// reward can run while an unrelated async injection is waiting; it must retain
 		// its established fire-and-forget scheduling semantics instead of being made a
@@ -1392,9 +1509,7 @@ public class AdvancedCoreUser {
 		final Player player = getPlayer();
 
 		if (plugin.isEnabled()) {
-			scheduleLegacyRewardAction(() -> {
-				if (player != null) plugin.getFullInventoryHandler().giveItem(player, item);
-			}, player, true);
+			scheduleLegacyItemAction(player, item);
 		} else {
 			collectAsyncFailure(new IllegalStateException("Plugin disabled before item reward was scheduled"));
 		}
@@ -1424,9 +1539,7 @@ public class AdvancedCoreUser {
 		final Player player = getPlayer();
 
 		if (plugin.isEnabled()) {
-			scheduleLegacyRewardAction(() -> {
-				if (player != null) plugin.getFullInventoryHandler().giveItem(player, item);
-			}, player, true);
+			scheduleLegacyItemAction(player, item);
 		} else {
 			collectAsyncFailure(new IllegalStateException("Plugin disabled before item reward was scheduled"));
 		}
@@ -1448,13 +1561,15 @@ public class AdvancedCoreUser {
 				if (m > 0) {
 					final double money = m;
 					scheduleLegacyRewardAction(
-							() -> plugin.getVaultHandler().getEcon().depositPlayer(getOfflinePlayer(), money), null, false);
+							() -> plugin.getVaultHandler().getEcon().depositPlayer(getOfflinePlayer(), money), null, false,
+							"money:deposit:" + Double.toString(money));
 
 				} else if (m < 0) {
 					m = m * -1;
 					final double money = m;
 					scheduleLegacyRewardAction(
-							() -> plugin.getVaultHandler().getEcon().withdrawPlayer(getOfflinePlayer(), money), null, false);
+							() -> plugin.getVaultHandler().getEcon().withdrawPlayer(getOfflinePlayer(), money), null, false,
+							"money:withdraw:" + Double.toString(money));
 
 				}
 			} catch (
@@ -1486,7 +1601,8 @@ public class AdvancedCoreUser {
 		Player player = getPlayer();
 		if (player != null && plugin.isEnabled()) {
 			scheduleLegacyRewardAction(() -> player.addPotionEffect(
-					new PotionEffect(PotionEffectType.getByName(potionName), 20 * duration, amplifier)), player, true);
+					new PotionEffect(PotionEffectType.getByName(potionName), 20 * duration, amplifier)), player, true,
+					"potion:" + potionName + ":" + duration + ":" + amplifier);
 		} else if (player != null && ASYNC_ACTION_COLLECTION.get() != null) {
 			collectAsyncFailure(new IllegalStateException(
 					"Potion reward could not be scheduled because the plugin is unavailable"));
@@ -1494,7 +1610,105 @@ public class AdvancedCoreUser {
 	}
 
 	/** Queues a legacy Bukkit action while exposing a nonblocking completion internally. */
-	private void scheduleLegacyRewardAction(Runnable action, Player player, boolean playerAware) {
+	private void scheduleLegacyItemAction(Player player, ItemStack... item) {
+		StringBuilder descriptor = new StringBuilder("item");
+		for (ItemStack current : item) {
+			descriptor.append('\n').append(itemDescriptor(current));
+		}
+		if (collectAsyncAction(() -> player == null ? CompletableFuture.completedFuture(null)
+				: plugin.getFullInventoryHandler().giveItemAsync(player, item), descriptor.toString())) {
+			return;
+		}
+		// Preserve ordinary fire-and-forget behavior without adding an ignored async
+		// timeout or a second scheduler boundary. Replay scopes above await the
+		// inventory handler's actual owner-task completion directly.
+		plugin.getFullInventoryHandler().giveItem(player, item);
+	}
+
+	private static String itemDescriptor(ItemStack item) {
+		if (item == null) return "null";
+		try {
+			return canonicalActionDescriptor(item.serialize());
+		} catch (Throwable ignored) {
+			// Unit-test and early-bootstrap environments can lack Bukkit's unsafe
+			// serializer. Retain every independently accessible item property instead
+			// of collapsing different metadata to an unstable display string.
+			HashMap<String, Object> fallback = new HashMap<>();
+			try {
+				fallback.put("type", item.getType());
+			} catch (Throwable ignoredAgain) { }
+			try {
+				fallback.put("amount", item.getAmount());
+			} catch (Throwable ignoredAgain) { }
+			try {
+				fallback.put("durability", item.getDurability());
+			} catch (Throwable ignoredAgain) { }
+			try {
+				fallback.put("meta", item.getItemMeta());
+			} catch (Throwable ignoredAgain) { }
+			fallback.put("class", item.getClass().getName());
+			return canonicalActionDescriptor(fallback);
+		}
+	}
+
+	/** Deterministic, delimiter-safe encoding for replayed action payloads. */
+	private static String canonicalActionDescriptor(Object value) {
+		if (value == null) return encodedActionPart("null", "");
+		if (value instanceof CharSequence || value instanceof Character || value instanceof Boolean
+				|| value instanceof Number || value instanceof Enum<?>) {
+			return encodedActionPart(value.getClass().getName(), value instanceof Enum<?>
+					? ((Enum<?>) value).name() : String.valueOf(value));
+		}
+		if (value instanceof ConfigurationSerializable) {
+			ConfigurationSerializable serializable = (ConfigurationSerializable) value;
+			return encodedActionPart("serializable-class", value.getClass().getName())
+					+ canonicalActionDescriptor(serializable.serialize());
+		}
+		if (value instanceof Map<?, ?>) {
+			ArrayList<String> entries = new ArrayList<>();
+			for (Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+				entries.add(canonicalActionDescriptor(entry.getKey()) + canonicalActionDescriptor(entry.getValue()));
+			}
+			java.util.Collections.sort(entries);
+			return encodedActionParts("map", entries);
+		}
+		if (value instanceof Iterable<?>) {
+			ArrayList<String> entries = new ArrayList<>();
+			for (Object entry : (Iterable<?>) value) entries.add(canonicalActionDescriptor(entry));
+			return encodedActionParts("list", entries);
+		}
+		if (value.getClass().isArray()) {
+			ArrayList<String> entries = new ArrayList<>();
+			for (int index = 0; index < Array.getLength(value); index++) {
+				entries.add(canonicalActionDescriptor(Array.get(value, index)));
+			}
+			return encodedActionParts("array:" + value.getClass().getComponentType().getName(), entries);
+		}
+		return encodedActionPart("object-class", value.getClass().getName());
+	}
+
+	private static String encodedActionParts(String type, Iterable<String> values) {
+		StringBuilder encoded = new StringBuilder(encodedActionPart("collection", type));
+		for (String value : values) encoded.append(encodedActionPart("entry", value));
+		return encoded.toString();
+	}
+
+	private static String encodedActionPart(String type, String value) {
+		String encodedType = Base64.getUrlEncoder().withoutPadding().encodeToString(type.getBytes(StandardCharsets.UTF_8));
+		String encodedValue = Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+		return encodedType.length() + ":" + encodedType + encodedValue.length() + ":" + encodedValue;
+	}
+
+	/** Queues a legacy Bukkit action while exposing a nonblocking completion internally. */
+	private void scheduleLegacyRewardAction(Runnable action, Player player, boolean playerAware, String descriptor) {
+		scheduleLegacyRewardActionAsync(() -> {
+			action.run();
+			return CompletableFuture.completedFuture(null);
+		}, player, playerAware, descriptor);
+	}
+
+	private void scheduleLegacyRewardActionAsync(Supplier<CompletionStage<Void>> action, Player player,
+			boolean playerAware, String descriptor) {
 		if (!collectAsyncAction(() -> {
 			CompletableFuture<Void> completion = new CompletableFuture<>();
 			AtomicBoolean claimed = new AtomicBoolean();
@@ -1505,8 +1719,15 @@ public class AdvancedCoreUser {
 					return;
 				}
 				try {
-					action.run();
-					completion.complete(null);
+					CompletionStage<Void> stage = action.get();
+					if (stage == null) {
+						completion.completeExceptionally(new IllegalStateException("Scheduled reward action returned null"));
+						return;
+					}
+					stage.whenComplete((ignored, failure) -> {
+						if (failure == null) completion.complete(null);
+						else completion.completeExceptionally(failure);
+					});
 				} catch (Throwable failure) {
 					completion.completeExceptionally(failure);
 				}
@@ -1524,9 +1745,19 @@ public class AdvancedCoreUser {
 				}
 			});
 			return completion;
-		})) {
-			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, action, player);
-			else getPlugin().getBukkitScheduler().runTask(plugin, action);
+		}, descriptor)) {
+			Runnable dispatch = () -> {
+				try {
+					CompletionStage<Void> stage = action.get();
+					if (stage == null) throw new IllegalStateException("Scheduled reward action returned null");
+				} catch (Throwable failure) {
+					if (failure instanceof RuntimeException) throw (RuntimeException) failure;
+					if (failure instanceof Error) throw (Error) failure;
+					throw new IllegalStateException("Failed to schedule legacy reward action", failure);
+				}
+			};
+			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, dispatch, player);
+			else getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -71,6 +71,7 @@ public class AdvancedCoreUser {
 	private static final String ASYNC_PROGRESS_DELIMITER = "%asyncprogress%";
 	private static final String ASYNC_RETRY_DELIMITER = "%asyncretry%";
 	private static final String ASYNC_OCCURRENCE_DELIMITER = "%asyncoccurrence%";
+	private static final String CHOICE_OCCURRENCE_PREFIX = "\\AdvancedCoreChoice/1/";
 	private static final Object REPLAY_CLAIMS_LOCK = new Object();
 	private static final WeakHashMap<AdvancedCorePlugin, HashMap<String, ReplayClaims>> REPLAY_CLAIMS = new WeakHashMap<>();
 	private static final ThreadLocal<AsyncActionCollection> ASYNC_ACTION_COLLECTION = new ThreadLocal<>();
@@ -894,10 +895,30 @@ public class AdvancedCoreUser {
 	 *
 	 * @param name the reward name
 	 */
-	public void addUnClaimedChoiceReward(String name) {
+	public synchronized void addUnClaimedChoiceReward(String name) {
 		ArrayList<String> choices = getUnClaimedChoices();
 		choices.add(name);
 		setUnClaimedChoice(choices);
+	}
+
+	/**
+	 * Adds an unclaimed choice once for a stable reward occurrence. The encoded
+	 * occurrence remains in the same durable list as the user-facing reward name,
+	 * so a replay cannot append a duplicate after a crash.
+	 *
+	 * @param name reward name shown in the choice UI
+	 * @param occurrenceId stable logical reward occurrence
+	 */
+	public synchronized void addUnClaimedChoiceReward(String name, String occurrenceId) {
+		if (occurrenceId == null || occurrenceId.isEmpty()) {
+			addUnClaimedChoiceReward(name);
+			return;
+		}
+		ArrayList<String> stored = getStoredUnClaimedChoices();
+		String entry = encodeUnclaimedChoice(name, occurrenceId);
+		if (stored.contains(entry)) return;
+		stored.add(entry);
+		getData().setStringList("UnClaimedChoices", stored);
 	}
 
 	/**
@@ -1515,8 +1536,10 @@ public class AdvancedCoreUser {
 	 *
 	 * @return the unclaimed choices
 	 */
-	public ArrayList<String> getUnClaimedChoices() {
-		return getData().getStringList("UnClaimedChoices", userDataFetchMode);
+	public synchronized ArrayList<String> getUnClaimedChoices() {
+		ArrayList<String> choices = new ArrayList<>();
+		for (String stored : getStoredUnClaimedChoices()) choices.add(decodeUnclaimedChoice(stored));
+		return choices;
 	}
 
 	/**
@@ -2366,10 +2389,15 @@ public class AdvancedCoreUser {
 	 *
 	 * @param name the reward name
 	 */
-	public void removeUnClaimedChoiceReward(String name) {
-		ArrayList<String> choices = getUnClaimedChoices();
-		choices.remove(name);
-		setUnClaimedChoice(choices);
+	public synchronized void removeUnClaimedChoiceReward(String name) {
+		ArrayList<String> choices = getStoredUnClaimedChoices();
+		for (int index = 0; index < choices.size(); index++) {
+			if (java.util.Objects.equals(name, decodeUnclaimedChoice(choices.get(index)))) {
+				choices.remove(index);
+				break;
+			}
+		}
+		getData().setStringList("UnClaimedChoices", choices);
 	}
 
 	/**
@@ -2744,6 +2772,30 @@ public class AdvancedCoreUser {
 	 */
 	public void setUnClaimedChoice(ArrayList<String> rewards) {
 		getData().setStringList("UnClaimedChoices", rewards);
+	}
+
+	private ArrayList<String> getStoredUnClaimedChoices() {
+		return getData().getStringList("UnClaimedChoices", userDataFetchMode);
+	}
+
+	private static String encodeUnclaimedChoice(String name, String occurrenceId) {
+		Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+		return CHOICE_OCCURRENCE_PREFIX
+				+ encoder.encodeToString(occurrenceId.getBytes(StandardCharsets.UTF_8)) + "."
+				+ encoder.encodeToString((name == null ? "" : name).getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String decodeUnclaimedChoice(String stored) {
+		if (stored == null || !stored.startsWith(CHOICE_OCCURRENCE_PREFIX)) return stored;
+		String encoded = stored.substring(CHOICE_OCCURRENCE_PREFIX.length());
+		int separator = encoded.indexOf('.');
+		if (separator < 1) return stored;
+		try {
+			Base64.getUrlDecoder().decode(encoded.substring(0, separator));
+			return new String(Base64.getUrlDecoder().decode(encoded.substring(separator + 1)), StandardCharsets.UTF_8);
+		} catch (IllegalArgumentException failure) {
+			return stored;
+		}
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -1035,6 +1035,7 @@ public class AdvancedCoreUser {
 					replayOptions.setAsyncReplayRegistryFingerprints(queuedReplay.asyncReplayRegistryFingerprints);
 					replayOptions.setLegacyAsyncReplayCheckpoint(queuedReplay.legacyAsyncReplayCheckpoint);
 					replayOptions.setAsyncReplayOccurrenceId(queuedReplay.asyncReplayOccurrenceId);
+					replayOptions.setTimedQueueReplay(true);
 					replayOptions.addPlaceholder("date",
 							"" + new SimpleDateFormat("EEE, d MMM yyyy HH:mm").format(new Date(time)));
 					// Keep the due entry durable while asynchronous stages are running.  A

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -1475,6 +1475,7 @@ public class AdvancedCoreUser {
 	 */
 	public void giveExp(int exp) {
 		Player player = getPlayer();
+		if (scheduleOwnedPlayerAction(player, () -> player.giveExp(exp), "exp:" + exp)) return;
 		if (player != null) {
 			player.giveExp(exp);
 		}
@@ -1487,6 +1488,7 @@ public class AdvancedCoreUser {
 	 */
 	public void giveExpLevels(int num) {
 		Player p = getPlayer();
+		if (scheduleOwnedPlayerAction(p, () -> p.setLevel(p.getLevel() + num), "exp-levels:" + num)) return;
 		if (p != null) {
 			p.setLevel(p.getLevel() + num);
 		}
@@ -1721,6 +1723,24 @@ public class AdvancedCoreUser {
 			action.run();
 			return CompletableFuture.completedFuture(null);
 		}, player, playerAware, descriptor);
+	}
+
+	/**
+	 * Makes a direct player mutation durable only while this user's replay scope is
+	 * active. Outside that scope callers retain the legacy immediate behavior.
+	 */
+	private boolean scheduleOwnedPlayerAction(Player player, Runnable action, String descriptor) {
+		if (!hasOwnedAsyncActionCollection()) return false;
+		if (player == null) {
+			collectAsyncFailure(new IllegalStateException("Player became unavailable before reward delivery"));
+			return true;
+		}
+		if (!plugin.isEnabled()) {
+			collectAsyncFailure(new IllegalStateException("Plugin disabled before player reward delivery"));
+			return true;
+		}
+		scheduleLegacyRewardAction(action, player, true, descriptor);
+		return true;
 	}
 
 	private void scheduleLegacyRewardActionAsync(Supplier<CompletionStage<Void>> action, Player player,
@@ -2193,6 +2213,7 @@ public class AdvancedCoreUser {
 		Runnable dispatch = () -> {
 			if (!claimed.compareAndSet(false, true)) return;
 			try {
+				validateLiveScheduledPlayer(player);
 				player.chat("/" + command);
 				completion.complete(null);
 			} catch (Throwable failure) {
@@ -2200,7 +2221,7 @@ public class AdvancedCoreUser {
 			}
 		};
 		try {
-			getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
+			getPlugin().getBukkitScheduler().runTask(plugin, dispatch, player);
 		} catch (Throwable failure) {
 			claimed.set(true);
 			completion.completeExceptionally(failure);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -8,11 +8,14 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
@@ -21,6 +24,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
@@ -69,10 +73,96 @@ public class AdvancedCoreUser {
 	private static final String ASYNC_OCCURRENCE_DELIMITER = "%asyncoccurrence%";
 	private static final Object REPLAY_CLAIMS_LOCK = new Object();
 	private static final WeakHashMap<AdvancedCorePlugin, HashMap<String, ReplayClaims>> REPLAY_CLAIMS = new WeakHashMap<>();
+	private static final ThreadLocal<AsyncActionCollection> ASYNC_ACTION_COLLECTION = new ThreadLocal<>();
+	private static final ThreadLocal<ArrayList<CompletionStage<Void>>> CONTINUATION_ASYNC_ACTIONS =
+			ThreadLocal.withInitial(ArrayList::new);
+	private final Set<AsyncActionCollection> activeAsyncActionCollections = Collections
+			.newSetFromMap(new IdentityHashMap<>());
+
+	/** Internal completion scope used by asynchronous reward dispatch. */
+	public static final class AsyncActionCollection {
+		private final AsyncActionCollection previous;
+		private final ArrayList<CompletionStage<Void>> actions = new ArrayList<>();
+		private boolean closed;
+
+		private AsyncActionCollection(AsyncActionCollection previous) {
+			this.previous = previous;
+		}
+
+		private synchronized boolean add(CompletionStage<Void> action) {
+			if (closed) return false;
+			actions.add(action);
+			return true;
+		}
+
+		private synchronized CompletionStage<Void> closeAndAwait() {
+			closed = true;
+			CompletionStage<Void> result = CompletableFuture.completedFuture(null);
+			for (CompletionStage<Void> action : actions) {
+				result = result.thenCompose(ignored -> action);
+			}
+			return result;
+		}
+	}
+
+	/** Starts collecting completion stages created by legacy reward callbacks. */
+	public AsyncActionCollection beginAsyncActionCollection() {
+		AsyncActionCollection collection = new AsyncActionCollection(ASYNC_ACTION_COLLECTION.get());
+		synchronized (activeAsyncActionCollections) {
+			activeAsyncActionCollections.add(collection);
+		}
+		ASYNC_ACTION_COLLECTION.set(collection);
+		return collection;
+	}
+
+	/** Restores the calling thread's previous collection while keeping this scope active for its returned stage. */
+	public void restoreAsyncActionCollectionScope(AsyncActionCollection collection) {
+		if (collection == null || ASYNC_ACTION_COLLECTION.get() != collection) return;
+		if (collection.previous == null) ASYNC_ACTION_COLLECTION.remove();
+		else ASYNC_ACTION_COLLECTION.set(collection.previous);
+	}
+
+	/** Closes a completed async scope and returns completion for every collected action. */
+	public CompletionStage<Void> endAsyncActionCollection(AsyncActionCollection collection) {
+		if (collection == null) return CompletableFuture.completedFuture(null);
+		restoreAsyncActionCollectionScope(collection);
+		synchronized (activeAsyncActionCollections) {
+			activeAsyncActionCollections.remove(collection);
+			return collection.closeAndAwait();
+		}
+	}
+
+	private boolean collectAsyncAction(CompletionStage<Void> action) {
+		AsyncActionCollection collection = ASYNC_ACTION_COLLECTION.get();
+		if (collection != null && collection.add(action)) return true;
+		synchronized (activeAsyncActionCollections) {
+			if (activeAsyncActionCollections.isEmpty()) return false;
+			// A CompletionStage continuation runs before completion callbacks attached
+			// to its returned stage. Hold its legacy action on that same thread until
+			// requestInjectionAsync's callback claims it for the exact collection.
+			CONTINUATION_ASYNC_ACTIONS.get().add(action);
+			return true;
+		}
+	}
+
+	/** Claims legacy actions created by the continuation that just completed on this thread. */
+	public void claimAsyncContinuationActions(AsyncActionCollection collection) {
+		if (collection == null) return;
+		ArrayList<CompletionStage<Void>> pending = CONTINUATION_ASYNC_ACTIONS.get();
+		if (pending.isEmpty()) return;
+		for (CompletionStage<Void> action : pending) collection.add(action);
+		pending.clear();
+		CONTINUATION_ASYNC_ACTIONS.remove();
+	}
+
+	private void collectAsyncFailure(Throwable failure) {
+		collectAsyncAction(CompletableFuture.failedFuture(failure));
+	}
 
 	private static final class ReplayClaims {
 		private final HashMap<String, Integer> offline = new HashMap<>();
 		private final HashSet<String> timed = new HashSet<>();
+		private CompletableFuture<Void> serialReplayTail = CompletableFuture.completedFuture(null);
 	}
 
 	/**
@@ -564,10 +654,21 @@ public class AdvancedCoreUser {
 					AtomicReference<String> currentEntry = new AtomicReference<>(entry.getKey());
 					replayOptions.setAsyncReplayCheckpointConsumer(
 							checkpoint -> checkpointTimedReward(currentEntry, time, checkpoint));
-					plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
-							new PersistedQueueReference(rewardReference), replayOptions).whenComplete((ignored, failure) -> {
-						if (failure == null) completeTimedReward(currentEntry.get(), time);
-						else restoreTimedReward(currentEntry.get(), time, failure);
+					enqueuePersistedReplay(() -> {
+						CompletionStage<Void> replay;
+						try {
+							replay = plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
+									new PersistedQueueReference(rewardReference), replayOptions);
+							if (replay == null) throw new IllegalStateException("Timed reward replay returned no completion stage");
+						} catch (Throwable failure) {
+							restoreTimedReward(currentEntry.get(), time, failure);
+							return CompletableFuture.completedFuture(null);
+						}
+						return replay.handle((ignored, failure) -> {
+							if (failure == null) completeTimedReward(currentEntry.get(), time);
+							else restoreTimedReward(currentEntry.get(), time, failure);
+							return null;
+						});
 					});
 					String rewardName = rewardReference;
 					plugin.debug("Giving timed/delayed reward " + rewardName + " for " + getPlayerName()
@@ -616,12 +717,55 @@ public class AdvancedCoreUser {
 			AtomicReference<String> currentEntry = new AtomicReference<>(rewardEntry);
 			options.setAsyncReplayCheckpointConsumer(checkpoint -> checkpointOfflineReward(currentEntry, checkpoint));
 
-			plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
-					new PersistedQueueReference(rewardReference), options).whenComplete((ignored, failure) -> {
-						if (failure == null) completeOfflineReward(currentEntry.get());
-						else restoreOfflineReward(currentEntry.get(), failure);
-					});
+			enqueuePersistedReplay(() -> {
+				CompletionStage<Void> replay;
+				try {
+					replay = plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
+							new PersistedQueueReference(rewardReference), options);
+					if (replay == null) throw new IllegalStateException("Offline reward replay returned no completion stage");
+				} catch (Throwable failure) {
+					restoreOfflineReward(currentEntry.get(), failure);
+					return CompletableFuture.completedFuture(null);
+				}
+				return replay.handle((ignored, failure) -> {
+					if (failure == null) completeOfflineReward(currentEntry.get());
+					else restoreOfflineReward(currentEntry.get(), failure);
+					return null;
+				});
+			});
 		}
+	}
+
+	/**
+	 * Runs persisted offline and timed occurrences one at a time for this plugin
+	 * and user. The tail deliberately absorbs a completed occurrence's failure:
+	 * its own restore path retains the queue entry, while the next occurrence must
+	 * still be allowed to start without blocking a caller thread.
+	 */
+	private void enqueuePersistedReplay(Supplier<CompletionStage<Void>> replay) {
+		ReplayClaims claims;
+		CompletableFuture<Void> previous;
+		CompletableFuture<Void> next = new CompletableFuture<>();
+		synchronized (plugin) {
+			claims = replayClaims();
+			previous = claims.serialReplayTail;
+			claims.serialReplayTail = next;
+		}
+		previous.whenComplete((ignored, previousFailure) -> {
+			CompletionStage<Void> stage;
+			try {
+				stage = replay.get();
+				if (stage == null) throw new IllegalStateException("Persisted reward replay returned no completion stage");
+			} catch (Throwable failure) {
+				next.complete(null);
+				releaseReplayClaimsIfEmpty(claims);
+				return;
+			}
+			stage.whenComplete((result, failure) -> {
+				next.complete(null);
+				releaseReplayClaimsIfEmpty(claims);
+			});
+		});
 	}
 
 	private void checkpointOfflineReward(AtomicReference<String> currentEntry, Reward.ReplayCheckpoint checkpoint) {
@@ -1119,15 +1263,11 @@ public class AdvancedCoreUser {
 		final Player player = getPlayer();
 
 		if (plugin.isEnabled()) {
-			getPlugin().getBukkitScheduler().runTask(plugin, new Runnable() {
-
-				@Override
-				public void run() {
-					if (player != null) {
-						plugin.getFullInventoryHandler().giveItem(player, item);
-					}
-				}
-			}, player);
+			scheduleLegacyRewardAction(() -> {
+				if (player != null) plugin.getFullInventoryHandler().giveItem(player, item);
+			}, player, true);
+		} else {
+			collectAsyncFailure(new IllegalStateException("Plugin disabled before item reward was scheduled"));
 		}
 
 	}
@@ -1155,15 +1295,11 @@ public class AdvancedCoreUser {
 		final Player player = getPlayer();
 
 		if (plugin.isEnabled()) {
-			getPlugin().getBukkitScheduler().runTask(plugin, new Runnable() {
-
-				@Override
-				public void run() {
-					if (player != null) {
-						plugin.getFullInventoryHandler().giveItem(player, item);
-					}
-				}
-			}, player);
+			scheduleLegacyRewardAction(() -> {
+				if (player != null) plugin.getFullInventoryHandler().giveItem(player, item);
+			}, player, true);
+		} else {
+			collectAsyncFailure(new IllegalStateException("Plugin disabled before item reward was scheduled"));
 		}
 
 	}
@@ -1175,36 +1311,28 @@ public class AdvancedCoreUser {
 	 */
 	public void giveMoney(double m) {
 		if (!plugin.isEnabled()) {
+			collectAsyncFailure(new IllegalStateException("Plugin disabled before money reward was scheduled"));
 			return;
 		}
 		if (plugin.getVaultHandler() != null && plugin.getVaultHandler().getEcon() != null) {
 			try {
 				if (m > 0) {
 					final double money = m;
-					getPlugin().getBukkitScheduler().runTask(plugin, new Runnable() {
-
-						@Override
-						public void run() {
-							plugin.getVaultHandler().getEcon().depositPlayer(getOfflinePlayer(), money);
-						}
-					});
+					scheduleLegacyRewardAction(
+							() -> plugin.getVaultHandler().getEcon().depositPlayer(getOfflinePlayer(), money), null, false);
 
 				} else if (m < 0) {
 					m = m * -1;
 					final double money = m;
-					getPlugin().getBukkitScheduler().runTask(plugin, new Runnable() {
-
-						@Override
-						public void run() {
-							plugin.getVaultHandler().getEcon().withdrawPlayer(getOfflinePlayer(), money);
-						}
-					});
+					scheduleLegacyRewardAction(
+							() -> plugin.getVaultHandler().getEcon().withdrawPlayer(getOfflinePlayer(), money), null, false);
 
 				}
 			} catch (
 
 			IllegalStateException e) {
 				e.printStackTrace();
+				collectAsyncFailure(e);
 			}
 		}
 	}
@@ -1228,17 +1356,48 @@ public class AdvancedCoreUser {
 	public void givePotionEffect(String potionName, int duration, int amplifier) {
 		Player player = getPlayer();
 		if (player != null && plugin.isEnabled()) {
-			getPlugin().getBukkitScheduler().runTask(plugin, new Runnable() {
-
-				@SuppressWarnings("deprecation")
-				@Override
-				public void run() {
-					player.addPotionEffect(
-							new PotionEffect(PotionEffectType.getByName(potionName), 20 * duration, amplifier));
-				}
-			}, player);
-
+			scheduleLegacyRewardAction(() -> player.addPotionEffect(
+					new PotionEffect(PotionEffectType.getByName(potionName), 20 * duration, amplifier)), player, true);
+		} else if (player != null && ASYNC_ACTION_COLLECTION.get() != null) {
+			collectAsyncFailure(new IllegalStateException(
+					"Potion reward could not be scheduled because the plugin is unavailable"));
 		}
+	}
+
+	/** Queues a legacy Bukkit action while exposing a nonblocking completion internally. */
+	private void scheduleLegacyRewardAction(Runnable action, Player player, boolean playerAware) {
+		CompletableFuture<Void> completion = new CompletableFuture<>();
+		if (!collectAsyncAction(completion)) {
+			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, action, player);
+			else getPlugin().getBukkitScheduler().runTask(plugin, action);
+			return;
+		}
+		AtomicBoolean claimed = new AtomicBoolean();
+		Runnable dispatch = () -> {
+			if (!claimed.compareAndSet(false, true)) return;
+			if (!plugin.isEnabled()) {
+				completion.completeExceptionally(new IllegalStateException("Plugin disabled before scheduled reward action ran"));
+				return;
+			}
+			try {
+				action.run();
+				completion.complete(null);
+			} catch (Throwable failure) {
+				completion.completeExceptionally(failure);
+			}
+		};
+		try {
+			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, dispatch, player);
+			else getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
+		} catch (Throwable failure) {
+			claimed.set(true);
+			completion.completeExceptionally(failure);
+		}
+		CompletableFuture.delayedExecutor(30, TimeUnit.SECONDS).execute(() -> {
+			if (claimed.compareAndSet(false, true)) {
+				completion.completeExceptionally(new TimeoutException("Timed out waiting for scheduled reward action"));
+			}
+		});
 	}
 
 	/**
@@ -1630,7 +1789,7 @@ public class AdvancedCoreUser {
 				return CompletableFuture.failedFuture(
 						new IllegalStateException("Player command could not run because the player or plugin is unavailable"));
 			}
-			return Reward.replayCommandSequence(plugin, placeholders, "player", cmds, command -> {
+			return Reward.replayCommandSequence(plugin, placeholders, "player", commands, cmds, (command, ignoredIndex) -> {
 				plugin.debug("Executing player command for " + getPlayerName() + ": " + command);
 				return runPlayerCommandAsync(player, command);
 			});

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -61,6 +61,7 @@ public class AdvancedCoreUser {
 	private static final String QUEUED_REFERENCE_PREFIX = "\\AdvancedCoreQueue/1/";
 	private static final String ASYNC_PROGRESS_DELIMITER = "%asyncprogress%";
 	private static final String ASYNC_RETRY_DELIMITER = "%asyncretry%";
+	private static final String ASYNC_OCCURRENCE_DELIMITER = "%asyncoccurrence%";
 	private final HashMap<String, Integer> offlineReplayInFlight = new HashMap<>();
 	private final HashSet<String> timedReplayInFlight = new HashSet<>();
 
@@ -269,13 +270,34 @@ public class AdvancedCoreUser {
 		String encodedName = Base64.getUrlEncoder().withoutPadding()
 				.encodeToString(reward.getRewardName().getBytes(StandardCharsets.UTF_8));
 		return QUEUED_REFERENCE_PREFIX + (reward.isGeneratedSnapshotCreated() ? "snapshot/" : "normal/")
-				+ encodedName;
+				+ encodedName + ASYNC_OCCURRENCE_DELIMITER + UUID.randomUUID();
 	}
 
 	private static QueuedReplay parseQueuedReplay(String storedReference) {
-		int marker = storedReference.lastIndexOf(ASYNC_PROGRESS_DELIMITER);
-		if (marker < 0) return new QueuedReplay(storedReference, 0, new HashMap<>());
-		String value = storedReference.substring(marker + ASYNC_PROGRESS_DELIMITER.length());
+		String occurrenceId = occurrenceId(storedReference);
+		String withoutOccurrence = stripAsyncOccurrenceMarker(storedReference);
+		int marker = withoutOccurrence.lastIndexOf(ASYNC_PROGRESS_DELIMITER);
+		if (marker < 0) return new QueuedReplay(withoutOccurrence, 0, new HashMap<>(), new HashMap<>(), false,
+				occurrenceId);
+		String value = withoutOccurrence.substring(marker + ASYNC_PROGRESS_DELIMITER.length());
+		if (value.startsWith("v3-")) {
+			try {
+				HashMap<String, Integer> progress = new HashMap<>();
+				HashMap<String, String> fingerprints = new HashMap<>();
+				String decoded = new String(Base64.getUrlDecoder().decode(value.substring(3)), StandardCharsets.UTF_8);
+				for (String line : decoded.split("\\n")) {
+					String[] pair = line.split("\\t", 3);
+					if (pair.length != 3) throw new IllegalArgumentException("Malformed replay checkpoint");
+					progress.put(new String(Base64.getUrlDecoder().decode(pair[0]), StandardCharsets.UTF_8),
+							Integer.parseInt(pair[1]));
+					fingerprints.put(new String(Base64.getUrlDecoder().decode(pair[0]), StandardCharsets.UTF_8), pair[2]);
+				}
+				return new QueuedReplay(withoutOccurrence.substring(0, marker), 0, progress, fingerprints, false,
+						occurrenceId);
+			} catch (IllegalArgumentException ignored) {
+				return new QueuedReplay(withoutOccurrence, 0, new HashMap<>(), new HashMap<>(), false, occurrenceId);
+			}
+		}
 		if (value.startsWith("v2-")) {
 			try {
 				HashMap<String, Integer> progress = new HashMap<>();
@@ -284,20 +306,49 @@ public class AdvancedCoreUser {
 					String[] pair = line.split("\\t", 2);
 					if (pair.length == 2) progress.put(pair[0], Integer.parseInt(pair[1]));
 				}
-				return new QueuedReplay(storedReference.substring(0, marker), 0, progress);
+				return new QueuedReplay(withoutOccurrence.substring(0, marker), 0, progress, new HashMap<>(), true,
+						occurrenceId);
 			} catch (IllegalArgumentException ignored) {
-				return new QueuedReplay(storedReference, 0, new HashMap<>());
+				return new QueuedReplay(withoutOccurrence, 0, new HashMap<>(), new HashMap<>(), false, occurrenceId);
 			}
 		}
 		try {
 			int progress = Integer.parseInt(value);
-			return progress > 0 ? new QueuedReplay(storedReference.substring(0, marker), progress, new HashMap<>())
-					: new QueuedReplay(storedReference.substring(0, marker), 0, new HashMap<>());
+			return progress > 0 ? new QueuedReplay(withoutOccurrence.substring(0, marker), progress, new HashMap<>(), new HashMap<>(), true,
+						occurrenceId)
+					: new QueuedReplay(withoutOccurrence.substring(0, marker), 0, new HashMap<>(), new HashMap<>(), false,
+							occurrenceId);
 		} catch (NumberFormatException ignored) {
 			// Preserve malformed legacy values as a normal reward reference instead
 			// of accidentally skipping an arbitrary portion of a reward chain.
-			return new QueuedReplay(storedReference, 0, new HashMap<>());
+			return new QueuedReplay(withoutOccurrence, 0, new HashMap<>(), new HashMap<>(), false, occurrenceId);
 		}
+	}
+
+	private static String occurrenceId(String storedReference) {
+		int marker = storedReference.indexOf(ASYNC_OCCURRENCE_DELIMITER);
+		if (marker < 0) return null;
+		int start = marker + ASYNC_OCCURRENCE_DELIMITER.length();
+		int end = storedReference.indexOf('%', start);
+		String candidate = storedReference.substring(start, end < 0 ? storedReference.length() : end);
+		try {
+			return UUID.fromString(candidate).toString();
+		} catch (IllegalArgumentException ignored) {
+			return null;
+		}
+	}
+
+	private static String stripAsyncOccurrenceMarker(String storedReference) {
+		int marker = storedReference.indexOf(ASYNC_OCCURRENCE_DELIMITER);
+		if (marker < 0) return storedReference;
+		int start = marker + ASYNC_OCCURRENCE_DELIMITER.length();
+		int end = storedReference.indexOf('%', start);
+		return storedReference.substring(0, marker) + (end < 0 ? "" : storedReference.substring(end));
+	}
+
+	private static String queuedReference(QueuedReplay replay) {
+		return replay.rewardReference + (replay.asyncReplayOccurrenceId == null ? ""
+				: ASYNC_OCCURRENCE_DELIMITER + replay.asyncReplayOccurrenceId);
 	}
 
 	private static String encodeAsyncReplayProgress(Map<String, Integer> progress) {
@@ -310,6 +361,25 @@ public class AdvancedCoreUser {
 		}
 		return encoded.length() == 0 ? "" : "v2-" + Base64.getUrlEncoder().withoutPadding()
 				.encodeToString(encoded.toString().getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String encodeAsyncReplayProgress(Map<String, Integer> progress, Map<String, String> fingerprints) {
+		if (fingerprints.isEmpty()) return encodeAsyncReplayProgress(progress);
+		StringBuilder encoded = new StringBuilder();
+		for (Entry<String, Integer> entry : progress.entrySet()) {
+			String fingerprint = fingerprints.get(entry.getKey());
+			if (entry.getValue() != null && entry.getValue() > 0 && fingerprint == null) {
+				return encodeAsyncReplayProgress(progress);
+			}
+		}
+		for (Entry<String, String> entry : fingerprints.entrySet()) {
+			if (entry.getValue() == null) continue;
+			encoded.append(Base64.getUrlEncoder().withoutPadding()
+						.encodeToString(entry.getKey().getBytes(StandardCharsets.UTF_8))).append('\t')
+						.append(progress.getOrDefault(entry.getKey(), 0)).append('\t').append(entry.getValue()).append('\n');
+		}
+		return encoded.length() == 0 ? encodeAsyncReplayProgress(progress) : "v3-"
+				+ Base64.getUrlEncoder().withoutPadding().encodeToString(encoded.toString().getBytes(StandardCharsets.UTF_8));
 	}
 
 	private static String stripTimedExecutionMarker(String storedReference) {
@@ -348,27 +418,27 @@ public class AdvancedCoreUser {
 	private static String withAsyncReplayProgress(String rewardEntry, Throwable failure) {
 		Reward.RewardReplayFailure replayFailure = replayFailure(failure);
 		int completed = completedAsyncInjections(failure);
-		String serializedProgress = replayFailure == null ? "" : encodeAsyncReplayProgress(replayFailure.getReplayProgress());
+		String serializedProgress = replayFailure == null ? "" : encodeAsyncReplayProgress(replayFailure.getReplayProgress(),
+				replayFailure.getReplayRegistryFingerprints());
 		if (completed <= 0 && serializedProgress.isEmpty()) return rewardEntry;
 		int placeholders = rewardEntry.indexOf("%placeholders%");
 		String storedReference = placeholders < 0 ? rewardEntry : rewardEntry.substring(0, placeholders);
 		String suffix = placeholders < 0 ? "" : rewardEntry.substring(placeholders);
 		if (replayFailure != null) suffix = "%placeholders%" + ArrayUtils.makeString(replayFailure.getReplayPlaceholders());
 		QueuedReplay queuedReplay = parseQueuedReplay(stripAsyncRetryMarker(storedReference));
-		if (!serializedProgress.isEmpty()) return queuedReplay.rewardReference + ASYNC_PROGRESS_DELIMITER
+		if (!serializedProgress.isEmpty()) return queuedReference(queuedReplay) + ASYNC_PROGRESS_DELIMITER
 				+ serializedProgress + suffix;
-		return queuedReplay.rewardReference + ASYNC_PROGRESS_DELIMITER
+		return queuedReference(queuedReplay) + ASYNC_PROGRESS_DELIMITER
 				+ Math.max(queuedReplay.completedAsyncInjections, completed) + suffix;
 	}
 
-	private static String withAsyncReplayProgress(String rewardEntry, Map<String, Integer> progress,
-			HashMap<String, String> placeholders) {
+	private static String withAsyncReplayProgress(String rewardEntry, Reward.ReplayCheckpoint checkpoint) {
 		int marker = rewardEntry.indexOf("%placeholders%");
 		String reference = marker < 0 ? rewardEntry : rewardEntry.substring(0, marker);
 		QueuedReplay queuedReplay = parseQueuedReplay(stripAsyncRetryMarker(reference));
-		String serialized = encodeAsyncReplayProgress(progress);
-		return queuedReplay.rewardReference + (serialized.isEmpty() ? "" : ASYNC_PROGRESS_DELIMITER + serialized)
-				+ "%placeholders%" + ArrayUtils.makeString(placeholders);
+		String serialized = encodeAsyncReplayProgress(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints());
+		return queuedReference(queuedReplay) + (serialized.isEmpty() ? "" : ASYNC_PROGRESS_DELIMITER + serialized)
+				+ "%placeholders%" + ArrayUtils.makeString(checkpoint.getPlaceholders());
 	}
 
 	private static int completedAsyncInjections(Throwable failure) {
@@ -393,12 +463,19 @@ public class AdvancedCoreUser {
 		private final String rewardReference;
 		private final int completedAsyncInjections;
 		private final Map<String, Integer> asyncReplayProgress;
+		private final Map<String, String> asyncReplayRegistryFingerprints;
+		private final boolean legacyAsyncReplayCheckpoint;
+		private final String asyncReplayOccurrenceId;
 
 		private QueuedReplay(String rewardReference, int completedAsyncInjections,
-				Map<String, Integer> asyncReplayProgress) {
+				Map<String, Integer> asyncReplayProgress, Map<String, String> asyncReplayRegistryFingerprints,
+				boolean legacyAsyncReplayCheckpoint, String asyncReplayOccurrenceId) {
 			this.rewardReference = rewardReference;
 			this.completedAsyncInjections = completedAsyncInjections;
 			this.asyncReplayProgress = asyncReplayProgress;
+			this.asyncReplayRegistryFingerprints = asyncReplayRegistryFingerprints;
+			this.legacyAsyncReplayCheckpoint = legacyAsyncReplayCheckpoint;
+			this.asyncReplayOccurrenceId = asyncReplayOccurrenceId;
 		}
 	}
 
@@ -463,6 +540,9 @@ public class AdvancedCoreUser {
 							.withPlaceHolder(ArrayUtils.fromString(placeholders));
 					replayOptions.setCompletedAsyncInjections(queuedReplay.completedAsyncInjections);
 					replayOptions.setAsyncReplayProgress(queuedReplay.asyncReplayProgress);
+					replayOptions.setAsyncReplayRegistryFingerprints(queuedReplay.asyncReplayRegistryFingerprints);
+					replayOptions.setLegacyAsyncReplayCheckpoint(queuedReplay.legacyAsyncReplayCheckpoint);
+					replayOptions.setAsyncReplayOccurrenceId(queuedReplay.asyncReplayOccurrenceId);
 					replayOptions.addPlaceholder("date",
 							"" + new SimpleDateFormat("EEE, d MMM yyyy HH:mm").format(new Date(time)));
 					// Keep the due entry durable while asynchronous stages are running.  A
@@ -518,6 +598,9 @@ public class AdvancedCoreUser {
 			if (force) options.setGiveOffline(false).forceOffline();
 			options.setCompletedAsyncInjections(queuedReplay.completedAsyncInjections);
 			options.setAsyncReplayProgress(queuedReplay.asyncReplayProgress);
+			options.setAsyncReplayRegistryFingerprints(queuedReplay.asyncReplayRegistryFingerprints);
+			options.setLegacyAsyncReplayCheckpoint(queuedReplay.legacyAsyncReplayCheckpoint);
+			options.setAsyncReplayOccurrenceId(queuedReplay.asyncReplayOccurrenceId);
 			AtomicReference<String> currentEntry = new AtomicReference<>(rewardEntry);
 			options.setAsyncReplayCheckpointConsumer(checkpoint -> checkpointOfflineReward(currentEntry, checkpoint));
 
@@ -532,7 +615,7 @@ public class AdvancedCoreUser {
 	private void checkpointOfflineReward(AtomicReference<String> currentEntry, Reward.ReplayCheckpoint checkpoint) {
 		synchronized (plugin) {
 			String current = currentEntry.get();
-			String updated = withAsyncReplayProgress(current, checkpoint.getReplayProgress(), checkpoint.getPlaceholders());
+			String updated = withAsyncReplayProgress(current, checkpoint);
 			ArrayList<String> pending = getOfflineRewards();
 			int index = pending.indexOf(current);
 			if (index >= 0) {
@@ -616,7 +699,7 @@ public class AdvancedCoreUser {
 	private synchronized void checkpointTimedReward(AtomicReference<String> currentEntry, long time,
 			Reward.ReplayCheckpoint checkpoint) {
 		String current = currentEntry.get();
-		String updated = withAsyncReplayProgress(current, checkpoint.getReplayProgress(), checkpoint.getPlaceholders());
+		String updated = withAsyncReplayProgress(current, checkpoint);
 		if (current.equals(updated)) return;
 		HashMap<String, Long> pending = getTimedRewards();
 		if (!Long.valueOf(time).equals(pending.get(current))) return;

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -1021,6 +1021,7 @@ public class AdvancedCoreUser {
 			int index = pending.indexOf(current);
 			if (index >= 0) {
 				pending.set(index, updated);
+				setOfflineRewardsDurably(pending, updated);
 				int claimed = claims.offline.getOrDefault(current, 0);
 				// Migrate this occurrence only. Identical legacy queue entries share a
 				// serialized key, but may each already be executing; moving the whole
@@ -1029,7 +1030,6 @@ public class AdvancedCoreUser {
 				else claims.offline.put(current, claimed - 1);
 				claims.offline.put(updated, claims.offline.getOrDefault(updated, 0) + 1);
 				currentEntry.set(updated);
-				setOfflineRewardsDurably(pending);
 			}
 		}
 	}
@@ -1062,9 +1062,17 @@ public class AdvancedCoreUser {
 		synchronized (plugin) {
 			ArrayList<String> pending = getOfflineRewards();
 			int index = pending.indexOf(rewardEntry);
-			if (index >= 0) pending.set(index, withAsyncReplayProgress(rewardEntry, failure));
-			releaseOfflineReward(rewardEntry);
-			setOfflineRewards(pending);
+			try {
+				if (index >= 0) {
+					String restored = withAsyncReplayProgress(rewardEntry, failure);
+					pending.set(index, restored);
+					setOfflineRewards(pending, true, restored);
+				} else {
+					setOfflineRewards(pending);
+				}
+			} finally {
+				releaseOfflineReward(rewardEntry);
+			}
 		}
 		plugin.getLogger().warning("Could not deliver queued offline reward for " + getPlayerName()
 				+ "; it will be retried: " + failure.getMessage());
@@ -2189,16 +2197,16 @@ public class AdvancedCoreUser {
 	 * replay. It completes only after each queued player command has run.
 	 */
 	public CompletionStage<Void> preformCommandAsync(ArrayList<String> commands, HashMap<String, String> placeholders) {
-		if (commands == null || commands.isEmpty()) return CompletableFuture.completedFuture(null);
 		try {
+			ArrayList<String> templates = commands == null ? new ArrayList<>() : new ArrayList<>(commands);
 			final ArrayList<String> cmds = PlaceholderUtils.replaceJavascript(getPlayer(),
-					PlaceholderUtils.replacePlaceHolder(commands, placeholders));
-			final Player player = getPlayer();
-			if (player == null || !plugin.isEnabled()) {
-				return CompletableFuture.failedFuture(
-						new IllegalStateException("Player command could not run because the player or plugin is unavailable"));
-			}
-			return Reward.replayCommandSequence(plugin, placeholders, "player", commands, cmds, (command, ignoredIndex) -> {
+					PlaceholderUtils.replacePlaceHolder(templates, placeholders));
+			return Reward.replayCommandSequence(plugin, placeholders, "player", templates, cmds, (command, ignoredIndex) -> {
+				final Player player = getPlayer();
+				if (player == null || !plugin.isEnabled()) {
+					return CompletableFuture.failedFuture(new IllegalStateException(
+							"Player command could not run because the player or plugin is unavailable"));
+				}
 				plugin.debug("Executing player command for " + getPlayerName() + ": " + command);
 				return runPlayerCommandAsync(player, command);
 			});
@@ -2568,19 +2576,34 @@ public class AdvancedCoreUser {
 		setOfflineRewards(offlineRewards, true);
 	}
 
-	/** Writes an async replay checkpoint before the next stage can execute. */
-	private void setOfflineRewardsDurably(ArrayList<String> offlineRewards) {
-		persistReplayCheckpoint(() -> setOfflineRewards(offlineRewards, false));
+	/** Writes a checkpoint without allowing size trimming to discard its active entry. */
+	private void setOfflineRewardsDurably(ArrayList<String> offlineRewards, String protectedEntry) {
+		persistReplayCheckpoint(() -> setOfflineRewards(offlineRewards, false, protectedEntry));
 	}
 
 	private void setOfflineRewards(ArrayList<String> offlineRewards, boolean queue) {
+		setOfflineRewards(offlineRewards, queue, null);
+	}
+
+	private void setOfflineRewards(ArrayList<String> offlineRewards, boolean queue, String protectedEntry) {
 		// MySQL TEXT max length is 65535 bytes
 		int maxLength = 65535;
 		String str = String.join("%line%", offlineRewards);
 
 		// Remove oldest rewards until within limit
 		while (str.getBytes().length > maxLength && !offlineRewards.isEmpty()) {
-			offlineRewards.remove(0);
+			int removalIndex = 0;
+			while (removalIndex < offlineRewards.size()
+					&& protectedEntry != null && protectedEntry.equals(offlineRewards.get(removalIndex))) {
+				removalIndex++;
+			}
+			if (removalIndex >= offlineRewards.size()) {
+				// Never trade a durable in-flight checkpoint for queue-size compliance.
+				// The storage write must retain the only record that prevents already
+				// completed non-idempotent stages from running again.
+				break;
+			}
+			offlineRewards.remove(removalIndex);
 			str = String.join("%line%", offlineRewards);
 		}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -8,14 +8,11 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
@@ -24,6 +21,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.bukkit.Bukkit;
@@ -74,45 +72,139 @@ public class AdvancedCoreUser {
 	private static final Object REPLAY_CLAIMS_LOCK = new Object();
 	private static final WeakHashMap<AdvancedCorePlugin, HashMap<String, ReplayClaims>> REPLAY_CLAIMS = new WeakHashMap<>();
 	private static final ThreadLocal<AsyncActionCollection> ASYNC_ACTION_COLLECTION = new ThreadLocal<>();
-	private static final ThreadLocal<ArrayList<CompletionStage<Void>>> CONTINUATION_ASYNC_ACTIONS =
-			ThreadLocal.withInitial(ArrayList::new);
-	private final Set<AsyncActionCollection> activeAsyncActionCollections = Collections
-			.newSetFromMap(new IdentityHashMap<>());
 
 	/** Internal completion scope used by asynchronous reward dispatch. */
 	public static final class AsyncActionCollection {
 		private final AsyncActionCollection previous;
-		private final ArrayList<CompletionStage<Void>> actions = new ArrayList<>();
+		private final AdvancedCoreUser owner;
+		private final ArrayList<Supplier<CompletionStage<Void>>> actions = new ArrayList<>();
+		private final Reward.ReplayState replayState;
+		private final HashMap<String, String> placeholders;
+		private final String checkpointKey;
+		private final int completedActions;
+		private final AdvancedCorePlugin plugin;
 		private boolean closed;
 
-		private AsyncActionCollection(AsyncActionCollection previous) {
+		private AsyncActionCollection(AsyncActionCollection previous, AdvancedCoreUser owner, Reward.ReplayState replayState,
+				HashMap<String, String> placeholders, String injectionKey, AdvancedCorePlugin plugin) {
 			this.previous = previous;
+			this.owner = owner;
+			this.replayState = replayState;
+			this.placeholders = placeholders;
+			this.checkpointKey = Reward.legacyActionReplayKey(injectionKey);
+			this.completedActions = Reward.completedLegacyActions(replayState, placeholders, checkpointKey);
+			this.plugin = plugin;
 		}
 
-		private synchronized boolean add(CompletionStage<Void> action) {
+		private synchronized boolean add(Supplier<CompletionStage<Void>> action) {
 			if (closed) return false;
 			actions.add(action);
 			return true;
 		}
 
+		private boolean belongsTo(AdvancedCoreUser user) {
+			return owner == user;
+		}
+
 		private synchronized CompletionStage<Void> closeAndAwait() {
 			closed = true;
 			CompletionStage<Void> result = CompletableFuture.completedFuture(null);
-			for (CompletionStage<Void> action : actions) {
-				result = result.thenCompose(ignored -> action);
+			for (int index = 0; index < actions.size(); index++) {
+				if (index < completedActions) continue;
+				Supplier<CompletionStage<Void>> action = actions.get(index);
+				int checkpoint = index + 1;
+				result = result.thenCompose(ignored -> {
+					try {
+						CompletionStage<Void> stage = action.get();
+						return stage == null ? CompletableFuture.failedFuture(
+								new IllegalStateException("Scheduled reward action returned null")) : stage;
+					} catch (Throwable failure) {
+						return CompletableFuture.failedFuture(failure);
+					}
+				}).thenCompose(ignored -> checkpoint(checkpoint));
 			}
 			return result;
+		}
+
+		private CompletionStage<Void> checkpoint(int completed) {
+			if (replayState == null || placeholders == null) return CompletableFuture.completedFuture(null);
+			String value = String.valueOf(completed);
+			placeholders.put(checkpointKey, value);
+			replayState.recordReplayMetadata(checkpointKey, value);
+			return replayState.persistCheckpointAsync(plugin, placeholders);
+		}
+	}
+
+	/**
+	 * Explicitly carries an async injector's originating action scope into a
+	 * completion callback. Injectors capture this while their request method is
+	 * invoked, then wrap only callbacks whose legacy user actions belong to that
+	 * request. It deliberately does not infer ownership from other pending work
+	 * on the callback thread.
+	 */
+	public static final class AsyncActionContext {
+		private final AsyncActionCollection collection;
+
+		private AsyncActionContext(AsyncActionCollection collection) {
+			this.collection = collection;
+		}
+
+		/** Wraps a CompletionStage callback that has no return value. */
+		public Runnable wrap(Runnable callback) {
+			if (callback == null) throw new IllegalArgumentException("callback cannot be null");
+			return () -> runInScope(() -> {
+				callback.run();
+				return null;
+			});
+		}
+
+		/** Wraps a CompletionStage mapping callback while preserving its result. */
+		public <T, R> Function<T, R> wrap(Function<T, R> callback) {
+			if (callback == null) throw new IllegalArgumentException("callback cannot be null");
+			return value -> runInScope(() -> callback.apply(value));
+		}
+
+		/** Wraps a deferred supplier used by an asynchronous injector. */
+		public <T> Supplier<T> wrap(Supplier<T> callback) {
+			if (callback == null) throw new IllegalArgumentException("callback cannot be null");
+			return () -> runInScope(callback);
+		}
+
+		private <T> T runInScope(Supplier<T> callback) {
+			if (collection == null) return callback.get();
+			AsyncActionCollection previous = ASYNC_ACTION_COLLECTION.get();
+			ASYNC_ACTION_COLLECTION.set(collection);
+			try {
+				return callback.get();
+			} finally {
+				if (previous == null) ASYNC_ACTION_COLLECTION.remove();
+				else ASYNC_ACTION_COLLECTION.set(previous);
+			}
 		}
 	}
 
 	/** Starts collecting completion stages created by legacy reward callbacks. */
 	public AsyncActionCollection beginAsyncActionCollection() {
-		AsyncActionCollection collection = new AsyncActionCollection(ASYNC_ACTION_COLLECTION.get());
-		synchronized (activeAsyncActionCollections) {
-			activeAsyncActionCollections.add(collection);
-		}
+		return beginAsyncActionCollection(null, null, null);
+	}
+
+	/** Starts a collection whose legacy actions advance the current replay checkpoint individually. */
+	public AsyncActionCollection beginAsyncActionCollection(Reward.ReplayState replayState,
+			HashMap<String, String> placeholders, String injectionKey) {
+		AsyncActionCollection collection = new AsyncActionCollection(ASYNC_ACTION_COLLECTION.get(), this, replayState,
+				placeholders, injectionKey, plugin);
 		ASYNC_ACTION_COLLECTION.set(collection);
 		return collection;
+	}
+
+	/**
+	 * Captures this user's active injector scope for an explicitly wrapped async
+	 * continuation. Calling this outside the originating injector returns an
+	 * inert context, so unrelated work keeps its ordinary scheduling semantics.
+	 */
+	public AsyncActionContext captureAsyncActionContext() {
+		AsyncActionCollection collection = ASYNC_ACTION_COLLECTION.get();
+		return new AsyncActionContext(collection != null && collection.belongsTo(this) ? collection : null);
 	}
 
 	/** Restores the calling thread's previous collection while keeping this scope active for its returned stage. */
@@ -126,34 +218,30 @@ public class AdvancedCoreUser {
 	public CompletionStage<Void> endAsyncActionCollection(AsyncActionCollection collection) {
 		if (collection == null) return CompletableFuture.completedFuture(null);
 		restoreAsyncActionCollectionScope(collection);
-		synchronized (activeAsyncActionCollections) {
-			activeAsyncActionCollections.remove(collection);
-			return collection.closeAndAwait();
-		}
+		return collection.closeAndAwait();
 	}
 
 	private boolean collectAsyncAction(CompletionStage<Void> action) {
-		AsyncActionCollection collection = ASYNC_ACTION_COLLECTION.get();
-		if (collection != null && collection.add(action)) return true;
-		synchronized (activeAsyncActionCollections) {
-			if (activeAsyncActionCollections.isEmpty()) return false;
-			// A CompletionStage continuation runs before completion callbacks attached
-			// to its returned stage. Hold its legacy action on that same thread until
-			// requestInjectionAsync's callback claims it for the exact collection.
-			CONTINUATION_ASYNC_ACTIONS.get().add(action);
-			return true;
-		}
+		return collectAsyncAction(() -> action);
 	}
 
-	/** Claims legacy actions created by the continuation that just completed on this thread. */
-	public void claimAsyncContinuationActions(AsyncActionCollection collection) {
-		if (collection == null) return;
-		ArrayList<CompletionStage<Void>> pending = CONTINUATION_ASYNC_ACTIONS.get();
-		if (pending.isEmpty()) return;
-		for (CompletionStage<Void> action : pending) collection.add(action);
-		pending.clear();
-		CONTINUATION_ASYNC_ACTIONS.remove();
+	private boolean collectAsyncAction(Supplier<CompletionStage<Void>> action) {
+		AsyncActionCollection collection = ASYNC_ACTION_COLLECTION.get();
+		if (collection != null && collection.belongsTo(this) && collection.add(action)) return true;
+		// Do not infer ownership from another pending collection. A normal synchronous
+		// reward can run while an unrelated async injection is waiting; it must retain
+		// its established fire-and-forget scheduling semantics instead of being made a
+		// dependency of whichever injection completes next on this thread.
+		return false;
 	}
+
+	/**
+	 * Retained for binary compatibility with integrations that previously called
+	 * this internal hand-off hook. Unscoped actions are intentionally not claimed:
+	 * only actions created while their originating collection is active may become
+	 * part of that collection.
+	 */
+	public void claimAsyncContinuationActions(AsyncActionCollection collection) { }
 
 	private void collectAsyncFailure(Throwable failure) {
 		collectAsyncAction(CompletableFuture.failedFuture(failure));
@@ -1407,38 +1495,39 @@ public class AdvancedCoreUser {
 
 	/** Queues a legacy Bukkit action while exposing a nonblocking completion internally. */
 	private void scheduleLegacyRewardAction(Runnable action, Player player, boolean playerAware) {
-		CompletableFuture<Void> completion = new CompletableFuture<>();
-		if (!collectAsyncAction(completion)) {
-			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, action, player);
-			else getPlugin().getBukkitScheduler().runTask(plugin, action);
-			return;
-		}
-		AtomicBoolean claimed = new AtomicBoolean();
-		Runnable dispatch = () -> {
-			if (!claimed.compareAndSet(false, true)) return;
-			if (!plugin.isEnabled()) {
-				completion.completeExceptionally(new IllegalStateException("Plugin disabled before scheduled reward action ran"));
-				return;
-			}
+		if (!collectAsyncAction(() -> {
+			CompletableFuture<Void> completion = new CompletableFuture<>();
+			AtomicBoolean claimed = new AtomicBoolean();
+			Runnable dispatch = () -> {
+				if (!claimed.compareAndSet(false, true)) return;
+				if (!plugin.isEnabled()) {
+					completion.completeExceptionally(new IllegalStateException("Plugin disabled before scheduled reward action ran"));
+					return;
+				}
+				try {
+					action.run();
+					completion.complete(null);
+				} catch (Throwable failure) {
+					completion.completeExceptionally(failure);
+				}
+			};
 			try {
-				action.run();
-				completion.complete(null);
+				if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, dispatch, player);
+				else getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
 			} catch (Throwable failure) {
+				claimed.set(true);
 				completion.completeExceptionally(failure);
 			}
-		};
-		try {
-			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, dispatch, player);
-			else getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
-		} catch (Throwable failure) {
-			claimed.set(true);
-			completion.completeExceptionally(failure);
+			CompletableFuture.delayedExecutor(30, TimeUnit.SECONDS).execute(() -> {
+				if (claimed.compareAndSet(false, true)) {
+					completion.completeExceptionally(new TimeoutException("Timed out waiting for scheduled reward action"));
+				}
+			});
+			return completion;
+		})) {
+			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, action, player);
+			else getPlugin().getBukkitScheduler().runTask(plugin, action);
 		}
-		CompletableFuture.delayedExecutor(30, TimeUnit.SECONDS).execute(() -> {
-			if (claimed.compareAndSet(false, true)) {
-				completion.completeExceptionally(new TimeoutException("Timed out waiting for scheduled reward action"));
-			}
-		});
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -896,9 +896,9 @@ public class AdvancedCoreUser {
 	 * @param name the reward name
 	 */
 	public synchronized void addUnClaimedChoiceReward(String name) {
-		ArrayList<String> choices = getUnClaimedChoices();
+		ArrayList<String> choices = getStoredUnClaimedChoices();
 		choices.add(name);
-		setUnClaimedChoice(choices);
+		getData().setStringList("UnClaimedChoices", choices);
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -322,9 +322,27 @@ public class AdvancedCoreUser {
 	 * @param placeholders the placeholders
 	 */
 	public void addOfflineRewards(Reward reward, HashMap<String, String> placeholders) {
+		addOfflineRewards(reward, placeholders, null);
+	}
+
+	/**
+	 * Adds an offline reward while retaining an in-flight asynchronous replay's
+	 * occurrence and durable checkpoint.  This overload is used when pause or
+	 * vanish handling defers a reward before its async chain can complete.
+	 *
+	 * @param reward       the reward
+	 * @param placeholders the placeholders
+	 * @param options      replay options to preserve, if any
+	 */
+	public void addOfflineRewards(Reward reward, HashMap<String, String> placeholders, RewardOptions options) {
 		synchronized (plugin) {
 			ArrayList<String> offlineRewards = getOfflineRewards();
-			offlineRewards.add(queuedRewardReference(reward) + "%placeholders%" + ArrayUtils.makeString(placeholders));
+			Reward.preserveReplayState(options);
+			HashMap<String, String> savedPlaceholders = placeholders == null ? new HashMap<>()
+					: new HashMap<>(placeholders);
+			if (options != null) savedPlaceholders.putAll(options.getPlaceholders());
+			offlineRewards.add(queuedRewardReference(reward, options) + "%placeholders%"
+					+ ArrayUtils.makeString(savedPlaceholders));
 			setOfflineRewards(offlineRewards);
 		}
 	}
@@ -369,10 +387,26 @@ public class AdvancedCoreUser {
 	}
 
 	private String queuedRewardReference(Reward reward) {
+		return queuedRewardReference(reward, null);
+	}
+
+	private String queuedRewardReference(Reward reward, RewardOptions options) {
 		String encodedName = Base64.getUrlEncoder().withoutPadding()
 				.encodeToString(reward.getRewardName().getBytes(StandardCharsets.UTF_8));
-		return QUEUED_REFERENCE_PREFIX + (reward.isGeneratedSnapshotCreated() ? "snapshot/" : "normal/")
-				+ encodedName + ASYNC_OCCURRENCE_DELIMITER + UUID.randomUUID();
+		String reference = QUEUED_REFERENCE_PREFIX + (reward.isGeneratedSnapshotCreated() ? "snapshot/" : "normal/")
+				+ encodedName + ASYNC_OCCURRENCE_DELIMITER
+				+ (options == null || options.getAsyncReplayOccurrenceId() == null
+						|| options.getAsyncReplayOccurrenceId().isEmpty() ? UUID.randomUUID()
+							: options.getAsyncReplayOccurrenceId());
+		if (options != null) {
+			String serialized = encodeAsyncReplayProgress(options.getAsyncReplayProgress(),
+					options.getAsyncReplayRegistryFingerprints());
+			if (!serialized.isEmpty()) reference += ASYNC_PROGRESS_DELIMITER + serialized;
+			else if (options.getCompletedAsyncInjections() > 0) {
+				reference += ASYNC_PROGRESS_DELIMITER + options.getCompletedAsyncInjections();
+			}
+		}
+		return reference;
 	}
 
 	private static QueuedReplay parseQueuedReplay(String storedReference) {
@@ -911,12 +945,19 @@ public class AdvancedCoreUser {
 	}
 
 	private void releaseReplayClaimsIfEmpty(ReplayClaims claims) {
-		if (!claims.offline.isEmpty() || !claims.timed.isEmpty()) return;
-		synchronized (REPLAY_CLAIMS_LOCK) {
-			HashMap<String, ReplayClaims> byUser = REPLAY_CLAIMS.get(plugin);
-			if (byUser == null || byUser.get(getUUID()) != claims) return;
-			byUser.remove(getUUID());
-			if (byUser.isEmpty()) REPLAY_CLAIMS.remove(plugin);
+		synchronized (plugin) {
+			synchronized (REPLAY_CLAIMS_LOCK) {
+				// Claim mutations use the same lock ordering (plugin, then this
+				// lock). Recheck only while holding both locks; checking before
+				// entering them permits a concurrent wrapper to add a claim that
+				// cleanup then drops.
+				if (!claims.offline.isEmpty() || !claims.timed.isEmpty()
+						|| !claims.serialReplayTail.isDone()) return;
+				HashMap<String, ReplayClaims> byUser = REPLAY_CLAIMS.get(plugin);
+				if (byUser == null || byUser.get(getUUID()) != claims) return;
+				byUser.remove(getUUID());
+				if (byUser.isEmpty()) REPLAY_CLAIMS.remove(plugin);
+			}
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -1609,14 +1609,19 @@ public class AdvancedCoreUser {
 	 */
 	public void givePotionEffect(String potionName, int duration, int amplifier) {
 		Player player = getPlayer();
-		if (player != null && plugin.isEnabled()) {
-			scheduleLegacyRewardAction(() -> player.addPotionEffect(
-					new PotionEffect(PotionEffectType.getByName(potionName), 20 * duration, amplifier)), player, true,
-					"potion:" + potionName + ":" + duration + ":" + amplifier);
-		} else if (player != null && ASYNC_ACTION_COLLECTION.get() != null) {
-			collectAsyncFailure(new IllegalStateException(
-					"Potion reward could not be scheduled because the plugin is unavailable"));
+		if (player == null) {
+			if (hasOwnedAsyncActionCollection()) collectAsyncFailure(new IllegalStateException(
+					"Player became unavailable before potion reward delivery"));
+			return;
 		}
+		if (!plugin.isEnabled()) {
+			if (hasOwnedAsyncActionCollection()) collectAsyncFailure(new IllegalStateException(
+					"Potion reward could not be scheduled because the plugin is unavailable"));
+			return;
+		}
+		scheduleLegacyRewardAction(() -> player.addPotionEffect(
+				new PotionEffect(PotionEffectType.getByName(potionName), 20 * duration, amplifier)), player, true,
+				"potion:" + potionName + ":" + duration + ":" + amplifier);
 	}
 
 	/** Queues a legacy Bukkit action while exposing a nonblocking completion internally. */
@@ -1730,6 +1735,7 @@ public class AdvancedCoreUser {
 					return;
 				}
 				try {
+					if (playerAware) validateLiveScheduledPlayer(player);
 					CompletionStage<Void> stage = action.get();
 					if (stage == null) {
 						completion.completeExceptionally(new IllegalStateException("Scheduled reward action returned null"));
@@ -1769,6 +1775,17 @@ public class AdvancedCoreUser {
 			};
 			if (playerAware) getPlugin().getBukkitScheduler().runTask(plugin, dispatch, player);
 			else getPlugin().getBukkitScheduler().runTask(plugin, dispatch);
+		}
+	}
+
+	/** Runs on the player-owned scheduler before a replay-aware player mutation. */
+	private void validateLiveScheduledPlayer(Player player) {
+		if (player == null || player.getUniqueId() == null) {
+			throw new IllegalStateException("Scheduled player reward has no live player identity");
+		}
+		Player current = Bukkit.getPlayer(player.getUniqueId());
+		if (current != player || !current.isOnline()) {
+			throw new IllegalStateException("Player became unavailable before scheduled reward delivery");
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -107,7 +107,8 @@ public class AdvancedCoreUser {
 			String fingerprint = Reward.legacyActionFingerprint(descriptor);
 			int occurrence = actionOccurrences.getOrDefault(fingerprint, 0);
 			actionOccurrences.put(fingerprint, occurrence + 1);
-			actions.add(new ReplayAction(fingerprint + "/" + occurrence, fingerprint, action));
+			actions.add(new ReplayAction(fingerprint + "/" + occurrence, fingerprint, action,
+					!descriptor.startsWith("failure:")));
 			return true;
 		}
 
@@ -118,7 +119,9 @@ public class AdvancedCoreUser {
 		private synchronized CompletionStage<Void> closeAndAwait() {
 			closed = true;
 			HashMap<String, String> currentSnapshot = new HashMap<>();
-			for (ReplayAction action : actions) currentSnapshot.put(action.identity, action.fingerprint);
+			for (ReplayAction action : actions) {
+				if (action.durable) currentSnapshot.put(action.identity, action.fingerprint);
+			}
 			HashMap<String, String> persistedSnapshot;
 			HashSet<String> completed;
 			try {
@@ -137,6 +140,13 @@ public class AdvancedCoreUser {
 			boolean snapshotChanged = persistedSnapshot.isEmpty();
 			if (snapshotChanged) persistedSnapshot = new HashMap<>(currentSnapshot);
 			else if (!persistedSnapshot.equals(currentSnapshot)) {
+				for (Entry<String, String> persisted : persistedSnapshot.entrySet()) {
+					if (!completed.contains(persisted.getKey())
+							&& !persisted.getValue().equals(currentSnapshot.get(persisted.getKey()))) {
+						return CompletableFuture.failedFuture(new IllegalStateException(
+								"Cannot safely resume because an unfinished legacy reward action changed or disappeared"));
+					}
+				}
 				// The actions are deliberately matched individually below. Retaining the
 				// original snapshot lets a reordered, shortened, or extended config skip
 				// only the exact effects known to have completed. New actions are added
@@ -160,6 +170,7 @@ public class AdvancedCoreUser {
 						return CompletableFuture.failedFuture(failure);
 					}
 				}).thenCompose(ignored -> {
+					if (!action.durable) return CompletableFuture.completedFuture(null);
 					completed.add(action.identity);
 					recordReplayValue(checkpointKey, encodeCompleted(completed));
 					return checkpoint();
@@ -243,11 +254,14 @@ public class AdvancedCoreUser {
 			private final String identity;
 			private final String fingerprint;
 			private final Supplier<CompletionStage<Void>> action;
+			private final boolean durable;
 
-			private ReplayAction(String identity, String fingerprint, Supplier<CompletionStage<Void>> action) {
+			private ReplayAction(String identity, String fingerprint, Supplier<CompletionStage<Void>> action,
+					boolean durable) {
 				this.identity = identity;
 				this.fingerprint = fingerprint;
 				this.action = action;
+				this.durable = durable;
 			}
 		}
 	}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -352,6 +352,11 @@ public class AdvancedCoreUser {
 		return false;
 	}
 
+	private boolean hasOwnedAsyncActionCollection() {
+		AsyncActionCollection collection = ASYNC_ACTION_COLLECTION.get();
+		return collection != null && collection.belongsTo(this);
+	}
+
 	/**
 	 * Retained for binary compatibility with integrations that previously called
 	 * this internal hand-off hook. Unscoped actions are intentionally not claimed:
@@ -1493,7 +1498,12 @@ public class AdvancedCoreUser {
 	 * @param builder the item builder
 	 */
 	public void giveItem(ItemBuilder builder) {
-		giveItem(builder.toItemStack(getPlayer()));
+		Player player = getPlayer();
+		if (player == null && hasOwnedAsyncActionCollection()) {
+			collectAsyncFailure(new IllegalStateException("Player became unavailable before item reward delivery"));
+			return;
+		}
+		giveItem(builder.toItemStack(player));
 	}
 
 	/**
@@ -1523,7 +1533,7 @@ public class AdvancedCoreUser {
 	 * @param placeholders the placeholders
 	 */
 	public void giveItem(ItemStack itemStack, HashMap<String, String> placeholders) {
-		giveItem(new ItemBuilder(itemStack).setPlaceholders(placeholders).toItemStack(getPlayer()));
+		giveItem(new ItemBuilder(itemStack).setPlaceholders(placeholders));
 	}
 
 	/**
@@ -1615,7 +1625,8 @@ public class AdvancedCoreUser {
 		for (ItemStack current : item) {
 			descriptor.append('\n').append(itemDescriptor(current));
 		}
-		if (collectAsyncAction(() -> player == null ? CompletableFuture.completedFuture(null)
+		if (collectAsyncAction(() -> player == null ? CompletableFuture.failedFuture(
+				new IllegalStateException("Player became unavailable before item reward delivery"))
 				: plugin.getFullInventoryHandler().giveItemAsync(player, item), descriptor.toString())) {
 			return;
 		}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -616,8 +616,19 @@ public class AdvancedCoreUser {
 			HashMap<String, String> savedPlaceholders = placeholders == null ? new HashMap<>()
 					: new HashMap<>(placeholders);
 			if (options != null) savedPlaceholders.putAll(options.getPlaceholders());
-			offlineRewards.add(queuedRewardReference(reward, options) + "%placeholders%"
-					+ ArrayUtils.makeString(savedPlaceholders));
+			String queued = queuedRewardReference(reward, options) + "%placeholders%"
+					+ ArrayUtils.makeString(savedPlaceholders);
+			String occurrence = options == null ? null : options.getAsyncReplayOccurrenceId();
+			int replacement = -1;
+			if (occurrence != null && !occurrence.isEmpty()) {
+				for (int index = offlineRewards.size() - 1; index >= 0; index--) {
+					if (!occurrence.equals(occurrenceId(offlineRewards.get(index)))) continue;
+					replacement = index;
+					offlineRewards.remove(index);
+				}
+			}
+			if (replacement < 0) offlineRewards.add(queued);
+			else offlineRewards.add(Math.min(replacement, offlineRewards.size()), queued);
 			setOfflineRewards(offlineRewards);
 		}
 	}
@@ -1178,6 +1189,14 @@ public class AdvancedCoreUser {
 	private boolean claimOfflineReward(String rewardEntry) {
 		synchronized (plugin) {
 			ReplayClaims claims = replayClaims();
+			String occurrence = occurrenceId(rewardEntry);
+			if (occurrence != null) {
+				boolean claimed = claims.offline.entrySet().stream().anyMatch(entry -> entry.getValue() > 0
+						&& occurrence.equals(occurrenceId(entry.getKey())));
+				if (claimed) return false;
+				claims.offline.put(rewardEntry, 1);
+				return true;
+			}
 			int occurrences = 0;
 			for (String pending : getOfflineRewards()) if (rewardEntry.equals(pending)) occurrences++;
 			int claimed = claims.offline.getOrDefault(rewardEntry, 0);

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -1876,11 +1876,11 @@ public class AdvancedCoreUser {
 	/** Runs on the player-owned scheduler before a replay-aware player mutation. */
 	private void validateLiveScheduledPlayer(Player player) {
 		if (player == null || player.getUniqueId() == null) {
-			throw new IllegalStateException("Scheduled player reward has no live player identity");
+			throw replayActionNotStarted("Scheduled player reward has no live player identity");
 		}
 		Player current = Bukkit.getPlayer(player.getUniqueId());
 		if (current != player || !current.isOnline()) {
-			throw new IllegalStateException("Player became unavailable before scheduled reward delivery");
+			throw replayActionNotStarted("Player became unavailable before scheduled reward delivery");
 		}
 	}
 

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/AdvancedCoreUser.java
@@ -10,9 +10,12 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
@@ -56,6 +59,10 @@ import net.md_5.bungee.chat.ComponentSerializer;
 public class AdvancedCoreUser {
 
 	private static final String QUEUED_REFERENCE_PREFIX = "\\AdvancedCoreQueue/1/";
+	private static final String ASYNC_PROGRESS_DELIMITER = "%asyncprogress%";
+	private static final String ASYNC_RETRY_DELIMITER = "%asyncretry%";
+	private final HashMap<String, Integer> offlineReplayInFlight = new HashMap<>();
+	private final HashSet<String> timedReplayInFlight = new HashSet<>();
 
 	/**
 	 * User data fetch mode for this user.
@@ -249,7 +256,7 @@ public class AdvancedCoreUser {
 	 *                     given
 	 */
 	public synchronized void addTimedReward(Reward reward, HashMap<String, String> placeholders, long epochMilli) {
-		HashMap<String, Long> timed = getTimedRewards();
+		HashMap<String, Long> timed = new HashMap<>(getTimedRewards());
 		String rewardName = queuedRewardReference(reward);
 		rewardName += "%extime%" + System.currentTimeMillis();
 
@@ -263,6 +270,136 @@ public class AdvancedCoreUser {
 				.encodeToString(reward.getRewardName().getBytes(StandardCharsets.UTF_8));
 		return QUEUED_REFERENCE_PREFIX + (reward.isGeneratedSnapshotCreated() ? "snapshot/" : "normal/")
 				+ encodedName;
+	}
+
+	private static QueuedReplay parseQueuedReplay(String storedReference) {
+		int marker = storedReference.lastIndexOf(ASYNC_PROGRESS_DELIMITER);
+		if (marker < 0) return new QueuedReplay(storedReference, 0, new HashMap<>());
+		String value = storedReference.substring(marker + ASYNC_PROGRESS_DELIMITER.length());
+		if (value.startsWith("v2-")) {
+			try {
+				HashMap<String, Integer> progress = new HashMap<>();
+				String decoded = new String(Base64.getUrlDecoder().decode(value.substring(3)), StandardCharsets.UTF_8);
+				for (String line : decoded.split("\\n")) {
+					String[] pair = line.split("\\t", 2);
+					if (pair.length == 2) progress.put(pair[0], Integer.parseInt(pair[1]));
+				}
+				return new QueuedReplay(storedReference.substring(0, marker), 0, progress);
+			} catch (IllegalArgumentException ignored) {
+				return new QueuedReplay(storedReference, 0, new HashMap<>());
+			}
+		}
+		try {
+			int progress = Integer.parseInt(value);
+			return progress > 0 ? new QueuedReplay(storedReference.substring(0, marker), progress, new HashMap<>())
+					: new QueuedReplay(storedReference.substring(0, marker), 0, new HashMap<>());
+		} catch (NumberFormatException ignored) {
+			// Preserve malformed legacy values as a normal reward reference instead
+			// of accidentally skipping an arbitrary portion of a reward chain.
+			return new QueuedReplay(storedReference, 0, new HashMap<>());
+		}
+	}
+
+	private static String encodeAsyncReplayProgress(Map<String, Integer> progress) {
+		if (progress.isEmpty()) return "";
+		StringBuilder encoded = new StringBuilder();
+		for (Entry<String, Integer> entry : progress.entrySet()) {
+			if (entry.getValue() != null && entry.getValue() > 0) {
+				encoded.append(entry.getKey()).append('\t').append(entry.getValue()).append('\n');
+			}
+		}
+		return encoded.length() == 0 ? "" : "v2-" + Base64.getUrlEncoder().withoutPadding()
+				.encodeToString(encoded.toString().getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String stripTimedExecutionMarker(String storedReference) {
+		int marker = storedReference.indexOf("%extime%");
+		if (marker < 0) return stripAsyncRetryMarker(storedReference);
+		int valueStart = marker + "%extime%".length();
+		int nextMarker = storedReference.indexOf('%', valueStart);
+		return stripAsyncRetryMarker(storedReference.substring(0, marker)
+				+ (nextMarker < 0 ? "" : storedReference.substring(nextMarker)));
+	}
+
+	private static String stripAsyncRetryMarker(String storedReference) {
+		int marker = storedReference.indexOf(ASYNC_RETRY_DELIMITER);
+		if (marker < 0) return storedReference;
+		int valueStart = marker + ASYNC_RETRY_DELIMITER.length();
+		int nextMarker = storedReference.indexOf('%', valueStart);
+		return storedReference.substring(0, marker) + (nextMarker < 0 ? "" : storedReference.substring(nextMarker));
+	}
+
+	private static int asyncRetryCount(String rewardEntry) {
+		int marker = rewardEntry.indexOf(ASYNC_RETRY_DELIMITER);
+		if (marker < 0) return 0;
+		int valueStart = marker + ASYNC_RETRY_DELIMITER.length();
+		int nextMarker = rewardEntry.indexOf('%', valueStart);
+		try { return Integer.parseInt(rewardEntry.substring(valueStart, nextMarker < 0 ? rewardEntry.length() : nextMarker)); }
+		catch (NumberFormatException ignored) { return 0; }
+	}
+
+	private static String withAsyncRetryCount(String rewardEntry, int count) {
+		int placeholders = rewardEntry.indexOf("%placeholders%");
+		String reference = placeholders < 0 ? rewardEntry : rewardEntry.substring(0, placeholders);
+		String suffix = placeholders < 0 ? "" : rewardEntry.substring(placeholders);
+		return stripAsyncRetryMarker(reference) + ASYNC_RETRY_DELIMITER + count + suffix;
+	}
+
+	private static String withAsyncReplayProgress(String rewardEntry, Throwable failure) {
+		Reward.RewardReplayFailure replayFailure = replayFailure(failure);
+		int completed = completedAsyncInjections(failure);
+		String serializedProgress = replayFailure == null ? "" : encodeAsyncReplayProgress(replayFailure.getReplayProgress());
+		if (completed <= 0 && serializedProgress.isEmpty()) return rewardEntry;
+		int placeholders = rewardEntry.indexOf("%placeholders%");
+		String storedReference = placeholders < 0 ? rewardEntry : rewardEntry.substring(0, placeholders);
+		String suffix = placeholders < 0 ? "" : rewardEntry.substring(placeholders);
+		if (replayFailure != null) suffix = "%placeholders%" + ArrayUtils.makeString(replayFailure.getReplayPlaceholders());
+		QueuedReplay queuedReplay = parseQueuedReplay(stripAsyncRetryMarker(storedReference));
+		if (!serializedProgress.isEmpty()) return queuedReplay.rewardReference + ASYNC_PROGRESS_DELIMITER
+				+ serializedProgress + suffix;
+		return queuedReplay.rewardReference + ASYNC_PROGRESS_DELIMITER
+				+ Math.max(queuedReplay.completedAsyncInjections, completed) + suffix;
+	}
+
+	private static String withAsyncReplayProgress(String rewardEntry, Map<String, Integer> progress,
+			HashMap<String, String> placeholders) {
+		int marker = rewardEntry.indexOf("%placeholders%");
+		String reference = marker < 0 ? rewardEntry : rewardEntry.substring(0, marker);
+		QueuedReplay queuedReplay = parseQueuedReplay(stripAsyncRetryMarker(reference));
+		String serialized = encodeAsyncReplayProgress(progress);
+		return queuedReplay.rewardReference + (serialized.isEmpty() ? "" : ASYNC_PROGRESS_DELIMITER + serialized)
+				+ "%placeholders%" + ArrayUtils.makeString(placeholders);
+	}
+
+	private static int completedAsyncInjections(Throwable failure) {
+		Throwable current = failure;
+		while (current != null) {
+			if (current instanceof Reward.RewardReplayFailure) {
+				return ((Reward.RewardReplayFailure) current).getCompletedInjectionCount();
+			}
+			current = current.getCause();
+		}
+		return 0;
+	}
+
+	private static Reward.RewardReplayFailure replayFailure(Throwable failure) {
+		for (Throwable current = failure; current != null; current = current.getCause()) {
+			if (current instanceof Reward.RewardReplayFailure) return (Reward.RewardReplayFailure) current;
+		}
+		return null;
+	}
+
+	private static final class QueuedReplay {
+		private final String rewardReference;
+		private final int completedAsyncInjections;
+		private final Map<String, Integer> asyncReplayProgress;
+
+		private QueuedReplay(String rewardReference, int completedAsyncInjections,
+				Map<String, Integer> asyncReplayProgress) {
+			this.rewardReference = rewardReference;
+			this.completedAsyncInjections = completedAsyncInjections;
+			this.asyncReplayProgress = asyncReplayProgress;
+		}
 	}
 
 	/**
@@ -309,45 +446,43 @@ public class AdvancedCoreUser {
 	public void checkDelayedTimedRewards() {
 		plugin.debug("Checking timed/delayed for " + getPlayerName());
 		HashMap<String, Long> timed = getTimedRewards();
-		HashMap<String, Long> newTimed = new HashMap<>();
-		HashMap<String, Long> replayingTimed = new HashMap<>();
-		HashMap<String, java.util.concurrent.CompletionStage<Void>> replayCompletions = new HashMap<>();
 		for (Entry<String, Long> entry : timed.entrySet()) {
 			long time = entry.getValue();
 
 			if (time != 0) {
 				Date timeDate = new Date(time);
-				if (new Date().after(timeDate)) {
+				if (new Date().after(timeDate) && claimTimedReward(entry.getKey(), time)) {
 					String[] data = entry.getKey().split("%placeholders%", 2);
-					String rewardReference = data[0].split("%extime%", 2)[0];
+					QueuedReplay queuedReplay = parseQueuedReplay(stripTimedExecutionMarker(data[0]));
+					String rewardReference = queuedReplay.rewardReference;
 					String placeholders = "";
 					if (data.length > 1) {
 						placeholders = data[1];
 					}
 					RewardOptions replayOptions = new RewardOptions().setCheckTimed(false)
 							.withPlaceHolder(ArrayUtils.fromString(placeholders));
+					replayOptions.setCompletedAsyncInjections(queuedReplay.completedAsyncInjections);
+					replayOptions.setAsyncReplayProgress(queuedReplay.asyncReplayProgress);
 					replayOptions.addPlaceholder("date",
 							"" + new SimpleDateFormat("EEE, d MMM yyyy HH:mm").format(new Date(time)));
-					replayingTimed.put(entry.getKey(), time);
-					replayCompletions.put(entry.getKey(), plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
-							new PersistedQueueReference(rewardReference), replayOptions));
+					// Keep the due entry durable while asynchronous stages are running.  A
+					// checkpoint can change its serialized key (for example by adding the
+					// v2 progress marker), so completion and failure must follow this
+					// reference rather than the original entry key.
+					AtomicReference<String> currentEntry = new AtomicReference<>(entry.getKey());
+					replayOptions.setAsyncReplayCheckpointConsumer(
+							checkpoint -> checkpointTimedReward(currentEntry, time, checkpoint));
+					plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
+							new PersistedQueueReference(rewardReference), replayOptions).whenComplete((ignored, failure) -> {
+						if (failure == null) completeTimedReward(currentEntry.get(), time);
+						else restoreTimedReward(currentEntry.get(), time, failure);
+					});
 					String rewardName = rewardReference;
 					plugin.debug("Giving timed/delayed reward " + rewardName + " for " + getPlayerName()
 							+ " with placeholders " + ArrayUtils.fromString(placeholders));
-				} else {
-					newTimed.put(entry.getKey(), time);
 				}
 			}
 
-		}
-		setTimedRewards(newTimed);
-		for (Entry<String, java.util.concurrent.CompletionStage<Void>> replay : replayCompletions.entrySet()) {
-			String rewardEntry = replay.getKey();
-			long time = replayingTimed.get(rewardEntry);
-			replay.getValue().exceptionally(failure -> {
-				restoreTimedReward(rewardEntry, time, failure);
-				return null;
-			});
 		}
 	}
 
@@ -362,56 +497,150 @@ public class AdvancedCoreUser {
 		if (isCheckWorld()) {
 			setCheckWorld(false);
 		}
-		ArrayList<String> rewards = getOfflineRewards();
-		if (rewards.isEmpty()) {
-			return;
-		}
+		dispatchOfflineRewards(false);
+	}
 
-		setOfflineRewards(new ArrayList<>());
-		RewardHandler rewardHandler = plugin.getRewardHandler();
-		AdvancedCoreUser user = this;
-
+	private void dispatchOfflineRewards(boolean force) {
+		ArrayList<String> rewards = new ArrayList<>(getOfflineRewards());
 		for (String rewardEntry : rewards) {
 			if (rewardEntry == null || rewardEntry.equals("null")) {
 				continue;
 			}
+			if (!claimOfflineReward(rewardEntry)) continue;
 
 			String[] parts = rewardEntry.split("%placeholders%", 2);
-			String rewardReference = parts[0];
+			QueuedReplay queuedReplay = parseQueuedReplay(parts[0]);
+			String rewardReference = queuedReplay.rewardReference;
 			String placeholderStr = parts.length > 1 ? parts[1] : "";
 
 			RewardOptions options = new RewardOptions().setOnline(false).setCheckTimed(false)
 					.withPlaceHolder(ArrayUtils.fromString(placeholderStr));
+			if (force) options.setGiveOffline(false).forceOffline();
+			options.setCompletedAsyncInjections(queuedReplay.completedAsyncInjections);
+			options.setAsyncReplayProgress(queuedReplay.asyncReplayProgress);
+			AtomicReference<String> currentEntry = new AtomicReference<>(rewardEntry);
+			options.setAsyncReplayCheckpointConsumer(checkpoint -> checkpointOfflineReward(currentEntry, checkpoint));
 
-			rewardHandler.givePersistedQueueRewardAsync(user, new PersistedQueueReference(rewardReference), options)
-					.exceptionally(failure -> {
-						restoreOfflineReward(rewardEntry, failure);
-						return null;
+			plugin.getRewardHandler().givePersistedQueueRewardAsync(this,
+					new PersistedQueueReference(rewardReference), options).whenComplete((ignored, failure) -> {
+						if (failure == null) completeOfflineReward(currentEntry.get());
+						else restoreOfflineReward(currentEntry.get(), failure);
 					});
 		}
-
 	}
 
-	/** Restores a queue entry only after an asynchronous replay fails. */
+	private void checkpointOfflineReward(AtomicReference<String> currentEntry, Reward.ReplayCheckpoint checkpoint) {
+		synchronized (plugin) {
+			String current = currentEntry.get();
+			String updated = withAsyncReplayProgress(current, checkpoint.getReplayProgress(), checkpoint.getPlaceholders());
+			ArrayList<String> pending = getOfflineRewards();
+			int index = pending.indexOf(current);
+			if (index >= 0) {
+				pending.set(index, updated);
+				int claimed = offlineReplayInFlight.getOrDefault(current, 0);
+				// Migrate this occurrence only. Identical legacy queue entries share a
+				// serialized key, but may each already be executing; moving the whole
+				// count would make the remaining old entry appear unclaimed.
+				if (claimed <= 1) offlineReplayInFlight.remove(current);
+				else offlineReplayInFlight.put(current, claimed - 1);
+				offlineReplayInFlight.put(updated, offlineReplayInFlight.getOrDefault(updated, 0) + 1);
+				currentEntry.set(updated);
+				setOfflineRewardsDurably(pending);
+			}
+		}
+	}
+
+	private boolean claimOfflineReward(String rewardEntry) {
+		synchronized (plugin) {
+			int occurrences = 0;
+			for (String pending : getOfflineRewards()) if (rewardEntry.equals(pending)) occurrences++;
+			int claimed = offlineReplayInFlight.getOrDefault(rewardEntry, 0);
+			if (claimed >= occurrences) return false;
+			offlineReplayInFlight.put(rewardEntry, claimed + 1);
+			return true;
+		}
+	}
+
+	private void completeOfflineReward(String rewardEntry) {
+		synchronized (plugin) {
+			ArrayList<String> pending = getOfflineRewards();
+			pending.remove(rewardEntry);
+			setOfflineRewards(pending);
+			releaseOfflineReward(rewardEntry);
+		}
+	}
+
+	/** Retains and updates a queue entry only after an asynchronous replay fails. */
 	private void restoreOfflineReward(String rewardEntry, Throwable failure) {
 		// Match addOfflineRewards' lock so a newly queued reward cannot be lost
 		// while a failed replay is being restored.
 		synchronized (plugin) {
 			ArrayList<String> pending = getOfflineRewards();
-			// Queue entries are allowed to repeat; each failed replay must restore
-			// its own occurrence rather than collapsing identical rewards.
-			pending.add(rewardEntry);
+			int index = pending.indexOf(rewardEntry);
+			if (index >= 0) pending.set(index, withAsyncReplayProgress(rewardEntry, failure));
+			releaseOfflineReward(rewardEntry);
 			setOfflineRewards(pending);
 		}
 		plugin.getLogger().warning("Could not deliver queued offline reward for " + getPlayerName()
 				+ "; it will be retried: " + failure.getMessage());
 	}
 
+	private void releaseOfflineReward(String rewardEntry) {
+		int claimed = offlineReplayInFlight.getOrDefault(rewardEntry, 0);
+		if (claimed <= 1) offlineReplayInFlight.remove(rewardEntry);
+		else offlineReplayInFlight.put(rewardEntry, claimed - 1);
+	}
+
+	private synchronized boolean claimTimedReward(String rewardEntry, long time) {
+		if (timedReplayInFlight.contains(rewardEntry) || !Long.valueOf(time).equals(getTimedRewards().get(rewardEntry))) {
+			return false;
+		}
+		timedReplayInFlight.add(rewardEntry);
+		return true;
+	}
+
+	private synchronized void completeTimedReward(String rewardEntry, long time) {
+		HashMap<String, Long> pending = getTimedRewards();
+		if (Long.valueOf(time).equals(pending.get(rewardEntry))) {
+			pending.remove(rewardEntry);
+			setTimedRewards(pending);
+		}
+		timedReplayInFlight.remove(rewardEntry);
+	}
+
+	/**
+	 * Persists every completed asynchronous stage before the next one can run.
+	 * Timed reward keys are map keys, so migrate the exact current key while
+	 * retaining its execution time and its in-flight claim.
+	 */
+	private synchronized void checkpointTimedReward(AtomicReference<String> currentEntry, long time,
+			Reward.ReplayCheckpoint checkpoint) {
+		String current = currentEntry.get();
+		String updated = withAsyncReplayProgress(current, checkpoint.getReplayProgress(), checkpoint.getPlaceholders());
+		if (current.equals(updated)) return;
+		HashMap<String, Long> pending = getTimedRewards();
+		if (!Long.valueOf(time).equals(pending.get(current))) return;
+		pending.remove(current);
+		pending.put(updated, time);
+		setTimedRewardsDurably(pending);
+		timedReplayInFlight.remove(current);
+		timedReplayInFlight.add(updated);
+		currentEntry.set(updated);
+	}
+
 	/** Restores a due timed entry after an asynchronous replay fails. */
 	private synchronized void restoreTimedReward(String rewardEntry, long time, Throwable failure) {
 		HashMap<String, Long> pending = getTimedRewards();
-		pending.putIfAbsent(rewardEntry, time);
+		int retry = Math.min(8, asyncRetryCount(rewardEntry) + 1);
+		long retryDelay = Math.min(TimeUnit.MINUTES.toMillis(5), TimeUnit.SECONDS.toMillis(1L << retry));
+		long retryTime = System.currentTimeMillis() + retryDelay;
+		pending.remove(rewardEntry);
+		pending.put(withAsyncRetryCount(withAsyncReplayProgress(rewardEntry, failure), retry), retryTime);
 		setTimedRewards(pending);
+		timedReplayInFlight.remove(rewardEntry);
+		// A due entry restored after its original timer fired needs its own retry
+		// timer; waiting for reconnect would strand it indefinitely.
+		loadTimedDelayedTimer(retryTime);
 		plugin.getLogger().warning("Could not deliver queued timed reward for " + getPlayerName()
 				+ "; it will be retried: " + failure.getMessage());
 	}
@@ -471,33 +700,7 @@ public class AdvancedCoreUser {
 		}
 
 		setCheckWorld(false);
-		ArrayList<String> rewards = getOfflineRewards();
-		if (rewards.isEmpty()) {
-			return;
-		}
-
-		setOfflineRewards(new ArrayList<>());
-		RewardHandler rewardHandler = plugin.getRewardHandler();
-		AdvancedCoreUser user = this;
-
-		for (String rewardEntry : rewards) {
-			if (rewardEntry == null || rewardEntry.equals("null")) {
-				continue;
-			}
-
-			String[] parts = rewardEntry.split("%placeholders%", 2);
-			String rewardReference = parts[0];
-			String placeholderStr = parts.length > 1 ? parts[1] : "";
-
-			RewardOptions options = new RewardOptions().setOnline(false).setGiveOffline(false).forceOffline()
-					.setCheckTimed(false).withPlaceHolder(ArrayUtils.fromString(placeholderStr));
-
-			rewardHandler.givePersistedQueueRewardAsync(user, new PersistedQueueReference(rewardReference), options)
-					.exceptionally(failure -> {
-						restoreOfflineReward(rewardEntry, failure);
-						return null;
-					});
-		}
+		dispatchOfflineRewards(true);
 	}
 
 	/**
@@ -1604,6 +1807,15 @@ public class AdvancedCoreUser {
 	 * @param offlineRewards the offline rewards
 	 */
 	public void setOfflineRewards(ArrayList<String> offlineRewards) {
+		setOfflineRewards(offlineRewards, true);
+	}
+
+	/** Writes an async replay checkpoint before the next stage can execute. */
+	private void setOfflineRewardsDurably(ArrayList<String> offlineRewards) {
+		persistReplayCheckpoint(() -> setOfflineRewards(offlineRewards, false));
+	}
+
+	private void setOfflineRewards(ArrayList<String> offlineRewards, boolean queue) {
 		// MySQL TEXT max length is 65535 bytes
 		int maxLength = 65535;
 		String str = String.join("%line%", offlineRewards);
@@ -1614,7 +1826,8 @@ public class AdvancedCoreUser {
 			str = String.join("%line%", offlineRewards);
 		}
 
-		data.setStringList(plugin.getUserManager().getOfflineRewardsPath(), offlineRewards);
+		if (queue) data.setStringList(plugin.getUserManager().getOfflineRewardsPath(), offlineRewards);
+		else data.setStringList(plugin.getUserManager().getOfflineRewardsPath(), offlineRewards, false);
 	}
 
 	/**
@@ -1642,6 +1855,25 @@ public class AdvancedCoreUser {
 	 * @param timed the timed rewards
 	 */
 	public void setTimedRewards(HashMap<String, Long> timed) {
+		setTimedRewards(timed, true);
+	}
+
+	/** Writes an async replay checkpoint before the next stage can execute. */
+	private void setTimedRewardsDurably(HashMap<String, Long> timed) {
+		persistReplayCheckpoint(() -> setTimedRewards(timed, false));
+	}
+
+	/**
+	 * A cached user may already have an older queued value for this key. Drain it
+	 * before the direct write so the delayed cache flush cannot replace a replay
+	 * checkpoint that an asynchronous reward stage has already relied on.
+	 */
+	private void persistReplayCheckpoint(Runnable write) {
+		if (isCached()) getCache().flushChangesAndRun(write);
+		else write.run();
+	}
+
+	private void setTimedRewards(HashMap<String, Long> timed, boolean queue) {
 		ArrayList<String> timedRewards = new ArrayList<>();
 		for (Entry<String, Long> entry : timed.entrySet()) {
 
@@ -1651,7 +1883,8 @@ public class AdvancedCoreUser {
 			timedRewards.add(str);
 
 		}
-		data.setStringList("TimedRewards", timedRewards);
+		if (queue) data.setStringList("TimedRewards", timedRewards);
+		else data.setStringList("TimedRewards", timedRewards, false);
 	}
 
 	/**

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/api/user/usercache/UserDataCache.java
@@ -100,6 +100,31 @@ public class UserDataCache {
 		}
 	}
 
+	/**
+	 * Drains every queued or in-flight cache batch before running a synchronous
+	 * write. The action runs while holding the cache monitor, preventing an old
+	 * queued value from being persisted after a durable replacement.
+	 */
+	public void flushChangesAndRun(Runnable action) {
+		if (action == null) return;
+		while (true) {
+			processChanges();
+			synchronized (this) {
+				while (inFlightBatches > 0) {
+					try {
+						wait();
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new IllegalStateException("Interrupted while flushing cached user changes", e);
+					}
+				}
+				if (cachedChanges != null && !cachedChanges.isEmpty()) continue;
+				action.run();
+				return;
+			}
+		}
+	}
+
 	public void displayCache() {
 		manager.getPlugin().devDebug(displayCacheStringList().toString());
 	}

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
@@ -39,12 +39,6 @@ public final class BukkitRuntimePlatform implements RuntimePlatform {
                         JavascriptEngineHandler.getInstance().clearCachedEngine();
                     }
                 }),
-                new Cleanup("MySQL", () -> {
-                    if (plugin.isLoadUserData() && plugin.getOptions() != null
-                            && UserStorage.MYSQL.equals(plugin.getOptions().getStorageType()) && plugin.getMysql() != null) {
-                        plugin.getMysql().close();
-                    }
-                }),
                 new Cleanup("server data timestamp", () -> {
                     if (plugin.getServerDataFile() != null) plugin.getServerDataFile().setLastUpdated();
                 }));
@@ -58,6 +52,12 @@ public final class BukkitRuntimePlatform implements RuntimePlatform {
 
     @Override public List<Cleanup> afterExecutorShutdown() {
         return List.of(
+                new Cleanup("MySQL", () -> {
+                    if (plugin.isLoadUserData() && plugin.getOptions() != null
+                            && UserStorage.MYSQL.equals(plugin.getOptions().getStorageType()) && plugin.getMysql() != null) {
+                        plugin.getMysql().close();
+                    }
+                }),
                 new Cleanup("plugin unload hook", plugin::onUnLoad),
                 new Cleanup("skull cache", () -> {
                     if (plugin.getSkullCacheHandler() != null) plugin.getSkullCacheHandler().close();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
@@ -29,6 +29,10 @@ public final class BukkitRuntimePlatform implements RuntimePlatform {
 
     @Override public List<Cleanup> beforeExecutorShutdown() {
         return List.of(
+                new Cleanup("full inventory handler", () -> {
+                    FullInventoryHandler handler = plugin.getFullInventoryHandler();
+                    if (handler != null) handler.shutdown();
+                }),
                 new Cleanup("Javascript engine", () -> {
                     if (plugin.getOptions() != null && plugin.getOptions().isJavascriptEngineEnabled()) {
                         plugin.getLogger().info("Shutting down Javascript engine");
@@ -57,13 +61,6 @@ public final class BukkitRuntimePlatform implements RuntimePlatform {
                 new Cleanup("plugin unload hook", plugin::onUnLoad),
                 new Cleanup("skull cache", () -> {
                     if (plugin.getSkullCacheHandler() != null) plugin.getSkullCacheHandler().close();
-                }),
-                new Cleanup("full inventory handler", () -> {
-                    FullInventoryHandler handler = plugin.getFullInventoryHandler();
-                    if (handler != null) {
-                        handler.shutdown();
-                        handler.save();
-                    }
                 }),
                 new Cleanup("hologram handler", () -> {
                     if (plugin.getHologramHandler() != null) plugin.getHologramHandler().onShutDown();

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/bukkit/runtime/BukkitRuntimePlatform.java
@@ -55,6 +55,11 @@ public final class BukkitRuntimePlatform implements RuntimePlatform {
                 new Cleanup("MySQL", () -> {
                     if (plugin.isLoadUserData() && plugin.getOptions() != null
                             && UserStorage.MYSQL.equals(plugin.getOptions().getStorageType()) && plugin.getMysql() != null) {
+                        ScheduledExecutorService timer = plugin.getTimer();
+                        if (timer != null && !timer.isTerminated()) {
+                            plugin.getLogger().warning("Leaving MySQL open because reward checkpoint tasks did not terminate");
+                            return;
+                        }
                         plugin.getMysql().close();
                     }
                 }),

--- a/AdvancedCore/src/main/java/com/bencodez/advancedcore/core/runtime/AdvancedCoreRuntime.java
+++ b/AdvancedCore/src/main/java/com/bencodez/advancedcore/core/runtime/AdvancedCoreRuntime.java
@@ -61,6 +61,10 @@ public final class AdvancedCoreRuntime {
         shutdownNow(platform.getTimer());
         shutdownNow(timeTimer);
         shutdownNow(platform.getInventoryTimer());
+        await(platform.getLoginTimer(), 1, TimeUnit.SECONDS);
+        await(platform.getTimer(), 1, TimeUnit.SECONDS);
+        await(timeTimer, 1, TimeUnit.SECONDS);
+        await(platform.getInventoryTimer(), 1, TimeUnit.SECONDS);
         clean(platform.afterExecutorShutdown());
     }
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -384,6 +384,32 @@ public class FullInventoryHandlerTest {
 	}
 
 	@Test
+	public void queuedReplayDeliveryDoesNotStartAfterShutdownSnapshot() throws Exception {
+		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		when(player.getInventory()).thenReturn(inventory);
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
+		fixture.handler.shutdown();
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			task.getValue().run();
+		}
+
+		java.util.concurrent.ExecutionException failure = assertThrows(java.util.concurrent.ExecutionException.class,
+				() -> delivery.toCompletableFuture().get(2, TimeUnit.SECONDS));
+		assertTrue(AdvancedCoreUser.isReplayActionNotStarted(failure));
+		verify(inventory, never()).addItem(item);
+	}
+
+	@Test
 	public void giveItemAsyncFailsWithoutMutationWhenPlayerDisconnectsAfterEnqueue() throws Exception {
 		Fixture fixture = createFixture();
 		UUID uuid = UUID.randomUUID();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -342,6 +342,48 @@ public class FullInventoryHandlerTest {
 	}
 
 	@Test
+	public void shutdownPersistsAcceptedOverflowBeforeDiscardingQueuedPersistence() throws Exception {
+		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		ItemStack excess = mock(ItemStack.class);
+		when(fixture.plugin.getOptions().isDropOnFullInv()).thenReturn(false);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		when(player.getInventory()).thenReturn(inventory);
+		when(inventory.addItem(item)).thenReturn(new HashMap<>(java.util.Map.of(0, excess)));
+		fixture.handler.getLastMessageTime().put(uuid, System.currentTimeMillis());
+		CountDownLatch executorBlocked = new CountDownLatch(1);
+		CountDownLatch releaseExecutor = new CountDownLatch(1);
+		fixture.handler.getTimer().execute(() -> {
+			executorBlocked.countDown();
+			try {
+				releaseExecutor.await(2, TimeUnit.SECONDS);
+			} catch (InterruptedException ignored) {
+				Thread.currentThread().interrupt();
+			}
+		});
+		assertTrue(executorBlocked.await(2, TimeUnit.SECONDS));
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			task.getValue().run();
+		}
+		assertFalse(delivery.toCompletableFuture().isDone());
+
+		fixture.handler.shutdown();
+		delivery.toCompletableFuture().get(2, TimeUnit.SECONDS);
+		releaseExecutor.countDown();
+		assertEquals(excess, fixture.data.getItemStack("FullInventory." + uuid + ".Items.0"));
+		verify(inventory, times(1)).addItem(item);
+	}
+
+	@Test
 	public void giveItemAsyncFailsWithoutMutationWhenPlayerDisconnectsAfterEnqueue() throws Exception {
 		Fixture fixture = createFixture();
 		UUID uuid = UUID.randomUUID();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -122,9 +122,12 @@ public class FullInventoryHandlerTest {
 	@Test
 	public void giveItemAsyncCompletesOnlyAfterOwnedInventoryDelivery() {
 		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
 		Player player = mock(Player.class);
 		PlayerInventory inventory = mock(PlayerInventory.class);
 		ItemStack item = mock(ItemStack.class);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
 		when(player.getInventory()).thenReturn(inventory);
 		when(inventory.addItem(item)).thenReturn(new HashMap<>());
 
@@ -133,18 +136,47 @@ public class FullInventoryHandlerTest {
 		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
 		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
 
-		task.getValue().run();
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			task.getValue().run();
+		}
 
 		assertTrue(delivery.toCompletableFuture().isDone());
 		verify(inventory).addItem(item);
 	}
 
 	@Test
-	public void timedOutGiveItemAsyncSuppressesTheQueuedDeliveryToPreventReplayDuplicates() throws Exception {
-		Fixture fixture = createFixture(0L);
+	public void giveItemAsyncFailsWithoutMutationWhenPlayerDisconnectsAfterEnqueue() throws Exception {
+		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
 		Player player = mock(Player.class);
 		PlayerInventory inventory = mock(PlayerInventory.class);
 		ItemStack item = mock(ItemStack.class);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.getInventory()).thenReturn(inventory);
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
+
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			task.getValue().run();
+		}
+
+		assertThrows(java.util.concurrent.ExecutionException.class,
+				() -> delivery.toCompletableFuture().get(2, TimeUnit.SECONDS));
+		verify(inventory, never()).addItem(item);
+	}
+
+	@Test
+	public void timedOutGiveItemAsyncSuppressesTheQueuedDeliveryToPreventReplayDuplicates() throws Exception {
+		Fixture fixture = createFixture(0L);
+		UUID uuid = UUID.randomUUID();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		when(player.getUniqueId()).thenReturn(uuid);
 		when(player.getInventory()).thenReturn(inventory);
 		when(inventory.addItem(item)).thenReturn(new HashMap<>());
 
@@ -268,6 +300,7 @@ public class FullInventoryHandlerTest {
 		YamlConfiguration data = new YamlConfiguration();
 
 		when(plugin.getInventoryTimer()).thenReturn(sharedInventoryTimer);
+		when(plugin.isEnabled()).thenReturn(true);
 		when(plugin.getBukkitScheduler()).thenReturn(bukkitScheduler);
 		when(plugin.getServerDataFile()).thenReturn(serverData);
 		when(serverData.getData()).thenReturn(data);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,8 +25,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -182,6 +187,65 @@ public class FullInventoryHandlerTest {
 		releaseSave.countDown();
 		delivery.toCompletableFuture().get(2, TimeUnit.SECONDS);
 		assertEquals(List.of(excess), fixture.handler.getItems().get(uuid));
+	}
+
+	@Test
+	public void replayOverflowSaveFailureDropsOnlyReservedOverflowWithoutReplayingPartialInsert() throws Exception {
+		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		ItemStack excess = mock(ItemStack.class);
+		World world = mock(World.class);
+		Location location = mock(Location.class);
+		when(fixture.plugin.getOptions().isDropOnFullInv()).thenReturn(false);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		when(player.getInventory()).thenReturn(inventory);
+		when(player.getWorld()).thenReturn(world);
+		when(player.getLocation()).thenReturn(location);
+		when(inventory.addItem(item)).thenReturn(new HashMap<>(java.util.Map.of(0, excess)));
+		when(world.dropItem(location, excess)).thenReturn(mock(org.bukkit.entity.Item.class));
+		fixture.handler.getLastMessageTime().put(uuid, System.currentTimeMillis());
+		doAnswer(invocation -> {
+			throw new IllegalStateException("disk unavailable");
+		}).when(fixture.serverData).saveData();
+
+		AtomicInteger scheduled = new AtomicInteger();
+		AtomicReference<Runnable> initialDelivery = new AtomicReference<>();
+		AtomicReference<Runnable> fallback = new AtomicReference<>();
+		CountDownLatch fallbackScheduled = new CountDownLatch(1);
+		doAnswer(invocation -> {
+			Runnable task = invocation.getArgument(1);
+			if (scheduled.incrementAndGet() == 1) initialDelivery.set(task);
+			else {
+				fallback.set(task);
+				fallbackScheduled.countDown();
+			}
+			return null;
+		}).when(fixture.bukkitScheduler).runTask(eq(fixture.plugin), any(Runnable.class), eq(player));
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+			initialDelivery.get().run();
+			assertTrue(fallbackScheduled.await(2, TimeUnit.SECONDS));
+			assertFalse(delivery.toCompletableFuture().isDone());
+
+			// The overflow remains reserved while its persistence is failing, so an
+			// ordinary sweep cannot consume it before the fallback owns it.
+			fixture.handler.check();
+			assertEquals(2, scheduled.get());
+			fallback.get().run();
+		}
+
+		delivery.toCompletableFuture().get(2, TimeUnit.SECONDS);
+		verify(inventory, times(1)).addItem(item);
+		verify(world).dropItem(location, excess);
+		assertFalse(fixture.handler.getItems().containsKey(uuid));
+		assertFalse(fixture.data.contains("FullInventory"));
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.item.FullInventoryHandler;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
@@ -144,6 +146,42 @@ public class FullInventoryHandlerTest {
 
 		assertTrue(delivery.toCompletableFuture().isDone());
 		verify(inventory).addItem(item);
+	}
+
+	@Test
+	public void giveItemAsyncWaitsForOverflowToBePersisted() throws Exception {
+		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		ItemStack excess = mock(ItemStack.class);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		when(player.getInventory()).thenReturn(inventory);
+		when(inventory.addItem(item)).thenReturn(new HashMap<>(java.util.Map.of(0, excess)));
+		fixture.handler.getLastMessageTime().put(uuid, System.currentTimeMillis());
+		CountDownLatch saveStarted = new CountDownLatch(1);
+		CountDownLatch releaseSave = new CountDownLatch(1);
+		doAnswer(invocation -> {
+			saveStarted.countDown();
+			assertTrue(releaseSave.await(2, TimeUnit.SECONDS));
+			return null;
+		}).when(fixture.serverData).saveData();
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			task.getValue().run();
+		}
+
+		assertTrue(saveStarted.await(2, TimeUnit.SECONDS));
+		assertFalse(delivery.toCompletableFuture().isDone());
+		releaseSave.countDown();
+		delivery.toCompletableFuture().get(2, TimeUnit.SECONDS);
+		assertEquals(List.of(excess), fixture.handler.getItems().get(uuid));
 	}
 
 	@Test
@@ -313,12 +351,14 @@ public class FullInventoryHandlerTest {
 
 	private Fixture createFixture(long itemDeliveryTimeoutMillis) {
 		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		AdvancedCoreConfigOptions options = mock(AdvancedCoreConfigOptions.class);
 		ScheduledExecutorService sharedInventoryTimer = mock(ScheduledExecutorService.class);
 		BukkitScheduler bukkitScheduler = mock(BukkitScheduler.class);
 		ServerData serverData = mock(ServerData.class);
 		YamlConfiguration data = new YamlConfiguration();
 
 		when(plugin.getInventoryTimer()).thenReturn(sharedInventoryTimer);
+		when(plugin.getOptions()).thenReturn(options);
 		when(plugin.isEnabled()).thenReturn(true);
 		when(plugin.getBukkitScheduler()).thenReturn(bukkitScheduler);
 		when(plugin.getServerDataFile()).thenReturn(serverData);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -249,6 +249,52 @@ public class FullInventoryHandlerTest {
 	}
 
 	@Test
+	public void replayOverflowDoesNotAcknowledgeAnUnavailableFallback() throws Exception {
+		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		ItemStack excess = mock(ItemStack.class);
+		when(fixture.plugin.getOptions().isDropOnFullInv()).thenReturn(false);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		when(player.getInventory()).thenReturn(inventory);
+		when(inventory.addItem(item)).thenReturn(new HashMap<>(java.util.Map.of(0, excess)));
+		fixture.handler.getLastMessageTime().put(uuid, System.currentTimeMillis());
+		doAnswer(invocation -> {
+			throw new IllegalStateException("disk unavailable");
+		}).when(fixture.serverData).saveData();
+
+		AtomicReference<Runnable> initialDelivery = new AtomicReference<>();
+		AtomicReference<Runnable> fallback = new AtomicReference<>();
+		CountDownLatch fallbackScheduled = new CountDownLatch(1);
+		doAnswer(invocation -> {
+			Runnable task = invocation.getArgument(1);
+			if (initialDelivery.get() == null) initialDelivery.set(task);
+			else {
+				fallback.set(task);
+				fallbackScheduled.countDown();
+			}
+			return null;
+		}).when(fixture.bukkitScheduler).runTask(eq(fixture.plugin), any(Runnable.class), eq(player));
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			initialDelivery.get().run();
+			assertTrue(fallbackScheduled.await(2, TimeUnit.SECONDS));
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			fallback.get().run();
+		}
+
+		assertFalse(delivery.toCompletableFuture().isDone());
+		verify(inventory, times(1)).addItem(item);
+		assertFalse(fixture.handler.getItems().containsKey(uuid));
+		assertFalse(fixture.data.contains("FullInventory"));
+	}
+
+	@Test
 	public void giveItemAsyncFailsWithoutMutationWhenPlayerDisconnectsAfterEnqueue() throws Exception {
 		Fixture fixture = createFixture();
 		UUID uuid = UUID.randomUUID();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -190,6 +190,53 @@ public class FullInventoryHandlerTest {
 	}
 
 	@Test
+	public void replayDropFailurePersistsOnlyTheUndroppedOverflow() throws Exception {
+		Fixture fixture = createFixture();
+		UUID uuid = UUID.randomUUID();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		ItemStack excess = mock(ItemStack.class);
+		World world = mock(World.class);
+		Location location = mock(Location.class);
+		when(fixture.plugin.getOptions().isDropOnFullInv()).thenReturn(true);
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		when(player.getInventory()).thenReturn(inventory);
+		when(player.getWorld()).thenReturn(world);
+		when(player.getLocation()).thenReturn(location);
+		when(inventory.addItem(item)).thenReturn(new HashMap<>(java.util.Map.of(0, excess)));
+		doAnswer(invocation -> {
+			throw new IllegalStateException("world unavailable");
+		}).when(world).dropItem(location, excess);
+		fixture.handler.getLastMessageTime().put(uuid, System.currentTimeMillis());
+		CountDownLatch saveStarted = new CountDownLatch(1);
+		CountDownLatch releaseSave = new CountDownLatch(1);
+		doAnswer(invocation -> {
+			saveStarted.countDown();
+			assertTrue(releaseSave.await(2, TimeUnit.SECONDS));
+			return null;
+		}).when(fixture.serverData).saveData();
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			task.getValue().run();
+		}
+
+		assertTrue(saveStarted.await(2, TimeUnit.SECONDS));
+		assertFalse(delivery.toCompletableFuture().isDone());
+		releaseSave.countDown();
+		delivery.toCompletableFuture().get(2, TimeUnit.SECONDS);
+		verify(inventory, times(1)).addItem(item);
+		verify(world).dropItem(location, excess);
+		assertEquals(List.of(excess), fixture.handler.getItems().get(uuid));
+		assertEquals(excess, fixture.data.getItemStack("FullInventory." + uuid + ".Items.0"));
+	}
+
+	@Test
 	public void replayOverflowSaveFailureDropsOnlyReservedOverflowWithoutReplayingPartialInsert() throws Exception {
 		Fixture fixture = createFixture();
 		UUID uuid = UUID.randomUUID();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -37,6 +37,7 @@ import org.mockito.MockedStatic;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.item.FullInventoryHandler;
+import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 import com.bencodez.advancedcore.data.ServerData;
 import com.bencodez.simpleapi.scheduler.BukkitScheduler;
 
@@ -164,9 +165,26 @@ public class FullInventoryHandlerTest {
 			task.getValue().run();
 		}
 
-		assertThrows(java.util.concurrent.ExecutionException.class,
+		java.util.concurrent.ExecutionException failure = assertThrows(java.util.concurrent.ExecutionException.class,
 				() -> delivery.toCompletableFuture().get(2, TimeUnit.SECONDS));
+		assertTrue(AdvancedCoreUser.isReplayActionNotStarted(failure));
 		verify(inventory, never()).addItem(item);
+	}
+
+	@Test
+	public void rejectedItemSchedulerSignalsThatDeliveryNeverStarted() throws Exception {
+		Fixture fixture = createFixture();
+		Player player = mock(Player.class);
+		ItemStack item = mock(ItemStack.class);
+		when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+		org.mockito.Mockito.doThrow(new IllegalStateException("scheduler stopped"))
+				.when(fixture.bukkitScheduler).runTask(eq(fixture.plugin), any(Runnable.class), eq(player));
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		java.util.concurrent.ExecutionException failure = assertThrows(java.util.concurrent.ExecutionException.class,
+				() -> delivery.toCompletableFuture().get(2, TimeUnit.SECONDS));
+
+		assertTrue(AdvancedCoreUser.isReplayActionNotStarted(failure));
 	}
 
 	@Test
@@ -181,8 +199,9 @@ public class FullInventoryHandlerTest {
 		when(inventory.addItem(item)).thenReturn(new HashMap<>());
 
 		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
-		assertThrows(java.util.concurrent.ExecutionException.class,
+		java.util.concurrent.ExecutionException failure = assertThrows(java.util.concurrent.ExecutionException.class,
 				() -> delivery.toCompletableFuture().get(2, TimeUnit.SECONDS));
+		assertTrue(AdvancedCoreUser.isReplayActionNotStarted(failure));
 		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
 		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/item/FullInventoryHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -19,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -118,6 +120,47 @@ public class FullInventoryHandlerTest {
 	}
 
 	@Test
+	public void giveItemAsyncCompletesOnlyAfterOwnedInventoryDelivery() {
+		Fixture fixture = createFixture();
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		when(player.getInventory()).thenReturn(inventory);
+		when(inventory.addItem(item)).thenReturn(new HashMap<>());
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		assertFalse(delivery.toCompletableFuture().isDone());
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
+
+		task.getValue().run();
+
+		assertTrue(delivery.toCompletableFuture().isDone());
+		verify(inventory).addItem(item);
+	}
+
+	@Test
+	public void timedOutGiveItemAsyncSuppressesTheQueuedDeliveryToPreventReplayDuplicates() throws Exception {
+		Fixture fixture = createFixture(0L);
+		Player player = mock(Player.class);
+		PlayerInventory inventory = mock(PlayerInventory.class);
+		ItemStack item = mock(ItemStack.class);
+		when(player.getInventory()).thenReturn(inventory);
+		when(inventory.addItem(item)).thenReturn(new HashMap<>());
+
+		CompletionStage<Void> delivery = fixture.handler.giveItemAsync(player, item);
+		assertThrows(java.util.concurrent.ExecutionException.class,
+				() -> delivery.toCompletableFuture().get(2, TimeUnit.SECONDS));
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		verify(fixture.bukkitScheduler).runTask(eq(fixture.plugin), task.capture(), eq(player));
+
+		task.getValue().run();
+		task.getValue().run();
+
+		verify(inventory, never()).addItem(item);
+	}
+
+	@Test
 	public void handlerTimerIsIsolatedFromPluginInventoryTimer() {
 		Fixture fixture = createFixture();
 		ScheduledExecutorService handlerTimer = fixture.handler.getTimer();
@@ -214,6 +257,10 @@ public class FullInventoryHandlerTest {
 	}
 
 	private Fixture createFixture() {
+		return createFixture(TimeUnit.SECONDS.toMillis(30));
+	}
+
+	private Fixture createFixture(long itemDeliveryTimeoutMillis) {
 		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
 		ScheduledExecutorService sharedInventoryTimer = mock(ScheduledExecutorService.class);
 		BukkitScheduler bukkitScheduler = mock(BukkitScheduler.class);
@@ -225,7 +272,12 @@ public class FullInventoryHandlerTest {
 		when(plugin.getServerDataFile()).thenReturn(serverData);
 		when(serverData.getData()).thenReturn(data);
 
-		FullInventoryHandler handler = new FullInventoryHandler(plugin);
+		FullInventoryHandler handler = new FullInventoryHandler(plugin) {
+			@Override
+			protected long getItemDeliveryTimeoutMillis() {
+				return itemDeliveryTimeoutMillis;
+			}
+		};
 		handlers.add(handler);
 		return new Fixture(plugin, sharedInventoryTimer, bukkitScheduler, serverData, data, handler);
 	}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/AdvancedCoreLifecycleTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/AdvancedCoreLifecycleTest.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.tests.lifecycle;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -65,7 +66,7 @@ public class AdvancedCoreLifecycleTest {
 		verify(timeTimer).shutdown();
 		verify(timer).awaitTermination(2, TimeUnit.SECONDS);
 		verify(loginTimer).awaitTermination(2, TimeUnit.SECONDS);
-		verify(inventoryTimer).awaitTermination(1, TimeUnit.SECONDS);
+		verify(inventoryTimer, times(2)).awaitTermination(1, TimeUnit.SECONDS);
 		verify(timeTimer).awaitTermination(2, TimeUnit.SECONDS);
 		verify(rewardHandler).shutdown();
 		verify(fullInventoryHandler).shutdown();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/AdvancedCoreLifecycleTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/AdvancedCoreLifecycleTest.java
@@ -69,7 +69,6 @@ public class AdvancedCoreLifecycleTest {
 		verify(timeTimer).awaitTermination(2, TimeUnit.SECONDS);
 		verify(rewardHandler).shutdown();
 		verify(fullInventoryHandler).shutdown();
-		verify(fullInventoryHandler).save();
 		verify(plugin).onUnLoad();
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
@@ -10,8 +10,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
+import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.item.FullInventoryHandler;
+import com.bencodez.advancedcore.api.user.UserStorage;
+import com.bencodez.advancedcore.api.user.userstorage.mysql.MySQL;
 import com.bencodez.advancedcore.bukkit.runtime.BukkitRuntimePlatform;
 import com.bencodez.advancedcore.core.platform.RuntimePlatform;
 import com.bencodez.advancedcore.core.platform.RuntimePlatform.Cleanup;
@@ -112,7 +115,13 @@ class CoreRuntimeTest {
 	@Test void bukkitAdapterFlushesFullInventoryBeforeExecutorShutdown() {
 		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
 		FullInventoryHandler handler = mock(FullInventoryHandler.class);
+		MySQL mysql = mock(MySQL.class);
+		AdvancedCoreConfigOptions options = mock(AdvancedCoreConfigOptions.class);
 		when(plugin.getFullInventoryHandler()).thenReturn(handler);
+		when(plugin.isLoadUserData()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(options);
+		when(options.getStorageType()).thenReturn(UserStorage.MYSQL);
+		when(plugin.getMysql()).thenReturn(mysql);
 		BukkitRuntimePlatform platform = new BukkitRuntimePlatform(plugin);
 
 		platform.beforeExecutorShutdown().stream()
@@ -120,6 +129,12 @@ class CoreRuntimeTest {
 				.findFirst().orElseThrow().action().run();
 
 		verify(handler).shutdown();
+		assertTrue(platform.beforeExecutorShutdown().stream()
+				.noneMatch(cleanup -> cleanup.name().equals("MySQL")));
+		platform.afterExecutorShutdown().stream()
+				.filter(cleanup -> cleanup.name().equals("MySQL"))
+				.findFirst().orElseThrow().action().run();
+		verify(mysql).close();
 		assertTrue(platform.afterExecutorShutdown().stream()
 				.noneMatch(cleanup -> cleanup.name().equals("full inventory handler")));
 	}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
@@ -55,11 +55,12 @@ class CoreRuntimeTest {
         new AdvancedCoreRuntime(platform).shutdown();
         assertEquals(List.of("pre", "login-stop", "timer-stop", "time-stop", "inventory-stop", "wait-log",
                 "login-wait", "timer-wait", "time-wait", "inventory-wait", "rewards",
-                "login-force", "timer-force", "time-force", "inventory-force", "post"), events);
+				"login-force", "timer-force", "time-force", "inventory-force",
+				"login-wait", "timer-wait", "time-wait", "inventory-wait", "post"), events);
         verify(login).awaitTermination(2, TimeUnit.SECONDS);
         verify(timer).awaitTermination(2, TimeUnit.SECONDS);
         verify(time).awaitTermination(2, TimeUnit.SECONDS);
-        verify(inventory).awaitTermination(1, TimeUnit.SECONDS);
+        verify(inventory, times(2)).awaitTermination(1, TimeUnit.SECONDS);
         verify(platform, times(1)).getTimeTimer();
     }
 
@@ -137,5 +138,26 @@ class CoreRuntimeTest {
 		verify(mysql).close();
 		assertTrue(platform.afterExecutorShutdown().stream()
 				.noneMatch(cleanup -> cleanup.name().equals("full inventory handler")));
+	}
+
+	@Test void bukkitAdapterDoesNotCloseMysqlWhileCheckpointTasksRemainActive() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		MySQL mysql = mock(MySQL.class);
+		AdvancedCoreConfigOptions options = mock(AdvancedCoreConfigOptions.class);
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		when(plugin.isLoadUserData()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(options);
+		when(options.getStorageType()).thenReturn(UserStorage.MYSQL);
+		when(plugin.getMysql()).thenReturn(mysql);
+		when(plugin.getLogger()).thenReturn(mock(java.util.logging.Logger.class));
+		when(plugin.getTimer()).thenReturn(timer);
+		when(timer.isTerminated()).thenReturn(false);
+		BukkitRuntimePlatform platform = new BukkitRuntimePlatform(plugin);
+
+		platform.afterExecutorShutdown().stream()
+				.filter(cleanup -> cleanup.name().equals("MySQL"))
+				.findFirst().orElseThrow().action().run();
+
+		verify(mysql, never()).close();
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/lifecycle/CoreRuntimeTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.item.FullInventoryHandler;
 import com.bencodez.advancedcore.bukkit.runtime.BukkitRuntimePlatform;
 import com.bencodez.advancedcore.core.platform.RuntimePlatform;
 import com.bencodez.advancedcore.core.platform.RuntimePlatform.Cleanup;
@@ -107,4 +108,19 @@ class CoreRuntimeTest {
         assertNull(platform.getTimeTimer());
         assertDoesNotThrow(() -> new AdvancedCoreLifecycle(null).shutdown());
     }
+
+	@Test void bukkitAdapterFlushesFullInventoryBeforeExecutorShutdown() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		FullInventoryHandler handler = mock(FullInventoryHandler.class);
+		when(plugin.getFullInventoryHandler()).thenReturn(handler);
+		BukkitRuntimePlatform platform = new BukkitRuntimePlatform(plugin);
+
+		platform.beforeExecutorShutdown().stream()
+				.filter(cleanup -> cleanup.name().equals("full inventory handler"))
+				.findFirst().orElseThrow().action().run();
+
+		verify(handler).shutdown();
+		assertTrue(platform.afterExecutorShutdown().stream()
+				.noneMatch(cleanup -> cleanup.name().equals("full inventory handler")));
+	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -116,7 +117,8 @@ public class MiscUtilsTest {
 		Server server = mock(Server.class);
 		ConsoleCommandSender console = mock(ConsoleCommandSender.class);
 		ArgumentCaptor<Runnable> immediate = ArgumentCaptor.forClass(Runnable.class);
-		ArgumentCaptor<Runnable> delayed = ArgumentCaptor.forClass(Runnable.class);
+		ArgumentCaptor<Runnable> firstDelayed = ArgumentCaptor.forClass(Runnable.class);
+		ArgumentCaptor<Runnable> secondDelayed = ArgumentCaptor.forClass(Runnable.class);
 
 		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
 			bukkit.when(Bukkit::getServer).thenReturn(server);
@@ -126,14 +128,16 @@ public class MiscUtilsTest {
 			java.util.concurrent.CompletionStage<Void> completion = miscUtils.executeConsoleCommandsAsync("Ben",
 					new ArrayList<>(List.of("say one", "say two", "say three")), new HashMap<>(), true);
 			verify(scheduler).runTask(eq(plugin), immediate.capture());
-			verify(scheduler, times(2)).runTaskLater(eq(plugin), delayed.capture(), anyLong());
+			verify(scheduler, never()).runTaskLater(eq(plugin), any(Runnable.class), anyLong());
 			assertFalse(completion.toCompletableFuture().isDone());
 
 			immediate.getValue().run();
 			assertFalse(completion.toCompletableFuture().isDone());
-			delayed.getAllValues().get(0).run();
+			verify(scheduler).runTaskLater(eq(plugin), firstDelayed.capture(), eq(1L));
+			firstDelayed.getValue().run();
 			assertFalse(completion.toCompletableFuture().isDone());
-			delayed.getAllValues().get(1).run();
+			verify(scheduler, times(2)).runTaskLater(eq(plugin), secondDelayed.capture(), eq(1L));
+			secondDelayed.getAllValues().get(1).run();
 			completion.toCompletableFuture().join();
 
 			verify(server).dispatchCommand(console, "say one");

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
@@ -1,10 +1,14 @@
 package com.bencodez.advancedcore.tests.misc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -81,6 +85,60 @@ public class MiscUtilsTest {
 			verify(scheduler).executeOrScheduleSync(eq(plugin), task.capture());
 			task.getValue().run();
 			verify(server).dispatchCommand(console, "say hi");
+		}
+	}
+
+	@Test
+	public void asyncConsoleCommandCompletesOnlyAfterItsScheduledDispatch() {
+		Server server = mock(Server.class);
+		ConsoleCommandSender console = mock(ConsoleCommandSender.class);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(Bukkit::getServer).thenReturn(server);
+			bukkit.when(Bukkit::getConsoleSender).thenReturn(console);
+			bukkit.when(() -> Bukkit.getOfflinePlayer("Ben")).thenReturn(null);
+
+			java.util.concurrent.CompletionStage<Void> completion = miscUtils.executeConsoleCommandsAsync("Ben", "/say hi",
+					new HashMap<>());
+			verify(scheduler).executeOrScheduleSync(eq(plugin), task.capture());
+			assertFalse(completion.toCompletableFuture().isDone());
+
+			task.getValue().run();
+			completion.toCompletableFuture().join();
+			assertTrue(completion.toCompletableFuture().isDone());
+			verify(server).dispatchCommand(console, "say hi");
+		}
+	}
+
+	@Test
+	public void asyncStaggeredCommandsCompleteOnlyAfterEveryScheduledDispatch() {
+		Server server = mock(Server.class);
+		ConsoleCommandSender console = mock(ConsoleCommandSender.class);
+		ArgumentCaptor<Runnable> immediate = ArgumentCaptor.forClass(Runnable.class);
+		ArgumentCaptor<Runnable> delayed = ArgumentCaptor.forClass(Runnable.class);
+
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(Bukkit::getServer).thenReturn(server);
+			bukkit.when(Bukkit::getConsoleSender).thenReturn(console);
+			bukkit.when(() -> Bukkit.getOfflinePlayer("Ben")).thenReturn(null);
+
+			java.util.concurrent.CompletionStage<Void> completion = miscUtils.executeConsoleCommandsAsync("Ben",
+					new ArrayList<>(List.of("say one", "say two", "say three")), new HashMap<>(), true);
+			verify(scheduler).runTask(eq(plugin), immediate.capture());
+			verify(scheduler, times(2)).runTaskLater(eq(plugin), delayed.capture(), anyLong());
+			assertFalse(completion.toCompletableFuture().isDone());
+
+			immediate.getValue().run();
+			assertFalse(completion.toCompletableFuture().isDone());
+			delayed.getAllValues().get(0).run();
+			assertFalse(completion.toCompletableFuture().isDone());
+			delayed.getAllValues().get(1).run();
+			completion.toCompletableFuture().join();
+
+			verify(server).dispatchCommand(console, "say one");
+			verify(server).dispatchCommand(console, "say two");
+			verify(server).dispatchCommand(console, "say three");
 		}
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/misc/MiscUtilsTest.java
@@ -113,6 +113,28 @@ public class MiscUtilsTest {
 	}
 
 	@Test
+	public void asyncConsoleCommandPreservesAnEmptyPlaceholderExpansion() {
+		Server server = mock(Server.class);
+		ConsoleCommandSender console = mock(ConsoleCommandSender.class);
+		ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+		HashMap<String, String> placeholders = new HashMap<>();
+		placeholders.put("command", "");
+
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(Bukkit::getServer).thenReturn(server);
+			bukkit.when(Bukkit::getConsoleSender).thenReturn(console);
+			bukkit.when(() -> Bukkit.getOfflinePlayer("Ben")).thenReturn(null);
+
+			java.util.concurrent.CompletionStage<Void> completion = miscUtils.executeConsoleCommandsAsync("Ben",
+					"%command%", placeholders);
+			verify(scheduler).executeOrScheduleSync(eq(plugin), task.capture());
+			task.getValue().run();
+			completion.toCompletableFuture().join();
+			verify(server).dispatchCommand(console, "");
+		}
+	}
+
+	@Test
 	public void asyncStaggeredCommandsCompleteOnlyAfterEveryScheduledDispatch() {
 		Server server = mock(Server.class);
 		ConsoleCommandSender console = mock(ConsoleCommandSender.class);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -82,6 +83,7 @@ import com.bencodez.advancedcore.api.rewards.injected.RewardInjectKeys;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectString;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectStringList;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
+import com.bencodez.simpleapi.scheduler.BukkitScheduler;
 
 public class BuiltinRewardBehaviorTest {
 
@@ -666,6 +668,13 @@ public class BuiltinRewardBehaviorTest {
 		RewardInjectBoolean choices = (RewardInjectBoolean) injects.get(0);
 		when(user.getChoicePreference("SourceReward")).thenReturn("OptionA");
 		CompletableFuture<Void> child = new CompletableFuture<>();
+		BukkitScheduler scheduler = mock(BukkitScheduler.class);
+		when(plugin.isEnabled()).thenReturn(true);
+		when(plugin.getBukkitScheduler()).thenReturn(scheduler);
+		doAnswer(invocation -> {
+			invocation.<Runnable>getArgument(1).run();
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
 
 		try (MockedConstruction<RewardBuilder> builders = mockConstruction(RewardBuilder.class,
 				withSettings().defaultAnswer(Answers.RETURNS_SELF),
@@ -675,6 +684,7 @@ public class BuiltinRewardBehaviorTest {
 			child.complete(null);
 			assertEquals("OptionA", result.toCompletableFuture().join());
 			verify(builders.constructed().get(0)).sendAsync(user);
+			verify(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
 		}
 	}
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
@@ -310,7 +310,7 @@ public class BuiltinRewardBehaviorTest {
         MiscUtils misc = mock(MiscUtils.class);
         CompletableFuture<Void> numberCommand = new CompletableFuture<>();
         CompletableFuture<Void> command = new CompletableFuture<>();
-        CompletableFuture<Void> commandList = new CompletableFuture<>();
+		CompletableFuture<Void> commandList = new CompletableFuture<>();
         CompletableFuture<Void> sectionConsole = new CompletableFuture<>();
         CompletableFuture<Void> sectionPlayer = new CompletableFuture<>();
         CompletableFuture<Void> random = new CompletableFuture<>();
@@ -320,11 +320,11 @@ public class BuiltinRewardBehaviorTest {
                     .thenReturn(numberCommand);
             when(misc.executeConsoleCommandsAsync(eq("Ben"), eq("say hi"), eq(placeholders))).thenReturn(command);
             ArrayList<String> list = new ArrayList<>(List.of("say one", "say two"));
-            when(misc.executeConsoleCommandsAsync(eq("Ben"), eq(list), eq(placeholders), eq(true)))
-                    .thenReturn(commandList);
+			when(misc.executeConsoleCommandsAsync(eq("Ben"), eq(list), eq(placeholders), eq(true)))
+					.thenReturn(commandList);
             ArrayList<String> console = new ArrayList<>(List.of("say console"));
-            when(misc.executeConsoleCommandsAsync(eq("Ben"), eq(console), eq(placeholders), eq(false)))
-                    .thenReturn(sectionConsole);
+			when(misc.executeConsoleCommandsAsync(eq("Ben"), eq(console), eq(placeholders), eq(false)))
+					.thenReturn(sectionConsole);
             ArrayList<String> player = new ArrayList<>(List.of("spawn"));
             when(user.preformCommandAsync(eq(player), eq(placeholders))).thenReturn(sectionPlayer);
             ArrayList<String> randomList = new ArrayList<>(List.of("say random"));
@@ -350,7 +350,7 @@ public class BuiltinRewardBehaviorTest {
             CompletionStage<String> listStage = ((RewardInjectStringList) injects.get(2))
                     .onRewardRequestAsync(reward, user, list, placeholders);
             assertFalse(listStage.toCompletableFuture().isDone());
-            commandList.complete(null);
+			commandList.complete(null);
             listStage.toCompletableFuture().join();
 
             ConfigurationSection commands = section("Commands");
@@ -392,6 +392,7 @@ public class BuiltinRewardBehaviorTest {
 
             assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
             verify(misc, never()).executeConsoleCommandsAsync(anyString(), any(), any(), anyBoolean());
+            verify(misc, never()).executeConsoleCommandsAsync(anyString(), anyString(), any());
         }
     }
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
@@ -660,6 +660,24 @@ public class BuiltinRewardBehaviorTest {
         verify(handler).giveChoicesReward(reward, user, "OptionA");
     }
 
+	@Test
+	public void choicesAsyncDispatchWaitsForSelectedReward() {
+		RewardChoices.register(handler, plugin);
+		RewardInjectBoolean choices = (RewardInjectBoolean) injects.get(0);
+		when(user.getChoicePreference("SourceReward")).thenReturn("OptionA");
+		CompletableFuture<Void> child = new CompletableFuture<>();
+
+		try (MockedConstruction<RewardBuilder> builders = mockConstruction(RewardBuilder.class,
+				withSettings().defaultAnswer(Answers.RETURNS_SELF),
+				(builder, context) -> when(builder.sendAsync(user)).thenReturn(child))) {
+			CompletionStage<String> result = choices.onRewardRequestAsync(reward, user, true, placeholders);
+			assertFalse(result.toCompletableFuture().isDone());
+			child.complete(null);
+			assertEquals("OptionA", result.toCompletableFuture().join());
+			verify(builders.constructed().get(0)).sendAsync(user);
+		}
+	}
+
     @Test
     public void javascriptActuallyExecutesScriptsAndTrueBranch() {
         RewardJavascript.register(handler, plugin);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
@@ -3,9 +3,12 @@ package com.bencodez.advancedcore.tests.rewards;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -366,6 +369,29 @@ public class BuiltinRewardBehaviorTest {
             assertFalse(randomStage.toCompletableFuture().isDone());
             random.complete(null);
             randomStage.toCompletableFuture().join();
+        }
+    }
+
+    @Test
+    public void mixedAsyncCommandsDoNotScheduleConsoleWorkWhenPlayerDispatchFails() {
+        RewardCommands.register(handler, plugin);
+        MiscUtils misc = mock(MiscUtils.class);
+        ArrayList<String> console = new ArrayList<>(List.of("give Ben diamond"));
+        ArrayList<String> player = new ArrayList<>(List.of("spawn"));
+        when(user.preformCommandAsync(eq(player), eq(placeholders)))
+                .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("player unavailable")));
+        ConfigurationSection commands = section("Commands");
+        commands.set("Console", console);
+        commands.set("Player", player);
+
+        try (MockedStatic<MiscUtils> miscStatic = mockStatic(MiscUtils.class)) {
+            miscStatic.when(MiscUtils::getInstance).thenReturn(misc);
+
+            CompletionStage<String> result = ((RewardInjectConfigurationSection) injects.get(3))
+                    .onRewardRequestedAsync(reward, user, commands, placeholders);
+
+            assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+            verify(misc, never()).executeConsoleCommandsAsync(anyString(), any(), any(), anyBoolean());
         }
     }
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
@@ -326,6 +326,7 @@ public class BuiltinRewardBehaviorTest {
 			when(misc.executeConsoleCommandsAsync(eq("Ben"), eq(console), eq(placeholders), eq(false)))
 					.thenReturn(sectionConsole);
             ArrayList<String> player = new ArrayList<>(List.of("spawn"));
+            when(user.validatePlayerCommandAvailabilityAsync()).thenReturn(CompletableFuture.completedFuture(null));
             when(user.preformCommandAsync(eq(player), eq(placeholders))).thenReturn(sectionPlayer);
             ArrayList<String> randomList = new ArrayList<>(List.of("say random"));
             HashMap<String, String> randomPlaceholders = new HashMap<>();
@@ -359,7 +360,10 @@ public class BuiltinRewardBehaviorTest {
             commands.set("Stagger", false);
             CompletionStage<String> sectionStage = ((RewardInjectConfigurationSection) injects.get(3))
                     .onRewardRequestedAsync(reward, user, commands, placeholders);
+            verify(misc).executeConsoleCommandsAsync(eq("Ben"), eq(console), eq(placeholders), eq(false));
+            verify(user, never()).preformCommandAsync(eq(player), eq(placeholders));
             sectionConsole.complete(null);
+            verify(user).preformCommandAsync(eq(player), eq(placeholders));
             assertFalse(sectionStage.toCompletableFuture().isDone());
             sectionPlayer.complete(null);
             sectionStage.toCompletableFuture().join();
@@ -378,7 +382,7 @@ public class BuiltinRewardBehaviorTest {
         MiscUtils misc = mock(MiscUtils.class);
         ArrayList<String> console = new ArrayList<>(List.of("give Ben diamond"));
         ArrayList<String> player = new ArrayList<>(List.of("spawn"));
-        when(user.preformCommandAsync(eq(player), eq(placeholders)))
+        when(user.validatePlayerCommandAvailabilityAsync())
                 .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("player unavailable")));
         ConfigurationSection commands = section("Commands");
         commands.set("Console", console);
@@ -393,6 +397,7 @@ public class BuiltinRewardBehaviorTest {
             assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
             verify(misc, never()).executeConsoleCommandsAsync(anyString(), any(), any(), anyBoolean());
             verify(misc, never()).executeConsoleCommandsAsync(anyString(), anyString(), any());
+			verify(user, never()).preformCommandAsync(any(), any());
         }
     }
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
@@ -261,10 +261,28 @@ public class BuiltinRewardBehaviorTest {
         ConfigurationSection section = section("TempPermission");
         section.set("Permission", "advancedcore.test");
         section.set("Expiration", 90);
+        when(user.getPlayer()).thenReturn(mock(Player.class));
 
         configInject(0).onRewardRequested(reward, user, section, placeholders);
 
         verify(user).addPermission("advancedcore.test", 90);
+    }
+
+    @Test
+    public void temporaryPermissionFailurePropagatesDuringAsyncReplay() {
+        RewardTempPermission.register(handler, plugin);
+        ConfigurationSection data = new YamlConfiguration();
+        ConfigurationSection section = data.createSection("TempPermission");
+        section.set("Permission", "advancedcore.test");
+        section.set("Expiration", 90);
+        when(user.getPlayer()).thenReturn(null);
+
+        RewardInject inject = injects.get(0);
+        assertTrue(inject.supportsAsyncRequest());
+        assertTrue(inject.requiresConfiguredDataForAsync());
+        assertThrows(java.util.concurrent.CompletionException.class,
+                () -> inject.onRewardRequestAsync(reward, user, data, placeholders).toCompletableFuture().join());
+        verify(user, never()).addPermission(anyString(), org.mockito.ArgumentMatchers.anyLong());
     }
 
     @Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/BuiltinRewardBehaviorTest.java
@@ -1,6 +1,7 @@
 package com.bencodez.advancedcore.tests.rewards;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,6 +20,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
 
 import org.bukkit.Location;
@@ -295,6 +298,74 @@ public class BuiltinRewardBehaviorTest {
             ArrayList<String> random = new ArrayList<>(List.of("say only"));
             ((RewardInjectStringList) injects.get(4)).onRewardRequest(reward, user, random, placeholders);
             verify(misc).executeConsoleCommands("Ben", "say only", placeholders);
+        }
+    }
+
+    @Test
+    public void asyncCommandsWaitForTheirDispatchStages() {
+        RewardCommands.register(handler, plugin);
+        MiscUtils misc = mock(MiscUtils.class);
+        CompletableFuture<Void> numberCommand = new CompletableFuture<>();
+        CompletableFuture<Void> command = new CompletableFuture<>();
+        CompletableFuture<Void> commandList = new CompletableFuture<>();
+        CompletableFuture<Void> sectionConsole = new CompletableFuture<>();
+        CompletableFuture<Void> sectionPlayer = new CompletableFuture<>();
+        CompletableFuture<Void> random = new CompletableFuture<>();
+        try (MockedStatic<MiscUtils> miscStatic = mockStatic(MiscUtils.class)) {
+            miscStatic.when(MiscUtils::getInstance).thenReturn(misc);
+            when(misc.executeConsoleCommandsAsync(eq("Ben"), eq("give Ben stone 5"), eq(placeholders)))
+                    .thenReturn(numberCommand);
+            when(misc.executeConsoleCommandsAsync(eq("Ben"), eq("say hi"), eq(placeholders))).thenReturn(command);
+            ArrayList<String> list = new ArrayList<>(List.of("say one", "say two"));
+            when(misc.executeConsoleCommandsAsync(eq("Ben"), eq(list), eq(placeholders), eq(true)))
+                    .thenReturn(commandList);
+            ArrayList<String> console = new ArrayList<>(List.of("say console"));
+            when(misc.executeConsoleCommandsAsync(eq("Ben"), eq(console), eq(placeholders), eq(false)))
+                    .thenReturn(sectionConsole);
+            ArrayList<String> player = new ArrayList<>(List.of("spawn"));
+            when(user.preformCommandAsync(eq(player), eq(placeholders))).thenReturn(sectionPlayer);
+            ArrayList<String> randomList = new ArrayList<>(List.of("say random"));
+            HashMap<String, String> randomPlaceholders = new HashMap<>();
+            when(misc.executeConsoleCommandsAsync(eq("Ben"), eq("say random"), eq(randomPlaceholders))).thenReturn(random);
+
+            ConfigurationSection number = section("NumberCommand");
+            number.set("Min", 5);
+            number.set("Max", 5);
+            number.set("Command", "give Ben stone %number%");
+            CompletionStage<String> numberStage = ((RewardInjectConfigurationSection) injects.get(0))
+                    .onRewardRequestedAsync(reward, user, number, placeholders);
+            assertFalse(numberStage.toCompletableFuture().isDone());
+            numberCommand.complete(null);
+            assertEquals("5", numberStage.toCompletableFuture().join());
+
+            CompletionStage<String> commandStage = ((RewardInjectString) injects.get(1))
+                    .onRewardRequestAsync(reward, user, "say hi", placeholders);
+            assertFalse(commandStage.toCompletableFuture().isDone());
+            command.complete(null);
+            commandStage.toCompletableFuture().join();
+
+            CompletionStage<String> listStage = ((RewardInjectStringList) injects.get(2))
+                    .onRewardRequestAsync(reward, user, list, placeholders);
+            assertFalse(listStage.toCompletableFuture().isDone());
+            commandList.complete(null);
+            listStage.toCompletableFuture().join();
+
+            ConfigurationSection commands = section("Commands");
+            commands.set("Console", console);
+            commands.set("Player", player);
+            commands.set("Stagger", false);
+            CompletionStage<String> sectionStage = ((RewardInjectConfigurationSection) injects.get(3))
+                    .onRewardRequestedAsync(reward, user, commands, placeholders);
+            sectionConsole.complete(null);
+            assertFalse(sectionStage.toCompletableFuture().isDone());
+            sectionPlayer.complete(null);
+            sectionStage.toCompletableFuture().join();
+
+            CompletionStage<String> randomStage = ((RewardInjectStringList) injects.get(4))
+                    .onRewardRequestAsync(reward, user, randomList, randomPlaceholders);
+            assertFalse(randomStage.toCompletableFuture().isDone());
+            random.complete(null);
+            randomStage.toCompletableFuture().join();
         }
     }
 

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/QueuedGeneratedRewardDispatchTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/QueuedGeneratedRewardDispatchTest.java
@@ -6,12 +6,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
+import java.io.File;
 import java.util.Base64;
+import java.util.Set;
 import java.util.logging.Logger;
+import java.util.concurrent.CompletionException;
 
 import org.bukkit.Bukkit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
@@ -23,6 +27,8 @@ import com.bencodez.advancedcore.api.rewards.RewardOptions;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 
 class QueuedGeneratedRewardDispatchTest {
+	@TempDir
+	File tempDir;
 
     private static final String QUEUE_PREFIX = "\\AdvancedCoreQueue/1/";
 
@@ -235,4 +241,23 @@ class QueuedGeneratedRewardDispatchTest {
 
         verify(handler, never()).getQueuedGeneratedReward("QueuedReward", "uuid");
     }
+
+	@Test
+	void asyncGeneratedSnapshotRejectsAUserOutsideItsPersistedQueueCapability() throws Exception {
+		AdvancedCorePlugin.setInstance(plugin);
+		try {
+			java.lang.reflect.Constructor<?> constructor = Class
+					.forName("com.bencodez.advancedcore.api.rewards.QueuedGeneratedReward")
+					.getDeclaredConstructor(File.class, String.class, Set.class);
+			constructor.setAccessible(true);
+			Reward queued = (Reward) constructor.newInstance(tempDir, "QueuedReward", Set.of("allowed"));
+
+			org.junit.jupiter.api.Assertions.assertThrows(CompletionException.class,
+					() -> queued.giveRewardAsync(user, new RewardOptions()).toCompletableFuture().join());
+
+			verify(plugin, never()).getOptions();
+		} finally {
+			AdvancedCorePlugin.setInstance(null);
+		}
+	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -536,6 +536,45 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void commandReplayRetriesOnlyTheFailedSuffix() throws Exception {
+		ArrayList<String> dispatched = new ArrayList<>();
+		AtomicBoolean failSecond = new AtomicBoolean(true);
+		handler.getInjectedRewards().add(new RewardInject("Commands") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> commandPlaceholders) {
+				return Reward.replayCommandSequence(plugin, commandPlaceholders, "console",
+						List.of("first", "second"), command -> {
+							dispatched.add(command);
+							return command.equals("second") && failSecond.get()
+									? CompletableFuture.failedFuture(new IllegalStateException("temporary"))
+									: CompletableFuture.completedFuture(null);
+						}).thenApply(nothing -> null);
+			}
+		});
+
+		Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+				() -> reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join());
+		Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+		failSecond.set(false);
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward,
+				user, checkpoint.getReplayPlaceholders(), 0,
+				state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+				"AsyncReward");
+		resumed.toCompletableFuture().join();
+
+		assertEquals(List.of("first", "second", "second"), dispatched);
+	}
+
+	@Test
 	void persistedReplayRejectsAChangedInjectorRegistryBeforeAnyStageRuns() throws Exception {
 		AtomicInteger applied = new AtomicInteger();
 		AtomicInteger inserted = new AtomicInteger();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -160,8 +160,10 @@ class RewardAsyncInjectionTest {
 			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
 			CompletionStage<Void> result = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
 			assertFalse(result.toCompletableFuture().isDone());
-			assertEquals(2, queued.size());
-			for (Runnable action : queued) action.run();
+			assertEquals(1, queued.size());
+			queued.remove(0).run();
+			assertEquals(1, queued.size());
+			queued.remove(0).run();
 			result.toCompletableFuture().join();
 		}
 		verify(economy).depositPlayer(offlinePlayer, 2);
@@ -194,6 +196,79 @@ class RewardAsyncInjectionTest {
 			assertThrows(java.util.concurrent.CompletionException.class,
 					() -> reward.giveInjectedRewardsAsync(realUser, new HashMap<>()).toCompletableFuture().join());
 		}
+	}
+
+	@Test
+	void capturedAsyncContinuationActionCheckpointsRetryOnlyTheUnfinishedSuffix() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Checkpointed");
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		ArrayList<Runnable> queued = new ArrayList<>();
+		doAnswer(invocation -> {
+			queued.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		CompletableFuture<Void> continuation = new CompletableFuture<>();
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				realUser.giveMoney(1);
+				realUser.giveMoney(2);
+				return null;
+			}
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				AdvancedCoreUser.AsyncActionContext context = ignoredUser.captureAsyncActionContext();
+				return continuation.thenApply(context.wrap(nothing -> {
+					realUser.giveMoney(1);
+					realUser.giveMoney(2);
+					return null;
+				}));
+			}
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			CompletionStage<Void> first = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			continuation.complete(null);
+			assertEquals(1, queued.size());
+			queued.remove(0).run();
+			assertEquals(1, queued.size());
+			enabled.set(false);
+			queued.remove(0).run();
+			Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+					() -> first.toCompletableFuture().join());
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+			assertTrue(checkpoint.getReplayPlaceholders().entrySet().stream().anyMatch(entry ->
+					entry.getKey().startsWith("__advancedcore_replay_legacy_actions_") && entry.getValue().equals("1")));
+
+			enabled.set(true);
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			assertEquals(1, queued.size(), "the completed first action is never scheduled again");
+			queued.remove(0).run();
+			resumed.toCompletableFuture().join();
+		}
+		verify(economy).depositPlayer(offlinePlayer, 1);
+		verify(economy).depositPlayer(offlinePlayer, 2);
 	}
 
 	@Test
@@ -231,7 +306,7 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
-	void legacyActionsCreatedByAnAsyncContinuationAreAwaited() {
+	void legacyActionsCapturedByAsyncContextAreAwaited() {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);
 		when(plugin.getOptions()).thenReturn(config);
@@ -254,10 +329,11 @@ class RewardAsyncInjectionTest {
 					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
 			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
 					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
-				return continuation.thenApply(nothing -> {
+				AdvancedCoreUser.AsyncActionContext context = ignoredUser.captureAsyncActionContext();
+				return continuation.thenApply(context.wrap(nothing -> {
 					realUser.giveMoney(2);
 					return null;
-				});
+				}));
 			}
 		});
 
@@ -276,7 +352,7 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
-	void serializedPersistedReplaysWaitForThePriorContinuationAndLegacyAction() throws Exception {
+	void serializedPersistedReplaysDoNotClaimUnscopedContinuationActions() throws Exception {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);
 		when(plugin.getOptions()).thenReturn(config);
@@ -325,10 +401,9 @@ class RewardAsyncInjectionTest {
 
 			continuations.get(0).complete(null);
 			assertEquals(1, queuedActions.size());
-			assertEquals(1, invocations.get(), "the first legacy action is part of the replay tail");
+			assertEquals(2, invocations.get(), "the second replay starts after the first async stage completes");
 			queuedActions.get(0).run();
 
-			assertEquals(2, invocations.get(), "the second replay starts only after the first action completed");
 			continuations.get(1).complete(null);
 			assertEquals(2, queuedActions.size());
 			queuedActions.get(1).run();
@@ -338,7 +413,7 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
-	void legacyContinuationActionIsClaimedOnlyByItsCompletingScope() {
+	void unscopedActionsAreNotClaimedByAnArbitraryCollection() {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);
 		when(plugin.getOptions()).thenReturn(config);
@@ -367,7 +442,7 @@ class RewardAsyncInjectionTest {
 				CompletionStage<Void> innerCompletion = realUser.endAsyncActionCollection(inner);
 				assertEquals(1, queuedActions.size());
 				assertTrue(outerCompletion.toCompletableFuture().isDone());
-				assertFalse(innerCompletion.toCompletableFuture().isDone());
+				assertTrue(innerCompletion.toCompletableFuture().isDone());
 			queuedActions.get(0).run();
 			outerCompletion.toCompletableFuture().join();
 			innerCompletion.toCompletableFuture().join();
@@ -375,7 +450,43 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
-	void failedLegacyActionCreatedByAnAsyncContinuationFailsTheReward() {
+	void synchronousRewardActionIsNotClaimedByPendingAsyncInjection() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		when(vault.getEcon()).thenReturn(mock(Economy.class));
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Independent");
+		ArrayList<Runnable> queuedActions = new ArrayList<>();
+		doAnswer(invocation -> {
+			queuedActions.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		CompletableFuture<Object> pending = new CompletableFuture<>();
+		handler.getInjectedRewards().add(new RewardInject("Async") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return pending; }
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			CompletionStage<Void> result = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			realUser.giveMoney(4);
+			assertEquals(1, queuedActions.size());
+			pending.complete(null);
+			assertTrue(result.toCompletableFuture().isDone(),
+					"an unrelated queued action must not become this async reward's dependency");
+		}
+	}
+
+	@Test
+	void failedLegacyActionCreatedByAnAsyncContinuationDoesNotFailAnUnrelatedReward() {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);
 		when(plugin.getOptions()).thenReturn(config);
@@ -410,12 +521,12 @@ class RewardAsyncInjectionTest {
 			continuation.complete(null);
 			enabled.set(false);
 			queued.get().run();
-			assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+			result.toCompletableFuture().join();
 		}
 	}
 
 	@Test
-	void concurrentContinuationActionsRemainBoundToTheirOwnReward() {
+	void concurrentContinuationsDoNotClaimOneAnotherActions() {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);
 		when(plugin.getOptions()).thenReturn(config);
@@ -457,7 +568,7 @@ class RewardAsyncInjectionTest {
 			CompletionStage<Void> second = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
 
 			continuations.get(0).complete(null);
-			assertThrows(java.util.concurrent.CompletionException.class, () -> first.toCompletableFuture().join());
+			first.toCompletableFuture().join();
 			assertFalse(second.toCompletableFuture().isDone());
 
 			continuations.get(1).complete(null);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -19,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,6 +33,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.rewards.Reward;
@@ -158,6 +162,55 @@ class RewardAsyncInjectionTest {
 		assertEquals(List.of("first-start", "second:first-value", "post:second-value"), events);
 		assertEquals("first-value", placeholders.get("first"));
 		assertEquals("second-value", placeholders.get("second"));
+	}
+
+	@Test
+	void checkpointWriteRunsOffServerThreadAndGatesTheNextInjection() throws Exception {
+		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
+		when(plugin.getTimer()).thenReturn(storageExecutor);
+		List<String> events = new ArrayList<>();
+		handler.getInjectedRewards().add(new RewardInject("First") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				events.add("first");
+				return null;
+			}
+		});
+		handler.getInjectedRewards().add(new RewardInject("Second") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				events.add("second");
+				return null;
+			}
+		});
+
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		constructor.setAccessible(true);
+		Object replayState = constructor.newInstance(null, null, false);
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState, (java.util.function.Consumer<Reward.ReplayCheckpoint>) checkpoint ->
+				events.add("checkpoint:" + checkpoint.getReplayProgress().get("AsyncReward")));
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> result = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				replayState, "AsyncReward", "occurrence");
+
+		ArgumentCaptor<Runnable> writes = ArgumentCaptor.forClass(Runnable.class);
+		verify(storageExecutor).execute(writes.capture());
+		assertEquals(List.of("first"), events);
+		assertFalse(result.toCompletableFuture().isDone());
+
+		writes.getValue().run();
+		verify(storageExecutor, times(2)).execute(writes.capture());
+		assertEquals(List.of("first", "checkpoint:1", "second"), events);
+		writes.getAllValues().get(writes.getAllValues().size() - 1).run();
+		result.toCompletableFuture().join();
+		assertEquals(List.of("first", "checkpoint:1", "second", "checkpoint:2"), events);
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1,0 +1,320 @@
+package com.bencodez.advancedcore.tests.rewards;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.rewards.Reward;
+import com.bencodez.advancedcore.api.rewards.RewardHandler;
+import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
+import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
+import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
+
+class RewardAsyncInjectionTest {
+
+	@TempDir
+	File tempDir;
+
+	private AdvancedCorePlugin plugin;
+	private RewardHandler handler;
+	private Reward reward;
+	private ConfigurationSection data;
+	private AdvancedCoreUser user;
+	private AtomicBoolean enabled;
+	private com.bencodez.simpleapi.scheduler.BukkitScheduler scheduler;
+
+	@BeforeEach
+	void setUp() {
+		plugin = mock(AdvancedCorePlugin.class);
+		enabled = new AtomicBoolean(true);
+		when(plugin.isEnabled()).thenAnswer(ignored -> enabled.get());
+		when(plugin.getDataFolder()).thenReturn(tempDir);
+		when(plugin.getLogger()).thenReturn(mock(Logger.class));
+		scheduler = mock(com.bencodez.simpleapi.scheduler.BukkitScheduler.class);
+		doAnswer(invocation -> {
+			invocation.getArgument(1, Runnable.class).run();
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+		when(plugin.getBukkitScheduler()).thenReturn(scheduler);
+		AdvancedCorePlugin.setInstance(plugin);
+		handler = new RewardHandler(plugin);
+		when(plugin.getRewardHandler()).thenReturn(handler);
+
+		YamlConfiguration configuration = new YamlConfiguration();
+		data = configuration.createSection("Reward");
+		reward = new Reward("AsyncReward", data);
+		try {
+			java.lang.reflect.Field pluginField = Reward.class.getDeclaredField("plugin");
+			pluginField.setAccessible(true);
+			pluginField.set(reward, plugin);
+		} catch (ReflectiveOperationException failure) {
+			throw new AssertionError(failure);
+		}
+		user = mock(AdvancedCoreUser.class);
+	}
+
+	@AfterEach
+	void tearDown() {
+		handler.getDelayedTimer().shutdownNow();
+		AdvancedCorePlugin.setInstance(null);
+	}
+
+	@Test
+	void asyncInjectionsAreSequentialAndPostRewardsWaitForThem() {
+		List<String> events = new ArrayList<>();
+		HashMap<String, String> placeholders = new HashMap<>();
+		CompletableFuture<Object> deferred = new CompletableFuture<>();
+
+		RewardInject first = new RewardInject("First") {
+			@Override
+			public boolean supportsAsyncRequest() {
+				return true;
+			}
+
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser, ConfigurationSection ignoredData,
+					HashMap<String, String> ignoredPlaceholders) {
+				throw new AssertionError("the asynchronous hook should be used");
+			}
+
+			@Override
+			public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				events.add("first-start");
+				return deferred;
+			}
+		};
+		first.asPlaceholder("first");
+		RewardInject second = new RewardInject("Second") {
+			@Override
+			public boolean supportsAsyncRequest() {
+				return true;
+			}
+
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser, ConfigurationSection ignoredData,
+					HashMap<String, String> ignoredPlaceholders) {
+				throw new AssertionError("the asynchronous hook should be used");
+			}
+
+			@Override
+			public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				events.add("second:" + ignoredPlaceholders.get("first"));
+				return CompletableFuture.completedFuture("second-value");
+			}
+		};
+		second.asPlaceholder("second");
+		RewardInject post = new RewardInject("Post") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser, ConfigurationSection ignoredData,
+					HashMap<String, String> ignoredPlaceholders) {
+				events.add("post:" + ignoredPlaceholders.get("second"));
+				return null;
+			}
+		};
+		post.postReward();
+		handler.getInjectedRewards().add(first);
+		handler.getInjectedRewards().add(second);
+		handler.getInjectedRewards().add(post);
+
+		CompletionStage<Void> result = reward.giveInjectedRewardsAsync(user, placeholders);
+		assertFalse(result.toCompletableFuture().isDone());
+		assertEquals(List.of("first-start"), events);
+
+		deferred.complete("first-value");
+		result.toCompletableFuture().join();
+		assertEquals(List.of("first-start", "second:first-value", "post:second-value"), events);
+		assertEquals("first-value", placeholders.get("first"));
+		assertEquals("second-value", placeholders.get("second"));
+	}
+
+	@Test
+	void typedIntegerAsyncHookUsesParsedValue() {
+		data.set("Amount", 7);
+		HashMap<String, String> placeholders = new HashMap<>();
+		List<Integer> received = new ArrayList<>();
+
+		RewardInjectInt amount = new RewardInjectInt("Amount") {
+			@Override
+			public boolean supportsAsyncRequest() {
+				return true;
+			}
+
+			@Override
+			public String onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser, int ignoredValue,
+					HashMap<String, String> ignoredPlaceholders) {
+				throw new AssertionError("the asynchronous typed hook should be used");
+			}
+
+			@Override
+			public CompletionStage<String> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser, int value,
+					HashMap<String, String> ignoredPlaceholders) {
+				received.add(value);
+				return CompletableFuture.completedFuture("async-" + value);
+			}
+		};
+		amount.asPlaceholder("amount");
+		handler.getInjectedRewards().add(amount);
+
+		reward.giveInjectedRewardsAsync(user, placeholders).toCompletableFuture().join();
+		assertTrue(received.contains(7));
+		assertEquals("async-7", placeholders.get("amount"));
+	}
+
+	@Test
+	void failedAsyncInjectionStopsDependentRewardsAndPropagates() {
+		AtomicBoolean dependentRan = new AtomicBoolean();
+		RewardInject failing = asyncInjection("Failure", CompletableFuture.failedFuture(
+				new IllegalStateException("durable update failed")), null);
+		RewardInject dependent = asyncInjection("Dependent", CompletableFuture.completedFuture(null), dependentRan);
+		handler.getInjectedRewards().add(failing);
+		handler.getInjectedRewards().add(dependent);
+
+		CompletionStage<Void> result = reward.giveInjectedRewardsAsync(user, new HashMap<>());
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		assertFalse(dependentRan.get());
+	}
+
+	@Test
+	void synchronizedAsyncInjectionSerializesThroughCompletion() {
+		List<CompletableFuture<Object>> completions = new ArrayList<>();
+		List<Integer> starts = new ArrayList<>();
+		RewardInject serialized = new RewardInject("Serialized") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward reward, AdvancedCoreUser user,
+					ConfigurationSection data, HashMap<String, String> placeholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+					ConfigurationSection data, HashMap<String, String> placeholders) {
+				starts.add(starts.size() + 1);
+				CompletableFuture<Object> completion = new CompletableFuture<>();
+				completions.add(completion);
+				return completion;
+			}
+		};
+		serialized.synchronize();
+		handler.getInjectedRewards().add(serialized);
+
+		CompletionStage<Void> first = reward.giveInjectedRewardsAsync(user, new HashMap<>());
+		CompletionStage<Void> second = reward.giveInjectedRewardsAsync(user, new HashMap<>());
+		assertEquals(List.of(1), starts);
+
+		completions.get(0).complete(null);
+		assertEquals(List.of(1, 2), starts);
+		completions.get(1).complete(null);
+		first.toCompletableFuture().join();
+		second.toCompletableFuture().join();
+	}
+
+	@Test
+	void shutdownStopsContinuationsAfterPendingInjection() {
+		CompletableFuture<Object> completion = new CompletableFuture<>();
+		AtomicBoolean dependentRan = new AtomicBoolean();
+		handler.getInjectedRewards().add(asyncInjection("Pending", completion, null));
+		handler.getInjectedRewards().add(
+				asyncInjection("Dependent", CompletableFuture.completedFuture(null), dependentRan));
+		CompletionStage<Void> result = reward.giveInjectedRewardsAsync(user, new HashMap<>());
+
+		enabled.set(false);
+		completion.complete(null);
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		assertFalse(dependentRan.get());
+	}
+
+	@Test
+	void schedulerCancellationCompletesStageExceptionally() {
+		Reward shortTimeoutReward = new Reward("AsyncReward", data) {
+			@Override
+			protected long getServerThreadDispatchTimeoutMillis() {
+				return 25;
+			}
+		};
+		try {
+			java.lang.reflect.Field pluginField = Reward.class.getDeclaredField("plugin");
+			pluginField.setAccessible(true);
+			pluginField.set(shortTimeoutReward, plugin);
+		} catch (ReflectiveOperationException failure) {
+			throw new AssertionError(failure);
+		}
+		AtomicBoolean invoked = new AtomicBoolean();
+		handler.getInjectedRewards().add(
+				asyncInjection("Dropped", CompletableFuture.completedFuture(null), invoked));
+		org.mockito.Mockito.reset(scheduler);
+		when(plugin.getBukkitScheduler()).thenReturn(scheduler);
+		AtomicReference<Runnable> droppedTask = new AtomicReference<>();
+		doAnswer(invocation -> {
+			droppedTask.set(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+
+		CompletionStage<Void> result = shortTimeoutReward.giveInjectedRewardsAsync(user, new HashMap<>());
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		droppedTask.get().run();
+		assertFalse(invoked.get());
+	}
+
+	@Test
+	void injectionCompletionIsNotLimitedBySchedulerHandoffTimeout() throws Exception {
+		Reward shortTimeoutReward = new Reward("AsyncReward", data) {
+			@Override
+			protected long getServerThreadDispatchTimeoutMillis() {
+				return 25;
+			}
+		};
+		try {
+			java.lang.reflect.Field pluginField = Reward.class.getDeclaredField("plugin");
+			pluginField.setAccessible(true);
+			pluginField.set(shortTimeoutReward, plugin);
+		} catch (ReflectiveOperationException failure) {
+			throw new AssertionError(failure);
+		}
+		CompletableFuture<Object> completion = new CompletableFuture<>();
+		handler.getInjectedRewards().add(asyncInjection("SlowStorage", completion, null));
+
+		CompletionStage<Void> result = shortTimeoutReward.giveInjectedRewardsAsync(user, new HashMap<>());
+		Thread.sleep(75);
+		assertFalse(result.toCompletableFuture().isDone());
+		completion.complete(null);
+		result.toCompletableFuture().join();
+	}
+
+	private RewardInject asyncInjection(String path, CompletionStage<Object> completion, AtomicBoolean invoked) {
+		return new RewardInject(path) {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward reward, AdvancedCoreUser user,
+					ConfigurationSection data, HashMap<String, String> placeholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward reward, AdvancedCoreUser user,
+					ConfigurationSection data, HashMap<String, String> placeholders) {
+				if (invoked != null) invoked.set(true);
+				return completion;
+			}
+		};
+	}
+}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -70,6 +70,7 @@ import com.bencodez.advancedcore.api.rewards.injected.RewardInjectString;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardSubRewards;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardRandomReward;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardJavascript;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardChoices;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardSpecialChance;
 import com.bencodez.advancedcore.api.javascript.JavascriptEngine;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
@@ -1731,6 +1732,45 @@ class RewardAsyncInjectionTest {
 
 		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
 		verify(handler, times(2)).giveRewardAsync(eq(user), eq("child"), any(RewardOptions.class));
+	}
+
+	@Test
+	void unclaimedChoiceIsAddedOnlyAfterItsSelectionIsDurable() throws Exception {
+		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
+		when(plugin.getTimer()).thenReturn(storageExecutor);
+		data.set("EnableChoices", true);
+		when(user.getChoicePreference("AsyncReward")).thenReturn("");
+		RewardChoices.register(handler, plugin);
+		List<Runnable> writes = new ArrayList<>();
+		doAnswer(invocation -> {
+			writes.add(invocation.getArgument(0));
+			return null;
+		}).when(storageExecutor).execute(any(Runnable.class));
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> stateConstructor = stateType.getDeclaredConstructor(Map.class, Map.class,
+				boolean.class);
+		stateConstructor.setAccessible(true);
+		Object replayState = stateConstructor.newInstance(new HashMap<>(), new HashMap<>(), false);
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState,
+				(java.util.function.Consumer<Reward.ReplayCheckpoint>) ignored -> { });
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+		replay.setAccessible(true);
+
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> result = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				replayState, "AsyncReward");
+
+		assertEquals(1, writes.size());
+		verify(user, never()).addUnClaimedChoiceReward("AsyncReward");
+		writes.get(0).run();
+		verify(user).addUnClaimedChoiceReward("AsyncReward");
+		assertEquals(2, writes.size());
+		writes.get(1).run();
+		result.toCompletableFuture().join();
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1463,6 +1463,28 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void removedSubRewardsSectionCannotDropItsPendingNestedSnapshot() throws Exception {
+		RewardSubRewards.register(handler, plugin);
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(Map.class, Map.class,
+				boolean.class);
+		constructor.setAccessible(true);
+		Object replayState = constructor.newInstance(new HashMap<>(), new HashMap<>(), false);
+		@SuppressWarnings("unchecked")
+		CompletionStage<List<String>> snapshot = Reward.replayNestedRewardSnapshot(plugin, new HashMap<>(),
+				"nested-list:Rewards", List.of("First", "Second"), (Reward.ReplayState) replayState,
+				"AsyncReward/0");
+		snapshot.toCompletableFuture().join();
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				replayState, "AsyncReward", "occurrence");
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+	}
+
+	@Test
 	void everyNestedRewardInjectorWaitsForItsSelectedChild() {
 		handler = org.mockito.Mockito.spy(new RewardHandler(plugin));
 		when(plugin.getRewardHandler()).thenReturn(handler);
@@ -1489,6 +1511,52 @@ class RewardAsyncInjectionTest {
 		child.complete(null);
 		result.toCompletableFuture().join();
 		assertEquals(List.of("after-child"), events);
+	}
+
+	@Test
+	void randomRewardResumesItsSelectedChildAfterConfigurationRemoval() throws Exception {
+		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
+		when(plugin.getTimer()).thenReturn(storageExecutor);
+		handler = org.mockito.Mockito.spy(new RewardHandler(plugin));
+		when(plugin.getRewardHandler()).thenReturn(handler);
+		when(user.getPlugin()).thenReturn(plugin);
+		data.set("RandomReward", new ArrayList<>(List.of("child")));
+		doReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")))
+				.when(handler).giveRewardAsync(eq(user), eq("child"), any(RewardOptions.class));
+		RewardRandomReward.register(handler, plugin);
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		Object initialState = state.newInstance(new HashMap<>(), new HashMap<>(), false);
+		List<Reward.ReplayCheckpoint> checkpoints = new ArrayList<>();
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(initialState,
+				(java.util.function.Consumer<Reward.ReplayCheckpoint>) checkpoints::add);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> first = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				initialState, "AsyncReward", "occurrence");
+		ArgumentCaptor<Runnable> writes = ArgumentCaptor.forClass(Runnable.class);
+		verify(storageExecutor).execute(writes.capture());
+		verify(handler, never()).giveRewardAsync(eq(user), eq("child"), any(RewardOptions.class));
+
+		writes.getValue().run();
+		assertThrows(java.util.concurrent.CompletionException.class, () -> first.toCompletableFuture().join());
+		assertEquals(1, checkpoints.size());
+		assertTrue(checkpoints.get(0).getPlaceholders().keySet().stream()
+				.anyMatch(key -> key.startsWith("__advancedcore_replay_selection_")));
+		data.set("RandomReward", null);
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user,
+				checkpoints.get(0).getPlaceholders(), 0,
+				state.newInstance(checkpoints.get(0).getReplayProgress(),
+						checkpoints.get(0).getReplayRegistryFingerprints(), false),
+				"AsyncReward", "occurrence");
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+		verify(handler, times(2)).giveRewardAsync(eq(user), eq("child"), any(RewardOptions.class));
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,6 +22,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -125,10 +127,12 @@ class RewardAsyncInjectionTest {
 		when(plugin.getVaultHandler()).thenReturn(vault);
 		FullInventoryHandler inventory = mock(FullInventoryHandler.class);
 		when(plugin.getFullInventoryHandler()).thenReturn(inventory);
+		CompletableFuture<Void> itemDelivery = new CompletableFuture<>();
 		UUID uuid = UUID.randomUUID();
 		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, uuid, false, false);
 		realUser.setPlayerName("Legacy");
 		Player player = mock(Player.class);
+		when(inventory.giveItemAsync(eq(player), any(ItemStack.class))).thenReturn(itemDelivery);
 		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
 		ArrayList<Runnable> queued = new ArrayList<>();
 		doAnswer(invocation -> {
@@ -162,12 +166,34 @@ class RewardAsyncInjectionTest {
 			assertFalse(result.toCompletableFuture().isDone());
 			assertEquals(1, queued.size());
 			queued.remove(0).run();
-			assertEquals(1, queued.size());
-			queued.remove(0).run();
+			assertTrue(queued.isEmpty(), "replay hands the item directly to the awaited inventory task");
+			assertFalse(result.toCompletableFuture().isDone(), "the inner item delivery still owns completion");
+			itemDelivery.complete(null);
 			result.toCompletableFuture().join();
 		}
 		verify(economy).depositPlayer(offlinePlayer, 2);
-		verify(inventory).giveItem(eq(player), any(ItemStack.class));
+		verify(inventory).giveItemAsync(eq(player), any(ItemStack.class));
+	}
+
+	@Test
+	void ordinaryItemGrantUsesTheVoidInventoryApiWithoutAnAsyncTimeout() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		FullInventoryHandler inventory = mock(FullInventoryHandler.class);
+		when(plugin.getFullInventoryHandler()).thenReturn(inventory);
+		UUID uuid = UUID.randomUUID();
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, uuid, false, false);
+		Player player = mock(Player.class);
+		ItemStack item = new ItemStack(Material.STONE);
+
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			realUser.giveItem(item);
+		}
+
+		verify(inventory).giveItem(player, item);
+		verify(inventory, never()).giveItemAsync(any(Player.class), any(ItemStack.class));
 	}
 
 	@Test
@@ -250,7 +276,9 @@ class RewardAsyncInjectionTest {
 					() -> first.toCompletableFuture().join());
 			Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
 			assertTrue(checkpoint.getReplayPlaceholders().entrySet().stream().anyMatch(entry ->
-					entry.getKey().startsWith("__advancedcore_replay_legacy_actions_") && entry.getValue().equals("1")));
+					entry.getKey().startsWith("__advancedcore_replay_legacy_actions_") && entry.getValue().startsWith("v2:")));
+			assertTrue(checkpoint.getReplayPlaceholders().keySet().stream()
+					.anyMatch(key -> key.startsWith("__advancedcore_replay_legacy_actions_") && key.endsWith("_snapshot")));
 
 			enabled.set(true);
 			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
@@ -269,6 +297,92 @@ class RewardAsyncInjectionTest {
 		}
 		verify(economy).depositPlayer(offlinePlayer, 1);
 		verify(economy).depositPlayer(offlinePlayer, 2);
+	}
+
+	@Test
+	void legacyActionSnapshotsSurviveReorderRemovalAndExtension() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("ActionSnapshot");
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		ArrayList<Runnable> queued = new ArrayList<>();
+		doAnswer(invocation -> {
+			queued.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		AtomicReference<List<Double>> amounts = new AtomicReference<>(new ArrayList<>(List.of(1D, 2D)));
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				for (double amount : amounts.get()) realUser.giveMoney(amount);
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			CompletionStage<Void> first = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			queued.remove(0).run();
+			enabled.set(false);
+			queued.remove(0).run();
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(assertThrows(
+					java.util.concurrent.CompletionException.class, () -> first.toCompletableFuture().join()));
+
+			enabled.set(true);
+			amounts.set(new ArrayList<>(List.of(2D, 3D)));
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			assertEquals(1, queued.size(), "the completed, removed action is not rescheduled");
+			queued.remove(0).run();
+			assertEquals(1, queued.size(), "the extended action runs after the unfinished stable action");
+			queued.remove(0).run();
+			resumed.toCompletableFuture().join();
+		}
+		verify(economy).depositPlayer(offlinePlayer, 1D);
+		verify(economy).depositPlayer(offlinePlayer, 2D);
+		verify(economy).depositPlayer(offlinePlayer, 3D);
+	}
+
+	@Test
+	void itemActionFingerprintIsCanonicalAndIncludesMetadata() throws Exception {
+		LinkedHashMap<String, Object> first = new LinkedHashMap<>();
+		first.put("type", "DIAMOND");
+		first.put("amount", 1);
+		first.put("meta", Map.of("display-name", "Original", "lore", List.of("one", "two")));
+		LinkedHashMap<String, Object> reordered = new LinkedHashMap<>();
+		reordered.put("meta", Map.of("lore", List.of("one", "two"), "display-name", "Original"));
+		reordered.put("amount", 1);
+		reordered.put("type", "DIAMOND");
+		LinkedHashMap<String, Object> changedMetadata = new LinkedHashMap<>(reordered);
+		changedMetadata.put("meta", Map.of("display-name", "Changed", "lore", List.of("one", "two")));
+		java.lang.reflect.Method descriptor = AdvancedCoreUser.class.getDeclaredMethod("canonicalActionDescriptor",
+				Object.class);
+		descriptor.setAccessible(true);
+		String firstDescriptor = (String) descriptor.invoke(null, first);
+		String reorderedDescriptor = (String) descriptor.invoke(null, reordered);
+		String changedDescriptor = (String) descriptor.invoke(null, changedMetadata);
+
+		assertEquals(Reward.legacyActionFingerprint(firstDescriptor), Reward.legacyActionFingerprint(reorderedDescriptor));
+		assertNotEquals(Reward.legacyActionFingerprint(firstDescriptor), Reward.legacyActionFingerprint(changedDescriptor));
 	}
 
 	@Test
@@ -582,11 +696,11 @@ class RewardAsyncInjectionTest {
 	void commandSnapshotIsCheckpointedBeforeItsFirstDispatch() throws Exception {
 		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
 		when(plugin.getTimer()).thenReturn(storageExecutor);
+		List<Reward.ReplayCheckpoint> checkpoints = new ArrayList<>();
 		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
 		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
 		constructor.setAccessible(true);
 		Object replayState = constructor.newInstance(new HashMap<>(), new HashMap<>(), false);
-		List<Reward.ReplayCheckpoint> checkpoints = new ArrayList<>();
 		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
 				java.util.function.Consumer.class);
 		setConsumer.setAccessible(true);
@@ -1161,6 +1275,44 @@ class RewardAsyncInjectionTest {
 		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
 		assertEquals(1, applied.get());
 		assertEquals(0, inserted.get());
+	}
+
+	@Test
+	void completedInjectorIsNotReplayedWhenItsConfigurationChangesDuringRecovery() throws Exception {
+		AtomicInteger applied = new AtomicInteger();
+		data.set("Applied", "before");
+		handler.getInjectedRewards().add(new RewardInject("Applied") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				applied.incrementAndGet();
+				return null;
+			}
+		});
+		handler.getInjectedRewards().add(new RewardInject("Fails") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				return CompletableFuture.failedFuture(new IllegalStateException("temporary"));
+			}
+		});
+
+		Reward.RewardReplayFailure checkpoint = findCheckpoint(assertThrows(
+				java.util.concurrent.CompletionException.class,
+				() -> reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join()));
+		data.set("Applied", "after");
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+				"AsyncReward");
+		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+		assertEquals(1, applied.get());
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1503,6 +1503,38 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void failingLegacyInjectionRetainsPersistedReplay() throws Exception {
+		AtomicBoolean laterRan = new AtomicBoolean();
+		handler.getInjectedRewards().add(new RewardInject("PlayerBoundLegacy") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				throw new NullPointerException("player disconnected");
+			}
+		});
+		handler.getInjectedRewards().add(asyncInjection("Later", CompletableFuture.completedFuture(null), laterRan));
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		Object replayState = state.newInstance(new HashMap<>(), new HashMap<>(), false);
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState,
+				(java.util.function.Consumer<Reward.ReplayCheckpoint>) ignored -> { });
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> result = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				replayState, "AsyncReward", "occurrence");
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		assertFalse(laterRan.get());
+	}
+
+	@Test
 	void synchronizedAsyncInjectionSerializesThroughCompletion() {
 		List<CompletableFuture<Object>> completions = new ArrayList<>();
 		List<Integer> starts = new ArrayList<>();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -41,6 +41,7 @@ import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.RewardOptions;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
+import com.bencodez.advancedcore.api.rewards.injected.RewardInjectString;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardSubRewards;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardRandomReward;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
@@ -244,6 +245,23 @@ class RewardAsyncInjectionTest {
 		reward.giveInjectedRewardsAsync(user, placeholders).toCompletableFuture().join();
 		assertTrue(received.contains(7));
 		assertEquals("async-7", placeholders.get("amount"));
+	}
+
+	@Test
+	void typedStringAsyncHookPreservesConfiguredValueWhenCallbackReturnsNull() {
+		data.set("Message", "configured-value");
+		HashMap<String, String> placeholders = new HashMap<>();
+		RewardInjectString message = new RewardInjectString("Message") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public String onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser, String value,
+					HashMap<String, String> ignoredPlaceholders) { return null; }
+		};
+		message.asPlaceholder("message");
+		handler.getInjectedRewards().add(message);
+
+		reward.giveInjectedRewardsAsync(user, placeholders).toCompletableFuture().join();
+
+		assertEquals("configured-value", placeholders.get("message"));
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1556,6 +1556,40 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void silentPlayerBoundLegacyInjectionRetainsPersistedReplay() throws Exception {
+		AtomicBoolean invoked = new AtomicBoolean();
+		RewardInject playerOutput = new RewardInject("Sound") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				invoked.set(true);
+				return null;
+			}
+		}.requiresPlayer();
+		handler.getInjectedRewards().add(playerOutput);
+		AdvancedCoreUser disconnected = mock(AdvancedCoreUser.class);
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		Object replayState = state.newInstance(new HashMap<>(), new HashMap<>(), false);
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState,
+				(java.util.function.Consumer<Reward.ReplayCheckpoint>) ignored -> { });
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> result = (CompletionStage<Void>) replay.invoke(reward, disconnected, new HashMap<>(), 0,
+				replayState, "AsyncReward", "occurrence");
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		assertFalse(invoked.get());
+	}
+
+	@Test
 	void synchronizedAsyncInjectionSerializesThroughCompletion() {
 		List<CompletableFuture<Object>> completions = new ArrayList<>();
 		List<Integer> starts = new ArrayList<>();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -486,6 +486,65 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void schedulerRejectionReleasesUnstartedRandomActionForReplay() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("RandomReplay");
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		AtomicReference<Double> amount = new AtomicReference<>(1D);
+		AtomicBoolean reject = new AtomicBoolean(true);
+		ArrayList<Runnable> queued = new ArrayList<>();
+		doAnswer(invocation -> {
+			if (reject.get()) throw new IllegalStateException("scheduler stopped");
+			queued.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				realUser.giveMoney(amount.get());
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(assertThrows(
+					java.util.concurrent.CompletionException.class,
+					() -> reward.giveInjectedRewardsAsync(realUser, new HashMap<>()).toCompletableFuture().join()));
+
+			amount.set(2D);
+			reject.set(false);
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			assertEquals(1, queued.size(), "the safely unstarted action is regenerated on retry");
+			queued.remove(0).run();
+			resumed.toCompletableFuture().join();
+		}
+		verify(economy, never()).depositPlayer(offlinePlayer, 1D);
+		verify(economy).depositPlayer(offlinePlayer, 2D);
+	}
+
+	@Test
 	void capturedAsyncContinuationActionCheckpointsRetryOnlyTheUnfinishedSuffix() throws Exception {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);
@@ -624,7 +683,7 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
-	void legacyActionReplayRejectsRemovalOfAnUnfinishedAction() throws Exception {
+	void legacyActionReplayAllowsRemovalOfAConclusiveUnstartedAction() throws Exception {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);
 		when(plugin.getOptions()).thenReturn(config);
@@ -675,9 +734,11 @@ class RewardAsyncInjectionTest {
 					checkpoint.getReplayPlaceholders(), 0,
 					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
 					"AsyncReward");
-			assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
-			assertTrue(queued.isEmpty(), "no action may run after an unfinished persisted action disappears");
+			resumed.toCompletableFuture().join();
+			assertTrue(queued.isEmpty(), "an action proven unstarted may disappear before retry");
 		}
+		verify(economy).depositPlayer(offlinePlayer, 1D);
+		verify(economy, never()).depositPlayer(offlinePlayer, 2D);
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1765,9 +1765,9 @@ class RewardAsyncInjectionTest {
 				replayState, "AsyncReward");
 
 		assertEquals(1, writes.size());
-		verify(user, never()).addUnClaimedChoiceReward("AsyncReward");
+		verify(user, never()).addUnClaimedChoiceReward(eq("AsyncReward"), any(String.class));
 		writes.get(0).run();
-		verify(user).addUnClaimedChoiceReward("AsyncReward");
+		verify(user).addUnClaimedChoiceReward(eq("AsyncReward"), any(String.class));
 		assertEquals(2, writes.size());
 		writes.get(1).run();
 		result.toCompletableFuture().join();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -57,6 +57,7 @@ import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.rewards.RewardBuilder;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.RewardOptions;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardExp;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardItems;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardPotions;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
@@ -344,6 +345,74 @@ class RewardAsyncInjectionTest {
 			assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
 		}
 		verify(player, never()).addPotionEffect(any());
+	}
+
+	@Test
+	void replayExperienceRemainsPendingForNullAndDisconnectedPlayers() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		UUID uuid = UUID.randomUUID();
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, uuid, false, false);
+		realUser.setPlayerName("ExperienceDispatch");
+		Player player = mock(Player.class);
+		when(player.getDisplayName()).thenReturn("ExperienceDispatch");
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		AtomicReference<Player> availablePlayer = new AtomicReference<>(player);
+		AtomicReference<Runnable> queuedInjection = new AtomicReference<>();
+		doAnswer(invocation -> {
+			queuedInjection.set(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+		data.set("EXP", 5);
+		RewardExp.register(handler, plugin);
+
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenAnswer(ignored -> availablePlayer.get());
+			CompletionStage<Void> delivery = reward.giveRewardUserAsync(realUser, new HashMap<>(), new RewardOptions());
+			assertFalse(delivery.toCompletableFuture().isDone());
+			availablePlayer.set(null);
+			Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+					() -> {
+						queuedInjection.get().run();
+						delivery.toCompletableFuture().join();
+					});
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+			assertEquals(0, checkpoint.getCompletedInjectionCount());
+			verify(player, never()).giveExp(5);
+
+			availablePlayer.set(player);
+			doAnswer(invocation -> {
+				invocation.getArgument(1, Runnable.class).run();
+				return null;
+			}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+			doAnswer(invocation -> {
+				invocation.getArgument(1, Runnable.class).run();
+				return null;
+			}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class), eq(player));
+			AtomicReference<Runnable> queuedExperience = new AtomicReference<>();
+			doAnswer(invocation -> {
+				queuedExperience.set(invocation.getArgument(1, Runnable.class));
+				return null;
+			}).when(scheduler).runTask(eq(plugin), any(Runnable.class), eq(player));
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			assertFalse(resumed.toCompletableFuture().isDone());
+			assertNotNull(queuedExperience.get());
+			availablePlayer.set(null);
+			queuedExperience.get().run();
+			assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+		}
+		verify(player, never()).giveExp(5);
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -129,6 +131,39 @@ class RewardAsyncInjectionTest {
 	void tearDown() {
 		handler.getDelayedTimer().shutdownNow();
 		AdvancedCorePlugin.setInstance(null);
+	}
+
+	@Test
+	void reusedTopLevelOptionsDoNotShareCompletedReplayState() {
+		AtomicInteger invocations = new AtomicInteger();
+		Player player = mock(Player.class);
+		when(user.getPlayer()).thenReturn(player);
+		doAnswer(invocation -> {
+			invocation.getArgument(1, Runnable.class).run();
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class), eq(player));
+		handler.getInjectedRewards().add(new RewardInject("Async") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				invocations.incrementAndGet();
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+		RewardOptions options = new RewardOptions().forceOffline();
+
+		Reward.ReplayState firstDispatch = Reward.replayStateFor(options);
+		Reward.ReplayState secondDispatch = Reward.replayStateFor(options);
+		reward.giveRewardUserAsync(user, new HashMap<>(), options).toCompletableFuture().join();
+		reward.giveRewardUserAsync(user, new HashMap<>(), options).toCompletableFuture().join();
+
+		assertNotSame(firstDispatch, secondDispatch);
+		assertEquals(2, invocations.get());
+		assertNull(options.getAsyncReplayState());
+		assertNull(options.getAsyncReplayKey());
+		assertNull(options.getAsyncReplayOccurrenceId());
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -423,7 +423,24 @@ class RewardAsyncInjectionTest {
 			assertNotNull(queuedExperience.get());
 			availablePlayer.set(null);
 			queuedExperience.get().run();
-			assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+			Throwable scheduledFailure = assertThrows(java.util.concurrent.CompletionException.class,
+					() -> resumed.toCompletableFuture().join());
+			Reward.RewardReplayFailure retryCheckpoint = findCheckpoint(scheduledFailure);
+
+			// The disconnected owner task never mutated the player, so its reservation
+			// must be released and a changed retry payload must be accepted.
+			data.set("EXP", 7);
+			availablePlayer.set(player);
+			doAnswer(invocation -> {
+				invocation.getArgument(1, Runnable.class).run();
+				return null;
+			}).when(scheduler).runTask(eq(plugin), any(Runnable.class), eq(player));
+			CompletionStage<Void> changedRetry = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					retryCheckpoint.getReplayPlaceholders(), 0,
+					state.newInstance(retryCheckpoint.getReplayProgress(),
+							retryCheckpoint.getReplayRegistryFingerprints(), false), "AsyncReward");
+			changedRetry.toCompletableFuture().join();
+			verify(player).giveExp(7);
 		}
 		verify(player, never()).giveExp(5);
 	}

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1565,15 +1565,18 @@ class RewardAsyncInjectionTest {
 		ArrayList<String> dispatched = new ArrayList<>();
 		AtomicBoolean failSecond = new AtomicBoolean(true);
 		AtomicInteger expansion = new AtomicInteger();
+		AtomicReference<List<String>> configuredTemplates = new AtomicReference<>(
+				List.of("first %value%", "second %value%"));
 		handler.getInjectedRewards().add(new RewardInject("Commands") {
 			@Override public boolean supportsAsyncRequest() { return true; }
 			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
 					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
 			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
 					ConfigurationSection ignoredData, HashMap<String, String> commandPlaceholders) {
-				List<String> templates = List.of("first %value%", "second %value%");
+				List<String> templates = configuredTemplates.get();
 				int currentExpansion = expansion.incrementAndGet();
-				List<String> expanded = List.of("first-" + currentExpansion, "second-" + currentExpansion);
+				List<String> expanded = templates.stream()
+						.map(template -> template.substring(0, template.indexOf(' ')) + "-" + currentExpansion).toList();
 				return Reward.replayCommandSequence(plugin, commandPlaceholders, "console", templates, expanded,
 						(command, ignoredIndex) -> {
 							dispatched.add(command);
@@ -1588,6 +1591,7 @@ class RewardAsyncInjectionTest {
 				() -> reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join());
 		Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
 		failSecond.set(false);
+		configuredTemplates.set(List.of("inserted %value%", "second %value%", "first %value%"));
 		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
 		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
 		state.setAccessible(true);
@@ -1601,6 +1605,25 @@ class RewardAsyncInjectionTest {
 		resumed.toCompletableFuture().join();
 
 		assertEquals(List.of("first-1", "second-1", "second-1"), dispatched);
+	}
+
+	@Test
+	void replayProgressBeyondTheInjectorRegistryFailsClosed() throws Exception {
+		AtomicInteger invoked = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Only") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				invoked.incrementAndGet();
+				return null;
+			}
+		});
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> result = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 2);
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		assertEquals(0, invoked.get());
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -35,6 +35,7 @@ import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardSubRewards;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardRandomReward;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 
 class RewardAsyncInjectionTest {
@@ -356,6 +357,109 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void everyNestedRewardInjectorWaitsForItsSelectedChild() {
+		handler = org.mockito.Mockito.spy(new RewardHandler(plugin));
+		when(plugin.getRewardHandler()).thenReturn(handler);
+		when(user.getPlugin()).thenReturn(plugin);
+		data.set("RandomReward", new ArrayList<>(List.of("child")));
+		CompletableFuture<Void> child = new CompletableFuture<>();
+		doReturn(child).when(handler).giveRewardAsync(eq(user), eq("child"), any());
+		List<String> events = new ArrayList<>();
+		RewardRandomReward.register(handler, plugin);
+		handler.getInjectedRewards().add(new RewardInject("After") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				events.add("after-child");
+				return null;
+			}
+		}.postReward());
+
+		CompletionStage<Void> result = reward.giveInjectedRewardsAsync(user, new HashMap<>());
+		assertFalse(result.toCompletableFuture().isDone());
+		assertTrue(events.isEmpty());
+		child.complete(null);
+		result.toCompletableFuture().join();
+		assertEquals(List.of("after-child"), events);
+	}
+
+	@Test
+	void replayCheckpointSkipsAlreadyAppliedInjectionAfterLaterFailure() throws Exception {
+		AtomicInteger alreadyApplied = new AtomicInteger();
+		AtomicBoolean fail = new AtomicBoolean(true);
+		RewardInject applied = new RewardInject("Money") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				alreadyApplied.incrementAndGet();
+				return "receipt-1";
+			}
+		};
+		applied.asPlaceholder("receipt");
+		handler.getInjectedRewards().add(applied);
+		handler.getInjectedRewards().add(new RewardInject("Durable") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				return fail.get() ? CompletableFuture.failedFuture(new IllegalStateException("temporary"))
+						: CompletableFuture.completedFuture(null);
+			}
+		});
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> first = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0);
+		Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+				() -> first.toCompletableFuture().join());
+		Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+		assertEquals(1, checkpoint.getCompletedInjectionCount());
+		assertEquals("receipt-1", checkpoint.getReplayPlaceholders().get("receipt"));
+		fail.set(false);
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(),
+				checkpoint.getCompletedInjectionCount());
+		resumed.toCompletableFuture().join();
+		assertEquals(1, alreadyApplied.get());
+	}
+
+	@Test
+	void replayProgressDoesNotSuppressASecondSameNamedChildOccurrence() throws Exception {
+		AtomicInteger deliveries = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Deliver") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				deliveries.incrementAndGet();
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(java.util.Map.class);
+		constructor.setAccessible(true);
+		Object state = constructor.newInstance((Object) null);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+		replay.setAccessible(true);
+		((CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0, state,
+				"root/Rewards/child:0")).toCompletableFuture().join();
+		((CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0, state,
+				"root/Rewards/child:1")).toCompletableFuture().join();
+		assertEquals(2, deliveries.get());
+	}
+
+	@Test
+	void replaySelectionKeepsTheFirstNondeterministicChoice() {
+		HashMap<String, String> placeholders = new HashMap<>();
+		AtomicInteger selections = new AtomicInteger();
+		assertEquals("first", Reward.replaySelection(placeholders,
+				() -> selections.incrementAndGet() == 1 ? "first" : "second"));
+		assertEquals("first", Reward.replaySelection(placeholders,
+				() -> selections.incrementAndGet() == 1 ? "first" : "second"));
+		assertEquals(1, selections.get());
+	}
+
+	@Test
 	void nestedAsyncInjectorCanAwaitTheSameSharedInjectorWithoutDeadlocking() {
 		AtomicInteger invocations = new AtomicInteger();
 		RewardInject nested = new RewardInject("Nested") {
@@ -389,5 +493,12 @@ class RewardAsyncInjectionTest {
 				return completion;
 			}
 		};
+	}
+
+	private Reward.RewardReplayFailure findCheckpoint(Throwable failure) {
+		for (Throwable current = failure; current != null; current = current.getCause()) {
+			if (current instanceof Reward.RewardReplayFailure) return (Reward.RewardReplayFailure) current;
+		}
+		throw new AssertionError("missing replay checkpoint", failure);
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -68,6 +69,7 @@ import com.bencodez.advancedcore.api.rewards.builtin.RewardRandomReward;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardJavascript;
 import com.bencodez.advancedcore.api.javascript.JavascriptEngine;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
+import com.bencodez.advancedcore.thread.FileThread;
 
 import net.milkbowl.vault.economy.Economy;
 
@@ -98,6 +100,13 @@ class RewardAsyncInjectionTest {
 		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
 		when(plugin.getBukkitScheduler()).thenReturn(scheduler);
 		AdvancedCorePlugin.setInstance(plugin);
+		try {
+			java.lang.reflect.Field pluginField = FileThread.class.getDeclaredField("plugin");
+			pluginField.setAccessible(true);
+			pluginField.set(FileThread.getInstance(), plugin);
+		} catch (ReflectiveOperationException failure) {
+			throw new AssertionError(failure);
+		}
 		handler = new RewardHandler(plugin);
 		when(plugin.getRewardHandler()).thenReturn(handler);
 
@@ -1158,6 +1167,34 @@ class RewardAsyncInjectionTest {
 		writes.getValue().run();
 		result.toCompletableFuture().join();
 		assertEquals(List.of("injection", "checkpoint", "ack:occurrence-1:AsyncReward/0"), events);
+	}
+
+	@Test
+	void timedOutQueuedCheckpointCannotPersistLater() throws Exception {
+		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
+		when(plugin.getTimer()).thenReturn(storageExecutor);
+		AtomicInteger writes = new AtomicInteger();
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		constructor.setAccessible(true);
+		Object replayState = constructor.newInstance(null, null, false);
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState,
+				(java.util.function.Consumer<Reward.ReplayCheckpoint>) checkpoint -> writes.incrementAndGet());
+		java.lang.reflect.Method persist = stateType.getDeclaredMethod("persistCheckpointAsync",
+				AdvancedCorePlugin.class, HashMap.class, long.class, TimeUnit.class);
+		persist.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> result = (CompletionStage<Void>) persist.invoke(replayState, plugin, new HashMap<>(), 0L,
+				TimeUnit.MILLISECONDS);
+
+		ArgumentCaptor<Runnable> queued = ArgumentCaptor.forClass(Runnable.class);
+		verify(storageExecutor).execute(queued.capture());
+		assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		queued.getValue().run();
+		assertEquals(0, writes.get());
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
@@ -32,6 +34,7 @@ import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardSubRewards;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 
 class RewardAsyncInjectionTest {
@@ -202,6 +205,22 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void failingLegacyInjectionDoesNotStopLaterAsyncChainSteps() {
+		AtomicBoolean laterRan = new AtomicBoolean();
+		handler.getInjectedRewards().add(new RewardInject("BrokenLegacy") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				throw new IllegalStateException("bad legacy configuration");
+			}
+		});
+		handler.getInjectedRewards().add(asyncInjection("Later", CompletableFuture.completedFuture(null), laterRan));
+
+		reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join();
+		assertTrue(laterRan.get());
+	}
+
+	@Test
 	void synchronizedAsyncInjectionSerializesThroughCompletion() {
 		List<CompletableFuture<Object>> completions = new ArrayList<>();
 		List<Integer> starts = new ArrayList<>();
@@ -303,6 +322,60 @@ class RewardAsyncInjectionTest {
 		assertFalse(result.toCompletableFuture().isDone());
 		completion.complete(null);
 		result.toCompletableFuture().join();
+	}
+
+	@Test
+	void nestedPostRewardWaitsForChildRewardBeforeAdvancing() {
+		handler = org.mockito.Mockito.spy(new RewardHandler(plugin));
+		when(plugin.getRewardHandler()).thenReturn(handler);
+		when(user.getPlugin()).thenReturn(plugin);
+		data.createSection("Rewards");
+		CompletableFuture<Void> child = new CompletableFuture<>();
+		doReturn(child).when(handler).giveRewardAsync(eq(user), any(ConfigurationSection.class), eq("Rewards"),
+				any());
+		List<String> events = new ArrayList<>();
+		RewardSubRewards.register(handler, plugin);
+		RewardInject after = new RewardInject("After") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				events.add("after-child");
+				return null;
+			}
+		};
+		after.postReward();
+		handler.getInjectedRewards().add(after);
+
+		CompletionStage<Void> result = reward.giveInjectedRewardsAsync(user, new HashMap<>());
+		assertFalse(result.toCompletableFuture().isDone());
+		assertTrue(events.isEmpty());
+
+		child.complete(null);
+		result.toCompletableFuture().join();
+		assertEquals(List.of("after-child"), events);
+	}
+
+	@Test
+	void nestedAsyncInjectorCanAwaitTheSameSharedInjectorWithoutDeadlocking() {
+		AtomicInteger invocations = new AtomicInteger();
+		RewardInject nested = new RewardInject("Nested") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public boolean supportsAsyncSynchronization() { return false; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward current, AdvancedCoreUser currentUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				if (invocations.incrementAndGet() == 1) {
+					return current.giveInjectedRewardsAsync(currentUser, new HashMap<>()).thenApply(ignored -> null);
+				}
+				return CompletableFuture.completedFuture(null);
+			}
+		};
+		nested.synchronize();
+		handler.getInjectedRewards().add(nested);
+
+		reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join();
+		assertEquals(2, invocations.get());
 	}
 
 	private RewardInject asyncInjection(String path, CompletionStage<Object> completion, AtomicBoolean invoked) {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -67,6 +68,7 @@ import com.bencodez.advancedcore.api.rewards.injected.RewardInjectString;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardSubRewards;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardRandomReward;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardJavascript;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardSpecialChance;
 import com.bencodez.advancedcore.api.javascript.JavascriptEngine;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 import com.bencodez.advancedcore.thread.FileThread;
@@ -619,6 +621,63 @@ class RewardAsyncInjectionTest {
 		verify(economy).depositPlayer(offlinePlayer, 1D);
 		verify(economy).depositPlayer(offlinePlayer, 2D);
 		verify(economy).depositPlayer(offlinePlayer, 3D);
+	}
+
+	@Test
+	void legacyActionReplayRejectsRemovalOfAnUnfinishedAction() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("RemovedUnfinishedAction");
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		ArrayList<Runnable> queued = new ArrayList<>();
+		doAnswer(invocation -> {
+			queued.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		AtomicReference<List<Double>> amounts = new AtomicReference<>(new ArrayList<>(List.of(1D, 2D)));
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				for (double amount : amounts.get()) realUser.giveMoney(amount);
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			CompletionStage<Void> first = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			queued.remove(0).run();
+			enabled.set(false);
+			queued.remove(0).run();
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(assertThrows(
+					java.util.concurrent.CompletionException.class, () -> first.toCompletableFuture().join()));
+
+			enabled.set(true);
+			amounts.set(new ArrayList<>(List.of(1D)));
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+			assertTrue(queued.isEmpty(), "no action may run after an unfinished persisted action disappears");
+		}
 	}
 
 	@Test
@@ -1587,6 +1646,92 @@ class RewardAsyncInjectionTest {
 		assertNotNull(nestedOptions.getAsyncReplayState());
 		assertTrue(nestedOptions.getAsyncReplayKey().endsWith("/path:TrueRewards"));
 		assertFalse(nestedOptions.getPlaceholders().isEmpty());
+	}
+
+	@Test
+	void disabledJavascriptResumesItsPersistedSelectedChild() throws Exception {
+		ConfigurationSection javascript = data.createSection("Javascript");
+		javascript.set("Enabled", true);
+		javascript.set("Expression", "true");
+		javascript.createSection("TrueRewards");
+		RewardJavascript.register(handler, plugin);
+		AtomicInteger sends = new AtomicInteger();
+
+		try (MockedConstruction<JavascriptEngine> engines = mockConstruction(JavascriptEngine.class,
+				org.mockito.Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF),
+				(engine, context) -> when(engine.getBooleanValue("true")).thenReturn(true));
+				MockedConstruction<RewardBuilder> builders = mockConstruction(RewardBuilder.class,
+						org.mockito.Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF),
+						(builder, context) -> {
+							RewardOptions nested = new RewardOptions();
+							when(builder.getRewardOptions()).thenReturn(nested);
+							when(builder.withPlaceHolder(any())).thenAnswer(invocation -> {
+								nested.withPlaceHolder(invocation.getArgument(0));
+								return builder;
+							});
+							when(builder.sendAsync(user)).thenAnswer(ignored -> sends.getAndIncrement() == 0
+									? CompletableFuture.failedFuture(new IllegalStateException("temporary child failure"))
+									: CompletableFuture.completedFuture(null));
+						})) {
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(assertThrows(CompletionException.class,
+					() -> reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join()));
+			javascript.set("Enabled", false);
+
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			resumed.toCompletableFuture().join();
+
+			assertEquals(2, sends.get());
+			assertEquals(1, engines.constructed().size(), "a persisted selection must not rerun JavaScript");
+		}
+	}
+
+	@Test
+	void specialChanceChildCarriesSelectionAndReplayStateIntoItsCheckpoint() {
+		ConfigurationSection specialChance = data.createSection("SpecialChance");
+		specialChance.createSection("1");
+		RewardSpecialChance.register(handler, plugin);
+		RewardOptions nestedOptions = new RewardOptions();
+
+		try (MockedConstruction<RewardBuilder> builders = mockConstruction(RewardBuilder.class,
+				org.mockito.Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF),
+				(builder, context) -> {
+					when(builder.getRewardOptions()).thenReturn(nestedOptions);
+					when(builder.withPlaceHolder(any())).thenAnswer(invocation -> {
+						nestedOptions.withPlaceHolder(invocation.getArgument(0));
+						return builder;
+					});
+					when(builder.sendAsync(user)).thenReturn(CompletableFuture.completedFuture(null));
+				})) {
+			reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join();
+		}
+
+		assertNotNull(nestedOptions.getAsyncReplayState());
+		assertTrue(nestedOptions.getAsyncReplayKey().endsWith("/path:1"));
+		assertFalse(nestedOptions.getPlaceholders().isEmpty());
+	}
+
+	@Test
+	void persistedReplayFailsWhenItsPlayerDisappearsBeforePreparation() {
+		when(user.getPlayerName()).thenReturn("Departed");
+		RewardOptions options = new RewardOptions();
+		options.setAsyncReplayCheckpointConsumer(ignored -> { });
+
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer("Departed")).thenReturn(null);
+			CompletionStage<Void> result = reward.giveRewardUserAsync(user, new HashMap<>(), options);
+			CompletionException failure = assertThrows(CompletionException.class,
+					() -> result.toCompletableFuture().join());
+			assertTrue(failure.getCause().getMessage().contains("Player became unavailable"));
+		}
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -52,10 +52,12 @@ import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
 import com.bencodez.advancedcore.VaultHandler;
 import com.bencodez.advancedcore.api.item.FullInventoryHandler;
+import com.bencodez.advancedcore.api.item.ItemBuilder;
 import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.rewards.RewardBuilder;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.RewardOptions;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardItems;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectString;
@@ -194,6 +196,84 @@ class RewardAsyncInjectionTest {
 
 		verify(inventory).giveItem(player, item);
 		verify(inventory, never()).giveItemAsync(any(Player.class), any(ItemStack.class));
+	}
+
+	@Test
+	void replayItemsRemainPendingWhenThePlayerDisconnectsBeforeTheirInjectionRuns() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		FullInventoryHandler inventory = mock(FullInventoryHandler.class);
+		when(plugin.getFullInventoryHandler()).thenReturn(inventory);
+		UUID uuid = UUID.randomUUID();
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, uuid, false, false);
+		realUser.setPlayerName("Dispatch");
+		Player player = mock(Player.class);
+		when(player.getDisplayName()).thenReturn("Dispatch");
+		AtomicReference<Player> availablePlayer = new AtomicReference<>(player);
+		AtomicReference<Runnable> queuedInjection = new AtomicReference<>();
+		doAnswer(invocation -> {
+			queuedInjection.set(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+		data.createSection("Items").createSection("Stone").set("Material", "STONE");
+		RewardItems.registerItems(handler, plugin);
+
+		try (MockedConstruction<ItemBuilder> builders = mockConstruction(ItemBuilder.class, (builder, context) -> {
+			when(builder.setPlaceholders(any(HashMap.class))).thenReturn(builder);
+			when(builder.toItemStack(any(Player.class))).thenReturn(new ItemStack(Material.STONE));
+		}); org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenAnswer(ignored -> availablePlayer.get());
+			CompletionStage<Void> delivery = reward.giveRewardUserAsync(realUser, new HashMap<>(), new RewardOptions());
+			assertFalse(delivery.toCompletableFuture().isDone(), "the initial online check only queues injection dispatch");
+			assertNotNull(queuedInjection.get());
+
+			availablePlayer.set(null);
+			Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+					() -> {
+						queuedInjection.get().run();
+						delivery.toCompletableFuture().join();
+					});
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+			assertEquals(0, checkpoint.getCompletedInjectionCount());
+			assertEquals(0, checkpoint.getReplayProgress().getOrDefault("AsyncReward", 0));
+			assertTrue(checkpoint.getReplayPlaceholders().entrySet().stream().noneMatch(entry ->
+					entry.getKey().startsWith("__advancedcore_replay_legacy_actions_")
+							&& !entry.getKey().endsWith("_snapshot")),
+					"an undelivered item must not receive an action-completion checkpoint");
+			verify(inventory, never()).giveItemAsync(any(Player.class), any(ItemStack.class));
+
+			availablePlayer.set(player);
+			when(inventory.giveItemAsync(eq(player), any(ItemStack.class)))
+					.thenReturn(CompletableFuture.completedFuture(null));
+			doAnswer(invocation -> {
+				invocation.getArgument(1, Runnable.class).run();
+				return null;
+			}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+			doAnswer(invocation -> {
+				invocation.getArgument(1, Runnable.class).run();
+				return null;
+			}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class), eq(player));
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			resumed.toCompletableFuture().join();
+
+			availablePlayer.set(null);
+			AdvancedCoreUser.AsyncActionCollection placeholderContext = realUser.beginAsyncActionCollection();
+			realUser.giveItem(new ItemStack(Material.STONE), new HashMap<>());
+			assertThrows(java.util.concurrent.CompletionException.class,
+					() -> realUser.endAsyncActionCollection(placeholderContext).toCompletableFuture().join(),
+					"placeholder-expanded items use the same replay-only unavailable-player failure");
+		}
+		verify(inventory).giveItemAsync(eq(player), any(ItemStack.class));
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -513,6 +513,27 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void timedReplayDeferralRemainsInTheTimedQueue() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isProcessRewards()).thenReturn(true);
+		when(config.isPauseRewards()).thenReturn(true);
+		when(config.getFormatRewardTimeFormat()).thenReturn("yyyy-MM-dd");
+		when(plugin.getOptions()).thenReturn(config);
+		when(user.getPlayerName()).thenReturn("Offline");
+		RewardOptions options = new RewardOptions().setCheckTimed(false).setIgnoreRequirements(true);
+		options.setTimedQueueReplay(true);
+		org.bukkit.plugin.PluginManager pluginManager = mock(org.bukkit.plugin.PluginManager.class);
+
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+			assertThrows(java.util.concurrent.CompletionException.class,
+					() -> reward.giveRewardAsync(user, options).toCompletableFuture().join());
+		}
+
+		verify(user, never()).addOfflineRewards(any(), any(), any());
+	}
+
+	@Test
 	void legacySchedulerRejectionFailsAsyncRewardClosed() {
 		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
 		when(config.isOnlineMode()).thenReturn(true);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1095,6 +1095,30 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void publicRewardUserApiRetainsNullOptionsCompatibilityWithAsyncInjectors() {
+		AtomicReference<RewardOptions> receivedOptions = new AtomicReference<>();
+		handler.getInjectedRewards().add(new RewardInject("Async") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public boolean requiresConfiguredDataForAsync() { return false; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+		Reward spyReward = org.mockito.Mockito.spy(reward);
+		doAnswer(invocation -> {
+			receivedOptions.set(invocation.getArgument(2));
+			return CompletableFuture.completedFuture(null);
+		}).when(spyReward).giveRewardUserAsync(eq(user), any(HashMap.class), any(RewardOptions.class));
+
+		spyReward.giveRewardUser(user, new HashMap<>(), null);
+
+		assertNotNull(receivedOptions.get());
+	}
+
+	@Test
 	void sharedNestedReplayStatePreventsSynchronousFallbackWhenOptionMapsAreEmpty() throws Exception {
 		AtomicInteger invoked = new AtomicInteger();
 		handler.getInjectedRewards().add(new RewardInject("Synchronous") {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -224,6 +224,7 @@ class RewardAsyncInjectionTest {
 		Player player = mock(Player.class);
 		when(player.getDisplayName()).thenReturn("Dispatch");
 		AtomicReference<Player> availablePlayer = new AtomicReference<>(player);
+		AtomicReference<Material> itemType = new AtomicReference<>(Material.STONE);
 		AtomicReference<Runnable> queuedInjection = new AtomicReference<>();
 		doAnswer(invocation -> {
 			queuedInjection.set(invocation.getArgument(1, Runnable.class));
@@ -234,7 +235,7 @@ class RewardAsyncInjectionTest {
 
 		try (MockedConstruction<ItemBuilder> builders = mockConstruction(ItemBuilder.class, (builder, context) -> {
 			when(builder.setPlaceholders(any(HashMap.class))).thenReturn(builder);
-			when(builder.toItemStack(any(Player.class))).thenReturn(new ItemStack(Material.STONE));
+			when(builder.toItemStack(any(Player.class))).thenAnswer(ignored -> new ItemStack(itemType.get()));
 		}); org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
 			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenAnswer(ignored -> availablePlayer.get());
 			CompletionStage<Void> delivery = reward.giveRewardUserAsync(realUser, new HashMap<>(), new RewardOptions());
@@ -257,6 +258,7 @@ class RewardAsyncInjectionTest {
 			verify(inventory, never()).giveItemAsync(any(Player.class), any(ItemStack.class));
 
 			availablePlayer.set(player);
+			itemType.set(Material.DIRT);
 			when(inventory.giveItemAsync(eq(player), any(ItemStack.class)))
 					.thenReturn(CompletableFuture.completedFuture(null));
 			doAnswer(invocation -> {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -3,6 +3,7 @@ package com.bencodez.advancedcore.tests.rewards;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -437,7 +438,8 @@ class RewardAsyncInjectionTest {
 		when(user.getPlugin()).thenReturn(plugin);
 		data.set("RandomReward", new ArrayList<>(List.of("child")));
 		CompletableFuture<Void> child = new CompletableFuture<>();
-		doReturn(child).when(handler).giveRewardAsync(eq(user), eq("child"), any());
+		ArgumentCaptor<RewardOptions> childOptions = ArgumentCaptor.forClass(RewardOptions.class);
+		doReturn(child).when(handler).giveRewardAsync(eq(user), eq("child"), childOptions.capture());
 		List<String> events = new ArrayList<>();
 		RewardRandomReward.register(handler, plugin);
 		handler.getInjectedRewards().add(new RewardInject("After") {
@@ -451,6 +453,8 @@ class RewardAsyncInjectionTest {
 		CompletionStage<Void> result = reward.giveInjectedRewardsAsync(user, new HashMap<>());
 		assertFalse(result.toCompletableFuture().isDone());
 		assertTrue(events.isEmpty());
+		assertNotNull(childOptions.getValue().getAsyncReplayState());
+		assertTrue(childOptions.getValue().getAsyncReplayKey().endsWith("/selected:child"));
 		child.complete(null);
 		result.toCompletableFuture().join();
 		assertEquals(List.of("after-child"), events);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,9 +36,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Answers;
+import org.mockito.MockedConstruction;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.rewards.Reward;
+import com.bencodez.advancedcore.api.rewards.RewardBuilder;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.RewardOptions;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
@@ -45,6 +49,8 @@ import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectString;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardSubRewards;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardRandomReward;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardJavascript;
+import com.bencodez.advancedcore.api.javascript.JavascriptEngine;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
 
 class RewardAsyncInjectionTest {
@@ -458,6 +464,36 @@ class RewardAsyncInjectionTest {
 		child.complete(null);
 		result.toCompletableFuture().join();
 		assertEquals(List.of("after-child"), events);
+	}
+
+	@Test
+	void javascriptChildCarriesSelectionAndReplayStateIntoItsCheckpoint() {
+		ConfigurationSection javascript = data.createSection("Javascript");
+		javascript.set("Enabled", true);
+		javascript.set("Expression", "true");
+		javascript.createSection("TrueRewards");
+		RewardJavascript.register(handler, plugin);
+		RewardOptions nestedOptions = new RewardOptions();
+
+		try (MockedConstruction<JavascriptEngine> engines = mockConstruction(JavascriptEngine.class,
+				org.mockito.Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF),
+				(engine, context) -> when(engine.getBooleanValue("true")).thenReturn(true));
+				MockedConstruction<RewardBuilder> builders = mockConstruction(RewardBuilder.class,
+						org.mockito.Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF),
+						(builder, context) -> {
+							when(builder.getRewardOptions()).thenReturn(nestedOptions);
+							when(builder.withPlaceHolder(any())).thenAnswer(invocation -> {
+								nestedOptions.withPlaceHolder(invocation.getArgument(0));
+								return builder;
+							});
+							when(builder.sendAsync(user)).thenReturn(CompletableFuture.completedFuture(null));
+						})) {
+			reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join();
+		}
+
+		assertNotNull(nestedOptions.getAsyncReplayState());
+		assertTrue(nestedOptions.getAsyncReplayKey().endsWith("/path:TrueRewards"));
+		assertFalse(nestedOptions.getPlaceholders().isEmpty());
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -58,6 +58,7 @@ import com.bencodez.advancedcore.api.rewards.RewardBuilder;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.RewardOptions;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardItems;
+import com.bencodez.advancedcore.api.rewards.builtin.RewardPotions;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectString;
@@ -274,6 +275,106 @@ class RewardAsyncInjectionTest {
 					"placeholder-expanded items use the same replay-only unavailable-player failure");
 		}
 		verify(inventory).giveItemAsync(eq(player), any(ItemStack.class));
+	}
+
+	@Test
+	void replayPotionsRemainPendingWhenThePlayerDisconnectsBeforeTheirInjectionRuns() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		UUID uuid = UUID.randomUUID();
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, uuid, false, false);
+		realUser.setPlayerName("PotionDispatch");
+		Player player = mock(Player.class);
+		when(player.getDisplayName()).thenReturn("PotionDispatch");
+		when(player.getUniqueId()).thenReturn(uuid);
+		when(player.isOnline()).thenReturn(true);
+		AtomicReference<Player> availablePlayer = new AtomicReference<>(player);
+		AtomicReference<Runnable> queuedInjection = new AtomicReference<>();
+		doAnswer(invocation -> {
+			queuedInjection.set(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+		data.createSection("Potions").createSection("SPEED").set("Duration", 1);
+		RewardPotions.register(handler, plugin);
+
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenAnswer(ignored -> availablePlayer.get());
+			CompletionStage<Void> delivery = reward.giveRewardUserAsync(realUser, new HashMap<>(), new RewardOptions());
+			assertFalse(delivery.toCompletableFuture().isDone());
+			availablePlayer.set(null);
+			Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+					() -> {
+						queuedInjection.get().run();
+						delivery.toCompletableFuture().join();
+					});
+			Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+			assertEquals(0, checkpoint.getCompletedInjectionCount());
+			assertEquals(0, checkpoint.getReplayProgress().getOrDefault("AsyncReward", 0));
+			verify(player, never()).addPotionEffect(any());
+
+			availablePlayer.set(player);
+			doAnswer(invocation -> {
+				invocation.getArgument(1, Runnable.class).run();
+				return null;
+			}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+			doAnswer(invocation -> {
+				invocation.getArgument(1, Runnable.class).run();
+				return null;
+			}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class), eq(player));
+			AtomicReference<Runnable> queuedPotionDelivery = new AtomicReference<>();
+			doAnswer(invocation -> {
+				queuedPotionDelivery.set(invocation.getArgument(1, Runnable.class));
+				return null;
+			}).when(scheduler).runTask(eq(plugin), any(Runnable.class), eq(player));
+			Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+			java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+			state.setAccessible(true);
+			java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+					AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+			replay.setAccessible(true);
+			CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, realUser,
+					checkpoint.getReplayPlaceholders(), 0,
+					state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+					"AsyncReward");
+			assertFalse(resumed.toCompletableFuture().isDone(), "recovery must requeue the unfinished potion action");
+			assertNotNull(queuedPotionDelivery.get());
+			availablePlayer.set(null);
+			queuedPotionDelivery.get().run();
+			assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+		}
+		verify(player, never()).addPotionEffect(any());
+	}
+
+	@Test
+	void offlineRequeueRetainsReplayStateAndLegacyActionMarkers() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isProcessRewards()).thenReturn(true);
+		when(config.isPauseRewards()).thenReturn(false);
+		when(config.isTreatVanishAsOffline()).thenReturn(false);
+		when(config.getFormatRewardTimeFormat()).thenReturn("yyyy-MM-dd");
+		when(plugin.getOptions()).thenReturn(config);
+		when(user.isOnline()).thenReturn(false);
+		when(user.getPlayerName()).thenReturn("Offline");
+		RewardOptions options = new RewardOptions().setCheckTimed(false).setIgnoreRequirements(true).setGiveOffline(true);
+		options.setOnline(false);
+		options.setAsyncReplayProgress(Map.of("AsyncReward", 1));
+		options.setAsyncReplayRegistryFingerprints(Map.of("AsyncReward", "registry-fingerprint"));
+		options.getPlaceholders().put("__advancedcore_replay_legacy_actions_marker", "v2:completed");
+		org.bukkit.plugin.PluginManager pluginManager = mock(org.bukkit.plugin.PluginManager.class);
+
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+			reward.giveReward(user, options);
+		}
+
+		ArgumentCaptor<RewardOptions> queuedOptions = ArgumentCaptor.forClass(RewardOptions.class);
+		verify(user).addOfflineRewards(eq(reward), eq(options.getPlaceholders()), queuedOptions.capture());
+		assertEquals(options, queuedOptions.getValue());
+		assertEquals(1, queuedOptions.getValue().getAsyncReplayProgress().get("AsyncReward"));
+		assertEquals("registry-fingerprint", queuedOptions.getValue().getAsyncReplayRegistryFingerprints().get("AsyncReward"));
+		assertEquals("v2:completed", queuedOptions.getValue().getPlaceholders()
+				.get("__advancedcore_replay_legacy_actions_marker"));
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -1117,6 +1117,99 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void injectionIsNotifiedOnlyAfterItsReplayCheckpointIsPersisted() throws Exception {
+		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
+		when(plugin.getTimer()).thenReturn(storageExecutor);
+		List<String> events = new ArrayList<>();
+		handler.getInjectedRewards().add(new RewardInject("Points") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				events.add("injection");
+				return null;
+			}
+			@Override public CompletionStage<Void> onReplayCheckpointPersisted(Reward ignored, AdvancedCoreUser ignoredUser,
+					String occurrenceId, String injectionKey) {
+				events.add("ack:" + occurrenceId + ":" + injectionKey);
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		constructor.setAccessible(true);
+		Object replayState = constructor.newInstance(null, null, false);
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState, (java.util.function.Consumer<Reward.ReplayCheckpoint>) checkpoint ->
+				events.add("checkpoint"));
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> result = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				replayState, "AsyncReward", "occurrence-1");
+
+		ArgumentCaptor<Runnable> writes = ArgumentCaptor.forClass(Runnable.class);
+		verify(storageExecutor).execute(writes.capture());
+		assertEquals(List.of("injection"), events);
+		assertFalse(result.toCompletableFuture().isDone());
+
+		writes.getValue().run();
+		result.toCompletableFuture().join();
+		assertEquals(List.of("injection", "checkpoint", "ack:occurrence-1:AsyncReward/0"), events);
+	}
+
+	@Test
+	void replayRetriesFailedCheckpointNotificationWithoutRepeatingInjection() throws Exception {
+		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
+		doAnswer(invocation -> {
+			invocation.getArgument(0, Runnable.class).run();
+			return null;
+		}).when(storageExecutor).execute(any(Runnable.class));
+		when(plugin.getTimer()).thenReturn(storageExecutor);
+		AtomicInteger injections = new AtomicInteger();
+		AtomicInteger notifications = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Points") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				injections.incrementAndGet();
+				return null;
+			}
+			@Override public CompletionStage<Void> onReplayCheckpointPersisted(Reward ignored,
+					AdvancedCoreUser ignoredUser, String occurrenceId, String injectionKey) {
+				return notifications.incrementAndGet() == 1
+						? CompletableFuture.failedFuture(new IllegalStateException("ack unavailable"))
+						: CompletableFuture.completedFuture(null);
+			}
+		});
+
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		constructor.setAccessible(true);
+		Object replayState = constructor.newInstance(null, null, false);
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState, (java.util.function.Consumer<Reward.ReplayCheckpoint>) checkpoint -> { });
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> first = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				replayState, "AsyncReward", "occurrence-1");
+		assertThrows(java.util.concurrent.CompletionException.class, () -> first.toCompletableFuture().join());
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> retry = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				replayState, "AsyncReward", "occurrence-1");
+		retry.toCompletableFuture().join();
+
+		assertEquals(1, injections.get());
+		assertEquals(2, notifications.get());
+	}
+
+	@Test
 	void typedIntegerAsyncHookUsesParsedValue() {
 		data.set("Amount", 7);
 		HashMap<String, String> placeholders = new HashMap<>();

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.tests.rewards;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +16,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
 import com.bencodez.advancedcore.AdvancedCorePlugin;
 import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
+import com.bencodez.advancedcore.api.rewards.RewardOptions;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInject;
 import com.bencodez.advancedcore.api.rewards.injected.RewardInjectInt;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardSubRewards;
@@ -422,6 +425,193 @@ class RewardAsyncInjectionTest {
 	}
 
 	@Test
+	void persistedReplayRejectsAChangedInjectorRegistryBeforeAnyStageRuns() throws Exception {
+		AtomicInteger applied = new AtomicInteger();
+		AtomicInteger inserted = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Applied") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				applied.incrementAndGet();
+				return null;
+			}
+		});
+		handler.getInjectedRewards().add(new RewardInject("Fails") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				return CompletableFuture.failedFuture(new IllegalStateException("temporary"));
+			}
+		});
+
+		Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+				() -> reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join());
+		Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+		assertFalse(checkpoint.getReplayRegistryFingerprints().isEmpty());
+
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> matchingRegistry = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+				"AsyncReward");
+		assertThrows(java.util.concurrent.CompletionException.class, () -> matchingRegistry.toCompletableFuture().join());
+		assertEquals(1, applied.get());
+
+		handler.getInjectedRewards().add(0, new RewardInject("Inserted") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				inserted.incrementAndGet();
+				return null;
+			}
+		});
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+				"AsyncReward");
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+		assertEquals(1, applied.get());
+		assertEquals(0, inserted.get());
+	}
+
+	@Test
+	void legacyCountOnlyReplayCheckpointDoesNotResumeAgainstAnUnknownRegistry() throws Exception {
+		AtomicInteger invoked = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Applied") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				invoked.incrementAndGet();
+				return null;
+			}
+		});
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 1,
+				state.newInstance(Map.of(), Map.of(), true), "AsyncReward");
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+		assertEquals(0, invoked.get());
+	}
+
+	@Test
+	void persistedReplayDoesNotFallBackToSynchronousDispatchWhenAsyncInjectorsAreGone() {
+		AtomicInteger invoked = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Synchronous") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				invoked.incrementAndGet();
+				return null;
+			}
+		});
+		RewardOptions options = new RewardOptions();
+		options.setAsyncReplayProgress(Map.of("AsyncReward", 1));
+		options.setAsyncReplayRegistryFingerprints(Map.of("AsyncReward", "removed-async-injector"));
+
+		reward.giveRewardUser(user, new HashMap<>(), options);
+
+		assertEquals(0, invoked.get());
+	}
+
+	@Test
+	void sharedNestedReplayStatePreventsSynchronousFallbackWhenOptionMapsAreEmpty() throws Exception {
+		AtomicInteger invoked = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Synchronous") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				invoked.incrementAndGet();
+				return null;
+			}
+		});
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		RewardOptions options = new RewardOptions();
+		options.setAsyncReplayKey("AsyncReward/0/child");
+		options.setAsyncReplayState((Reward.ReplayState) state.newInstance(Map.of("AsyncReward/0/child", 1),
+				Map.of("AsyncReward/0/child", "removed-async-injector"), false));
+		assertTrue(options.getAsyncReplayProgress().isEmpty());
+		assertTrue(options.getAsyncReplayRegistryFingerprints().isEmpty());
+
+		reward.giveRewardUser(user, new HashMap<>(), options);
+
+		assertEquals(0, invoked.get());
+	}
+
+	@Test
+	void childCheckpointBindsItsUncompletedParentRegistryBeforeNestedDispatch() throws Exception {
+		AtomicBoolean dispatchingChild = new AtomicBoolean();
+		AtomicInteger parentInvocations = new AtomicInteger();
+		AtomicInteger insertedInvocations = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Nested") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward current, AdvancedCoreUser currentUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				if (dispatchingChild.get()) return CompletableFuture.completedFuture(null);
+				parentInvocations.incrementAndGet();
+				dispatchingChild.set(true);
+				try {
+					Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+					java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+							AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+					replay.setAccessible(true);
+					CompletionStage<Void> child = (CompletionStage<Void>) replay.invoke(current, currentUser, new HashMap<>(), 0,
+							Reward.currentReplayState(), Reward.currentReplayKey() + "/child");
+					return child.whenComplete((ignored, failure) -> dispatchingChild.set(false)).thenApply(ignored -> null);
+				} catch (ReflectiveOperationException failure) {
+					return CompletableFuture.failedFuture(failure);
+				}
+			}
+		});
+		handler.getInjectedRewards().add(new RewardInject("ChildFailure") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				return dispatchingChild.get() ? CompletableFuture.failedFuture(new IllegalStateException("temporary"))
+						: CompletableFuture.completedFuture(null);
+			}
+		});
+
+		Throwable failure = assertThrows(java.util.concurrent.CompletionException.class,
+				() -> reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join());
+		Reward.RewardReplayFailure checkpoint = findCheckpoint(failure);
+		assertTrue(checkpoint.getReplayRegistryFingerprints().containsKey("AsyncReward"));
+		assertTrue(checkpoint.getReplayRegistryFingerprints().containsKey("AsyncReward/0/child"));
+
+		handler.getInjectedRewards().add(0, new RewardInject("Inserted") {
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				insertedInvocations.incrementAndGet();
+				return null;
+			}
+		});
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		state.setAccessible(true);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class);
+		replay.setAccessible(true);
+		CompletionStage<Void> resumed = (CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0,
+				state.newInstance(checkpoint.getReplayProgress(), checkpoint.getReplayRegistryFingerprints(), false),
+				"AsyncReward");
+
+		assertThrows(java.util.concurrent.CompletionException.class, () -> resumed.toCompletableFuture().join());
+		assertEquals(1, parentInvocations.get());
+		assertEquals(0, insertedInvocations.get());
+	}
+
+	@Test
 	void replayProgressDoesNotSuppressASecondSameNamedChildOccurrence() throws Exception {
 		AtomicInteger deliveries = new AtomicInteger();
 		handler.getInjectedRewards().add(new RewardInject("Deliver") {
@@ -457,6 +647,54 @@ class RewardAsyncInjectionTest {
 		assertEquals("first", Reward.replaySelection(placeholders,
 				() -> selections.incrementAndGet() == 1 ? "first" : "second"));
 		assertEquals(1, selections.get());
+	}
+
+	@Test
+	void independentAsyncRewardOccurrencesReceiveDifferentDurableIds() {
+		List<String> occurrences = new ArrayList<>();
+		handler.getInjectedRewards().add(new RewardInject("Capture") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				occurrences.add(Reward.currentReplayOccurrenceId());
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+
+		reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join();
+		reward.giveInjectedRewardsAsync(user, new HashMap<>()).toCompletableFuture().join();
+
+		assertEquals(2, occurrences.size());
+		assertNotEquals(occurrences.get(0), occurrences.get(1));
+	}
+
+	@Test
+	void retryOfTheSameOccurrenceRetainsItsId() throws Exception {
+		List<String> occurrences = new ArrayList<>();
+		handler.getInjectedRewards().add(new RewardInject("Capture") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				occurrences.add(Reward.currentReplayOccurrenceId());
+				return CompletableFuture.completedFuture(null);
+			}
+		});
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> state = stateType.getDeclaredConstructor(Map.class);
+		state.setAccessible(true);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("giveInjectedRewardsAsync",
+				AdvancedCoreUser.class, HashMap.class, int.class, stateType, String.class, String.class);
+		replay.setAccessible(true);
+		for (int attempt = 0; attempt < 2; attempt++) {
+			((CompletionStage<Void>) replay.invoke(reward, user, new HashMap<>(), 0, state.newInstance((Object) null),
+					"AsyncReward", "occurrence-1")).toCompletableFuture().join();
+		}
+
+		assertEquals(List.of("occurrence-1", "occurrence-1"), occurrences);
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardAsyncInjectionTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,8 +31,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +47,9 @@ import org.mockito.Answers;
 import org.mockito.MockedConstruction;
 
 import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
+import com.bencodez.advancedcore.VaultHandler;
+import com.bencodez.advancedcore.api.item.FullInventoryHandler;
 import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.rewards.RewardBuilder;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
@@ -52,6 +62,8 @@ import com.bencodez.advancedcore.api.rewards.builtin.RewardRandomReward;
 import com.bencodez.advancedcore.api.rewards.builtin.RewardJavascript;
 import com.bencodez.advancedcore.api.javascript.JavascriptEngine;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
+
+import net.milkbowl.vault.economy.Economy;
 
 class RewardAsyncInjectionTest {
 
@@ -100,6 +112,414 @@ class RewardAsyncInjectionTest {
 	void tearDown() {
 		handler.getDelayedTimer().shutdownNow();
 		AdvancedCorePlugin.setInstance(null);
+	}
+
+	@Test
+	void legacyScheduledRewardsWaitForQueuedBukkitActions() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		FullInventoryHandler inventory = mock(FullInventoryHandler.class);
+		when(plugin.getFullInventoryHandler()).thenReturn(inventory);
+		UUID uuid = UUID.randomUUID();
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, uuid, false, false);
+		realUser.setPlayerName("Legacy");
+		Player player = mock(Player.class);
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		ArrayList<Runnable> queued = new ArrayList<>();
+		doAnswer(invocation -> {
+			queued.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		doAnswer(invocation -> {
+			queued.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class), eq(player));
+		doAnswer(invocation -> {
+			invocation.getArgument(1, Runnable.class).run();
+			return null;
+		})
+				.when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class), eq(player));
+
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				realUser.giveMoney(2);
+				realUser.giveItem(new ItemStack(Material.STONE));
+				return null;
+			}
+		});
+
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(player);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			CompletionStage<Void> result = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			assertFalse(result.toCompletableFuture().isDone());
+			assertEquals(2, queued.size());
+			for (Runnable action : queued) action.run();
+			result.toCompletableFuture().join();
+		}
+		verify(economy).depositPlayer(offlinePlayer, 2);
+		verify(inventory).giveItem(eq(player), any(ItemStack.class));
+	}
+
+	@Test
+	void legacySchedulerRejectionFailsAsyncRewardClosed() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		when(vault.getEcon()).thenReturn(mock(Economy.class));
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Legacy");
+		doThrow(new IllegalStateException("scheduler stopped")).when(scheduler)
+				.runTask(eq(plugin), any(Runnable.class));
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				realUser.giveMoney(2);
+				return null;
+			}
+		});
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			assertThrows(java.util.concurrent.CompletionException.class,
+					() -> reward.giveInjectedRewardsAsync(realUser, new HashMap<>()).toCompletableFuture().join());
+		}
+	}
+
+	@Test
+	void legacyQueuedActionFailsWhenPluginShutsDownBeforeExecution() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		when(vault.getEcon()).thenReturn(mock(Economy.class));
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Legacy");
+		AtomicReference<Runnable> queued = new AtomicReference<>();
+		doAnswer(invocation -> {
+			queued.set(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override
+			public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				realUser.giveMoney(2);
+				return null;
+			}
+		});
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			CompletionStage<Void> result = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			assertFalse(result.toCompletableFuture().isDone());
+			enabled.set(false);
+			queued.get().run();
+			assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		}
+	}
+
+	@Test
+	void legacyActionsCreatedByAnAsyncContinuationAreAwaited() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Legacy");
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		ArrayList<Runnable> queued = new ArrayList<>();
+		doAnswer(invocation -> {
+			queued.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		CompletableFuture<Void> continuation = new CompletableFuture<>();
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				return continuation.thenApply(nothing -> {
+					realUser.giveMoney(2);
+					return null;
+				});
+			}
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			CompletionStage<Void> result = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			continuation.complete(null);
+			assertEquals(1, queued.size());
+			assertFalse(result.toCompletableFuture().isDone());
+			queued.get(0).run();
+			result.toCompletableFuture().join();
+		}
+		verify(economy).depositPlayer(offlinePlayer, 2);
+	}
+
+	@Test
+	void serializedPersistedReplaysWaitForThePriorContinuationAndLegacyAction() throws Exception {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Serialized");
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		ArrayList<Runnable> queuedActions = new ArrayList<>();
+		doAnswer(invocation -> {
+			queuedActions.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		ArrayList<CompletableFuture<Void>> continuations = new ArrayList<>();
+		continuations.add(new CompletableFuture<>());
+		continuations.add(new CompletableFuture<>());
+		AtomicInteger invocations = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				int index = invocations.getAndIncrement();
+				return continuations.get(index).thenApply(nothing -> {
+					realUser.giveMoney(index + 1);
+					return null;
+				});
+			}
+		});
+
+		java.lang.reflect.Method enqueue = AdvancedCoreUser.class.getDeclaredMethod("enqueuePersistedReplay",
+				java.util.function.Supplier.class);
+		enqueue.setAccessible(true);
+		java.util.function.Supplier<CompletionStage<Void>> replay =
+				() -> reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			enqueue.invoke(realUser, replay);
+			enqueue.invoke(realUser, replay);
+			assertEquals(1, invocations.get(), "the second replay must remain behind the first continuation");
+
+			continuations.get(0).complete(null);
+			assertEquals(1, queuedActions.size());
+			assertEquals(1, invocations.get(), "the first legacy action is part of the replay tail");
+			queuedActions.get(0).run();
+
+			assertEquals(2, invocations.get(), "the second replay starts only after the first action completed");
+			continuations.get(1).complete(null);
+			assertEquals(2, queuedActions.size());
+			queuedActions.get(1).run();
+		}
+		verify(economy).depositPlayer(offlinePlayer, 1);
+		verify(economy).depositPlayer(offlinePlayer, 2);
+	}
+
+	@Test
+	void legacyContinuationActionIsClaimedOnlyByItsCompletingScope() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		when(vault.getEcon()).thenReturn(mock(Economy.class));
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Nested");
+		ArrayList<Runnable> queuedActions = new ArrayList<>();
+		doAnswer(invocation -> {
+			queuedActions.add(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(mock(OfflinePlayer.class));
+			AdvancedCoreUser.AsyncActionCollection outer = realUser.beginAsyncActionCollection();
+			AdvancedCoreUser.AsyncActionCollection inner = realUser.beginAsyncActionCollection();
+			realUser.restoreAsyncActionCollectionScope(inner);
+				realUser.restoreAsyncActionCollectionScope(outer);
+				realUser.giveMoney(1);
+				realUser.claimAsyncContinuationActions(inner);
+
+				CompletionStage<Void> outerCompletion = realUser.endAsyncActionCollection(outer);
+				CompletionStage<Void> innerCompletion = realUser.endAsyncActionCollection(inner);
+				assertEquals(1, queuedActions.size());
+				assertTrue(outerCompletion.toCompletableFuture().isDone());
+				assertFalse(innerCompletion.toCompletableFuture().isDone());
+			queuedActions.get(0).run();
+			outerCompletion.toCompletableFuture().join();
+			innerCompletion.toCompletableFuture().join();
+		}
+	}
+
+	@Test
+	void failedLegacyActionCreatedByAnAsyncContinuationFailsTheReward() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		when(vault.getEcon()).thenReturn(mock(Economy.class));
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Legacy");
+		AtomicReference<Runnable> queued = new AtomicReference<>();
+		doAnswer(invocation -> {
+			queued.set(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		CompletableFuture<Void> continuation = new CompletableFuture<>();
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				return continuation.thenApply(nothing -> {
+					realUser.giveMoney(2);
+					return null;
+				});
+			}
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			CompletionStage<Void> result = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			continuation.complete(null);
+			enabled.set(false);
+			queued.get().run();
+			assertThrows(java.util.concurrent.CompletionException.class, () -> result.toCompletableFuture().join());
+		}
+	}
+
+	@Test
+	void concurrentContinuationActionsRemainBoundToTheirOwnReward() {
+		AdvancedCoreConfigOptions config = mock(AdvancedCoreConfigOptions.class);
+		when(config.isOnlineMode()).thenReturn(true);
+		when(plugin.getOptions()).thenReturn(config);
+		VaultHandler vault = mock(VaultHandler.class);
+		Economy economy = mock(Economy.class);
+		when(vault.getEcon()).thenReturn(economy);
+		when(plugin.getVaultHandler()).thenReturn(vault);
+		AdvancedCoreUser realUser = new AdvancedCoreUser(plugin, UUID.randomUUID(), false, false);
+		realUser.setPlayerName("Concurrent");
+		OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
+		AtomicReference<Runnable> successfulAction = new AtomicReference<>();
+		doThrow(new IllegalStateException("first scheduler failure")).doAnswer(invocation -> {
+			successfulAction.set(invocation.getArgument(1, Runnable.class));
+			return null;
+		}).when(scheduler).runTask(eq(plugin), any(Runnable.class));
+		ArrayList<CompletableFuture<Void>> continuations = new ArrayList<>();
+		continuations.add(new CompletableFuture<>());
+		continuations.add(new CompletableFuture<>());
+		AtomicInteger invocation = new AtomicInteger();
+		handler.getInjectedRewards().add(new RewardInject("Legacy") {
+			@Override public boolean supportsAsyncRequest() { return true; }
+			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
+			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
+					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) {
+				int index = invocation.getAndIncrement();
+				return continuations.get(index).thenApply(nothing -> {
+					realUser.giveMoney(index + 1);
+					return null;
+				});
+			}
+		});
+
+		UUID uuid = UUID.fromString(realUser.getUUID());
+		try (org.mockito.MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(null);
+			bukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offlinePlayer);
+			CompletionStage<Void> first = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+			CompletionStage<Void> second = reward.giveInjectedRewardsAsync(realUser, new HashMap<>());
+
+			continuations.get(0).complete(null);
+			assertThrows(java.util.concurrent.CompletionException.class, () -> first.toCompletableFuture().join());
+			assertFalse(second.toCompletableFuture().isDone());
+
+			continuations.get(1).complete(null);
+			successfulAction.get().run();
+			second.toCompletableFuture().join();
+		}
+		verify(economy).depositPlayer(offlinePlayer, 2);
+	}
+
+	@Test
+	void commandSnapshotIsCheckpointedBeforeItsFirstDispatch() throws Exception {
+		ScheduledExecutorService storageExecutor = mock(ScheduledExecutorService.class);
+		when(plugin.getTimer()).thenReturn(storageExecutor);
+		Class<?> stateType = Class.forName("com.bencodez.advancedcore.api.rewards.Reward$ReplayState");
+		java.lang.reflect.Constructor<?> constructor = stateType.getDeclaredConstructor(Map.class, Map.class, boolean.class);
+		constructor.setAccessible(true);
+		Object replayState = constructor.newInstance(new HashMap<>(), new HashMap<>(), false);
+		List<Reward.ReplayCheckpoint> checkpoints = new ArrayList<>();
+		java.lang.reflect.Method setConsumer = stateType.getDeclaredMethod("setCheckpointConsumer",
+				java.util.function.Consumer.class);
+		setConsumer.setAccessible(true);
+		setConsumer.invoke(replayState, (java.util.function.Consumer<Reward.ReplayCheckpoint>) checkpoints::add);
+		java.lang.reflect.Method replay = Reward.class.getDeclaredMethod("replayCommandSequence",
+				AdvancedCorePlugin.class, HashMap.class, String.class, List.class, List.class, stateType, String.class,
+				java.util.function.BiFunction.class);
+		replay.setAccessible(true);
+		List<String> dispatched = new ArrayList<>();
+		@SuppressWarnings("unchecked")
+		CompletionStage<Void> result = (CompletionStage<Void>) replay.invoke(null, plugin, new HashMap<>(), "console",
+				List.of("say %value%"), List.of("say fixed"), replayState, "AsyncReward/0",
+					(java.util.function.BiFunction<String, Integer, CompletionStage<Void>>) (command, index) -> {
+					dispatched.add(command);
+					return CompletableFuture.completedFuture(null);
+				});
+
+		ArgumentCaptor<Runnable> writes = ArgumentCaptor.forClass(Runnable.class);
+		verify(storageExecutor).execute(writes.capture());
+		assertTrue(dispatched.isEmpty());
+		assertFalse(result.toCompletableFuture().isDone());
+		writes.getValue().run();
+		assertEquals(List.of("say fixed"), dispatched);
+		assertTrue(checkpoints.get(0).getReplayProgress().isEmpty());
+		assertTrue(checkpoints.get(0).getPlaceholders().entrySet().stream()
+				.anyMatch(entry -> entry.getKey().startsWith("__advancedcore_replay_commands_")
+						&& entry.getKey().endsWith("_snapshot") && entry.getValue().contains("c2F5IGZpeGVk")));
+		ArgumentCaptor<Runnable> progressWrite = ArgumentCaptor.forClass(Runnable.class);
+		verify(storageExecutor, times(2)).execute(progressWrite.capture());
+		progressWrite.getAllValues().get(1).run();
+		result.toCompletableFuture().join();
+	}
+
+	@Test
+	void commandSnapshotDistinguishesAnEmptyElementFromAnEmptyList() throws Exception {
+		java.lang.reflect.Method encode = Reward.class.getDeclaredMethod("encodeCommandSnapshot", List.class);
+		encode.setAccessible(true);
+		String emptyList = (String) encode.invoke(null, List.of());
+		String emptyElement = (String) encode.invoke(null, List.of(""));
+		assertNotEquals(emptyList, emptyElement);
+		java.lang.reflect.Method decode = Reward.class.getDeclaredMethod("decodeCommandSnapshot", String.class, int.class);
+		decode.setAccessible(true);
+		assertEquals(List.of(), decode.invoke(null, emptyList, 0));
+		assertEquals(List.of(""), decode.invoke(null, emptyElement, 1));
 	}
 
 	@Test
@@ -539,16 +959,20 @@ class RewardAsyncInjectionTest {
 	void commandReplayRetriesOnlyTheFailedSuffix() throws Exception {
 		ArrayList<String> dispatched = new ArrayList<>();
 		AtomicBoolean failSecond = new AtomicBoolean(true);
+		AtomicInteger expansion = new AtomicInteger();
 		handler.getInjectedRewards().add(new RewardInject("Commands") {
 			@Override public boolean supportsAsyncRequest() { return true; }
 			@Override public Object onRewardRequest(Reward ignored, AdvancedCoreUser ignoredUser,
 					ConfigurationSection ignoredData, HashMap<String, String> ignoredPlaceholders) { return null; }
 			@Override public CompletionStage<Object> onRewardRequestAsync(Reward ignored, AdvancedCoreUser ignoredUser,
 					ConfigurationSection ignoredData, HashMap<String, String> commandPlaceholders) {
-				return Reward.replayCommandSequence(plugin, commandPlaceholders, "console",
-						List.of("first", "second"), command -> {
+				List<String> templates = List.of("first %value%", "second %value%");
+				int currentExpansion = expansion.incrementAndGet();
+				List<String> expanded = List.of("first-" + currentExpansion, "second-" + currentExpansion);
+				return Reward.replayCommandSequence(plugin, commandPlaceholders, "console", templates, expanded,
+						(command, ignoredIndex) -> {
 							dispatched.add(command);
-							return command.equals("second") && failSecond.get()
+							return command.startsWith("second-") && failSecond.get()
 									? CompletableFuture.failedFuture(new IllegalStateException("temporary"))
 									: CompletableFuture.completedFuture(null);
 						}).thenApply(nothing -> null);
@@ -571,7 +995,7 @@ class RewardAsyncInjectionTest {
 				"AsyncReward");
 		resumed.toCompletableFuture().join();
 
-		assertEquals(List.of("first", "second", "second"), dispatched);
+		assertEquals(List.of("first-1", "second-1", "second-1"), dispatched);
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -214,6 +214,40 @@ public class RewardExecutorTest {
 		verify(misc, never()).executeConsoleCommandsAsync(eq("Ben"), eq("/inserted"), any());
 	}
 
+	@Test
+	public void snapshottedListFailsWhenANamedChildDisappears() {
+		YamlConfiguration data = new YamlConfiguration();
+		data.set("Rewards", new ArrayList<>(List.of("First", "Missing")));
+		Reward firstReward = mock(Reward.class);
+		Reward missingReward = mock(Reward.class);
+		when(firstReward.giveRewardAsync(eq(user), any(RewardOptions.class)))
+				.thenReturn(CompletableFuture.completedFuture(null));
+		when(missingReward.giveRewardAsync(eq(user), any(RewardOptions.class)))
+				.thenReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")));
+		when(handler.getReward("First")).thenReturn(firstReward);
+		when(handler.getReward("Missing")).thenReturn(missingReward, (Reward) null);
+		AtomicReference<Reward.ReplayCheckpoint> checkpoint = new AtomicReference<>();
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		doAnswer(invocation -> {
+			invocation.<Runnable>getArgument(0).run();
+			return null;
+		}).when(timer).execute(any(Runnable.class));
+		when(plugin.getTimer()).thenReturn(timer);
+		RewardOptions first = new RewardOptions();
+		first.setAsyncReplayCheckpointConsumer(checkpoint::set);
+
+		assertThrows(CompletionException.class,
+				() -> executor.giveRewardAsync(user, data, "Rewards", first).toCompletableFuture().join());
+		assertNotNull(checkpoint.get());
+		RewardOptions retry = new RewardOptions()
+				.setPlaceholders(new java.util.HashMap<>(checkpoint.get().getPlaceholders()));
+		retry.setAsyncReplayCheckpointConsumer(ignored -> { });
+
+		assertThrows(CompletionException.class,
+				() -> executor.giveRewardAsync(user, data, "Rewards", retry).toCompletableFuture().join());
+		verify(missingReward).giveRewardAsync(eq(user), any(RewardOptions.class));
+	}
+
     @Test
     public void stringRewardDispatchesNamedReward() {
         YamlConfiguration data = new YamlConfiguration();
@@ -363,6 +397,15 @@ public class RewardExecutorTest {
                 () -> executor.givePersistedQueueRewardAsync(user, "Missing", new RewardOptions())
                         .toCompletableFuture().join());
     }
+
+	@Test
+	public void unresolvedNestedConfigurationFailsSoReplayCannotDropIt() {
+		YamlConfiguration data = new YamlConfiguration();
+
+		assertThrows(CompletionException.class,
+				() -> executor.giveRewardAsync(user, data, "Removed", new RewardOptions())
+						.toCompletableFuture().join());
+	}
 
     @Test
     public void choicesDispatchThroughRewardBuilder() {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
@@ -130,7 +131,7 @@ public class RewardExecutorTest {
     }
 
     @Test
-	public void asyncListDispatchUsesASeparateReplayContextForEveryEntry() {
+    public void asyncListDispatchUsesASeparateReplayContextForEveryEntry() {
         YamlConfiguration data = new YamlConfiguration();
         data.set("Rewards", new ArrayList<>(List.of("Child", "Child")));
         Reward child = mock(Reward.class);
@@ -138,7 +139,11 @@ public class RewardExecutorTest {
         when(child.giveRewardAsync(eq(user), any(RewardOptions.class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
-        executor.giveRewardAsync(user, data, "Rewards", new RewardOptions()).toCompletableFuture().join();
+        try (MockedStatic<Reward> replay = mockStatic(Reward.class,
+                org.mockito.Mockito.CALLS_REAL_METHODS)) {
+            replay.when(Reward::currentReplayOccurrenceId).thenReturn("parent-occurrence");
+            executor.giveRewardAsync(user, data, "Rewards", new RewardOptions()).toCompletableFuture().join();
+        }
 
         ArgumentCaptor<RewardOptions> captured = ArgumentCaptor.forClass(RewardOptions.class);
         verify(child, org.mockito.Mockito.times(2)).giveRewardAsync(eq(user), captured.capture());
@@ -146,7 +151,42 @@ public class RewardExecutorTest {
         assertFalse(children.get(0) == children.get(1));
         assertFalse(children.get(0).getAsyncReplayKey().equals(children.get(1).getAsyncReplayKey()));
         assertSame(children.get(0).getAsyncReplayState(), children.get(1).getAsyncReplayState());
+		assertEquals("parent-occurrence", children.get(0).getAsyncReplayOccurrenceId());
+		assertEquals("parent-occurrence", children.get(1).getAsyncReplayOccurrenceId());
 	}
+
+    @Test
+    public void asyncRewardDispatchLeavesThePrimaryThreadAndRetainsCompletion() {
+        Reward child = mock(Reward.class);
+        CompletableFuture<Void> childResult = new CompletableFuture<>();
+        when(child.giveRewardAsync(eq(user), any(RewardOptions.class))).thenReturn(childResult);
+        BukkitScheduler scheduler = mock(BukkitScheduler.class);
+        when(plugin.getBukkitScheduler()).thenReturn(scheduler);
+        ArgumentCaptor<Runnable> dispatch = ArgumentCaptor.forClass(Runnable.class);
+        RewardOptions options = new RewardOptions();
+        Reward.ReplayState replayState = Reward.replayStateFor(new RewardOptions());
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class);
+                MockedStatic<Reward> replay = mockStatic(Reward.class)) {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            replay.when(Reward::currentReplayState).thenReturn(replayState);
+            replay.when(Reward::currentReplayKey).thenReturn("parent");
+            replay.when(Reward::currentReplayOccurrenceId).thenReturn("occurrence");
+            when(child.getRewardName()).thenReturn("child");
+            CompletionStage<Void> result = executor.giveRewardAsync(user, child, options);
+
+            verify(scheduler).runTaskAsynchronously(eq(plugin), dispatch.capture());
+            verify(child, never()).giveRewardAsync(eq(user), any(RewardOptions.class));
+            assertSame(replayState, options.getAsyncReplayState());
+            assertEquals("parent/child", options.getAsyncReplayKey());
+            assertEquals("occurrence", options.getAsyncReplayOccurrenceId());
+            assertFalse(result.toCompletableFuture().isDone());
+            dispatch.getValue().run();
+            assertFalse(result.toCompletableFuture().isDone());
+            childResult.completeExceptionally(new IllegalStateException("child failed"));
+            assertThrows(CompletionException.class, () -> result.toCompletableFuture().join());
+        }
+    }
 
 	@Test
 	public void asyncListLazilyClonesAndCarriesOnlyReplayMetadata() {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -156,13 +156,10 @@ public class RewardExecutorTest {
 	}
 
     @Test
-    public void asyncRewardDispatchLeavesThePrimaryThreadAndRetainsCompletion() {
+    public void asyncRewardSetupStaysOnThePrimaryThreadAndRetainsCompletion() {
         Reward child = mock(Reward.class);
         CompletableFuture<Void> childResult = new CompletableFuture<>();
         when(child.giveRewardAsync(eq(user), any(RewardOptions.class))).thenReturn(childResult);
-        BukkitScheduler scheduler = mock(BukkitScheduler.class);
-        when(plugin.getBukkitScheduler()).thenReturn(scheduler);
-        ArgumentCaptor<Runnable> dispatch = ArgumentCaptor.forClass(Runnable.class);
         RewardOptions options = new RewardOptions();
         Reward.ReplayState replayState = Reward.replayStateFor(new RewardOptions());
 
@@ -175,13 +172,10 @@ public class RewardExecutorTest {
             when(child.getRewardName()).thenReturn("child");
             CompletionStage<Void> result = executor.giveRewardAsync(user, child, options);
 
-            verify(scheduler).runTaskAsynchronously(eq(plugin), dispatch.capture());
-            verify(child, never()).giveRewardAsync(eq(user), any(RewardOptions.class));
+            verify(child).giveRewardAsync(eq(user), any(RewardOptions.class));
             assertSame(replayState, options.getAsyncReplayState());
             assertEquals("parent/child", options.getAsyncReplayKey());
             assertEquals("occurrence", options.getAsyncReplayOccurrenceId());
-            assertFalse(result.toCompletableFuture().isDone());
-            dispatch.getValue().run();
             assertFalse(result.toCompletableFuture().isDone());
             childResult.completeExceptionally(new IllegalStateException("child failed"));
             assertThrows(CompletionException.class, () -> result.toCompletableFuture().join());

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -62,9 +62,19 @@ public class RewardExecutorTest {
         handler = mock(RewardHandler.class);
         user = mock(AdvancedCoreUser.class);
         executor = new RewardExecutor(handler, plugin);
+		BukkitScheduler scheduler = mock(BukkitScheduler.class);
 
         when(plugin.getLogger()).thenReturn(mock(Logger.class));
         when(plugin.isEnabled()).thenReturn(true);
+		when(plugin.getBukkitScheduler()).thenReturn(scheduler);
+		doAnswer(invocation -> {
+			invocation.<Runnable>getArgument(1).run();
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class));
+		doAnswer(invocation -> {
+			invocation.<Runnable>getArgument(1).run();
+			return null;
+		}).when(scheduler).executeOrScheduleSync(eq(plugin), any(Runnable.class), any(org.bukkit.entity.Entity.class));
         when(user.getPlayerName()).thenReturn("Ben");
         when(user.getUUID()).thenReturn("uuid");
         when(user.isOnline()).thenReturn(true);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -216,13 +216,17 @@ public class RewardExecutorTest {
     public void commandStyleRewardExecutesConsoleCommand() {
         MiscUtils misc = mock(MiscUtils.class);
         RewardOptions options = new RewardOptions().addPlaceholder("player", "Ben");
+        when(misc.executeConsoleCommandsAsync("Ben", "/say hi", options.getPlaceholders()))
+                .thenReturn(CompletableFuture.completedFuture(null));
 
         try (MockedStatic<MiscUtils> miscStatic = mockStatic(MiscUtils.class)) {
             miscStatic.when(MiscUtils::getInstance).thenReturn(misc);
             executor.giveReward(user, "/say hi", options);
+            executor.giveRewardAsync(user, "/say hi", options).toCompletableFuture().join();
         }
 
         verify(misc).executeConsoleCommands("Ben", "/say hi", options.getPlaceholders());
+        verify(misc).executeConsoleCommandsAsync("Ben", "/say hi", options.getPlaceholders());
     }
 
     @Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -201,6 +201,7 @@ public class RewardExecutorTest {
 			assertThrows(CompletionException.class,
 					() -> executor.giveRewardAsync(user, data, "Rewards", first).toCompletableFuture().join());
 			assertNotNull(checkpoint.get());
+			data.set("Rewards", "/inserted");
 
 			RewardOptions retry = new RewardOptions()
 					.setPlaceholders(new java.util.HashMap<>(checkpoint.get().getPlaceholders()));
@@ -210,6 +211,7 @@ public class RewardExecutorTest {
 
 		verify(misc).executeConsoleCommandsAsync(eq("Ben"), eq("/first"), any());
 		verify(misc, org.mockito.Mockito.times(2)).executeConsoleCommandsAsync(eq("Ben"), eq("/second"), any());
+		verify(misc, never()).executeConsoleCommandsAsync(eq("Ben"), eq("/inserted"), any());
 	}
 
     @Test
@@ -348,6 +350,18 @@ public class RewardExecutorTest {
                 () -> executor.givePersistedQueueRewardAsync(user, "Daily", options).toCompletableFuture().join());
 
         verify(reward, never()).giveRewardAsync(eq(user), any(RewardOptions.class));
+    }
+
+    @Test
+    public void unresolvedPersistedRewardFailsSoTheQueueCanRetainIt() {
+        when(handler.rewardExist("Missing")).thenReturn(false);
+        when(handler.hasDirectRewardHandle("Missing")).thenReturn(false);
+        when(handler.getQueuedGeneratedReward("Missing", user.getUUID())).thenReturn(null);
+        when(handler.getReward("Missing")).thenReturn(null);
+
+        assertThrows(CompletionException.class,
+                () -> executor.givePersistedQueueRewardAsync(user, "Missing", new RewardOptions())
+                        .toCompletableFuture().join());
     }
 
     @Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
@@ -122,6 +123,25 @@ public class RewardExecutorTest {
         verify(first).giveReward(user, options);
         verify(second).giveReward(user, options);
         assertTrue(options.isOnlineSet());
+    }
+
+    @Test
+    public void asyncListDispatchUsesASeparateReplayContextForEveryEntry() {
+        YamlConfiguration data = new YamlConfiguration();
+        data.set("Rewards", new ArrayList<>(List.of("Child", "Child")));
+        Reward child = mock(Reward.class);
+        when(handler.getReward("Child")).thenReturn(child);
+        when(child.giveRewardAsync(eq(user), any(RewardOptions.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        executor.giveRewardAsync(user, data, "Rewards", new RewardOptions()).toCompletableFuture().join();
+
+        ArgumentCaptor<RewardOptions> captured = ArgumentCaptor.forClass(RewardOptions.class);
+        verify(child, org.mockito.Mockito.times(2)).giveRewardAsync(eq(user), captured.capture());
+        List<RewardOptions> children = captured.getAllValues();
+        assertFalse(children.get(0) == children.get(1));
+        assertFalse(children.get(0).getAsyncReplayKey().equals(children.get(1).getAsyncReplayKey()));
+        assertSame(children.get(0).getAsyncReplayState(), children.get(1).getAsyncReplayState());
     }
 
     @Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -149,6 +149,34 @@ public class RewardExecutorTest {
 	}
 
 	@Test
+	public void asyncListLazilyClonesAndCarriesOnlyReplayMetadata() {
+		YamlConfiguration data = new YamlConfiguration();
+		data.set("Rewards", new ArrayList<>(List.of("First", "Second")));
+		Reward first = mock(Reward.class);
+		Reward second = mock(Reward.class);
+		when(handler.getReward("First")).thenReturn(first);
+		when(handler.getReward("Second")).thenReturn(second);
+		RewardOptions parent = new RewardOptions().addPlaceholder("ordinary", "parent");
+		when(first.giveRewardAsync(eq(user), any(RewardOptions.class))).thenAnswer(invocation -> {
+			RewardOptions child = invocation.getArgument(1);
+			child.getPlaceholders().put("ordinary", "child");
+			child.getAsyncReplayState().recordReplayMetadata("__advancedcore_replay_commands_test_snapshot", "v1:c2");
+			return CompletableFuture.completedFuture(null);
+		});
+		when(second.giveRewardAsync(eq(user), any(RewardOptions.class)))
+				.thenReturn(CompletableFuture.failedFuture(new IllegalStateException("later child failed")));
+
+		assertThrows(CompletionException.class,
+				() -> executor.giveRewardAsync(user, data, "Rewards", parent).toCompletableFuture().join());
+
+		ArgumentCaptor<RewardOptions> captured = ArgumentCaptor.forClass(RewardOptions.class);
+		verify(second).giveRewardAsync(eq(user), captured.capture());
+		assertEquals("parent", captured.getValue().getPlaceholders().get("ordinary"));
+		assertEquals("v1:c2", captured.getValue().getPlaceholders()
+				.get("__advancedcore_replay_commands_test_snapshot"));
+	}
+
+	@Test
 	public void asyncListReplayDoesNotRepeatCompletedDirectCommands() {
 		YamlConfiguration data = new YamlConfiguration();
 		data.set("Rewards", new ArrayList<>(List.of("/first", "/second")));

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -259,6 +260,27 @@ public class RewardExecutorTest {
         }
 
         verify(reward).giveReward(user, options);
+    }
+
+    @Test
+    public void disabledPluginFailsEveryConfiguredAsyncDispatchWithoutExecuting() {
+        Reward reward = mock(Reward.class);
+        RewardOptions options = new RewardOptions();
+        YamlConfiguration data = new YamlConfiguration();
+        data.set("Reward", "Daily");
+        when(handler.getReward("Daily")).thenReturn(reward);
+        when(plugin.isEnabled()).thenReturn(false);
+
+        assertThrows(java.util.concurrent.CompletionException.class,
+                () -> executor.giveRewardAsync(user, reward, options).toCompletableFuture().join());
+        assertThrows(java.util.concurrent.CompletionException.class,
+                () -> executor.giveRewardAsync(user, "Daily", options).toCompletableFuture().join());
+        assertThrows(java.util.concurrent.CompletionException.class,
+                () -> executor.giveRewardAsync(user, data, "Reward", options).toCompletableFuture().join());
+        assertThrows(java.util.concurrent.CompletionException.class,
+                () -> executor.givePersistedQueueRewardAsync(user, "Daily", options).toCompletableFuture().join());
+
+        verify(reward, never()).giveRewardAsync(eq(user), any(RewardOptions.class));
     }
 
     @Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -13,12 +13,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
@@ -127,7 +130,7 @@ public class RewardExecutorTest {
     }
 
     @Test
-    public void asyncListDispatchUsesASeparateReplayContextForEveryEntry() {
+	public void asyncListDispatchUsesASeparateReplayContextForEveryEntry() {
         YamlConfiguration data = new YamlConfiguration();
         data.set("Rewards", new ArrayList<>(List.of("Child", "Child")));
         Reward child = mock(Reward.class);
@@ -143,7 +146,43 @@ public class RewardExecutorTest {
         assertFalse(children.get(0) == children.get(1));
         assertFalse(children.get(0).getAsyncReplayKey().equals(children.get(1).getAsyncReplayKey()));
         assertSame(children.get(0).getAsyncReplayState(), children.get(1).getAsyncReplayState());
-    }
+	}
+
+	@Test
+	public void asyncListReplayDoesNotRepeatCompletedDirectCommands() {
+		YamlConfiguration data = new YamlConfiguration();
+		data.set("Rewards", new ArrayList<>(List.of("/first", "/second")));
+		MiscUtils misc = mock(MiscUtils.class);
+		when(misc.executeConsoleCommandsAsync(eq("Ben"), eq("/first"), any()))
+				.thenReturn(CompletableFuture.completedFuture(null));
+		when(misc.executeConsoleCommandsAsync(eq("Ben"), eq("/second"), any()))
+				.thenReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")),
+						CompletableFuture.completedFuture(null));
+		AtomicReference<Reward.ReplayCheckpoint> checkpoint = new AtomicReference<>();
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		doAnswer(invocation -> {
+			invocation.<Runnable>getArgument(0).run();
+			return null;
+		}).when(timer).execute(any(Runnable.class));
+		when(plugin.getTimer()).thenReturn(timer);
+		RewardOptions first = new RewardOptions();
+		first.setAsyncReplayCheckpointConsumer(checkpoint::set);
+
+		try (MockedStatic<MiscUtils> miscStatic = mockStatic(MiscUtils.class)) {
+			miscStatic.when(MiscUtils::getInstance).thenReturn(misc);
+			assertThrows(CompletionException.class,
+					() -> executor.giveRewardAsync(user, data, "Rewards", first).toCompletableFuture().join());
+			assertNotNull(checkpoint.get());
+
+			RewardOptions retry = new RewardOptions()
+					.setPlaceholders(new java.util.HashMap<>(checkpoint.get().getPlaceholders()));
+			retry.setAsyncReplayCheckpointConsumer(ignored -> { });
+			executor.giveRewardAsync(user, data, "Rewards", retry).toCompletableFuture().join();
+		}
+
+		verify(misc).executeConsoleCommandsAsync(eq("Ben"), eq("/first"), any());
+		verify(misc, org.mockito.Mockito.times(2)).executeConsoleCommandsAsync(eq("Ben"), eq("/second"), any());
+	}
 
     @Test
     public void stringRewardDispatchesNamedReward() {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/rewards/RewardExecutorTest.java
@@ -166,12 +166,14 @@ public class RewardExecutorTest {
 	}
 
     @Test
-    public void asyncRewardSetupStaysOnThePrimaryThreadAndRetainsCompletion() {
+    public void asyncRewardSetupLeavesThePrimaryThreadAndRetainsCompletion() {
         Reward child = mock(Reward.class);
         CompletableFuture<Void> childResult = new CompletableFuture<>();
         when(child.giveRewardAsync(eq(user), any(RewardOptions.class))).thenReturn(childResult);
         RewardOptions options = new RewardOptions();
         Reward.ReplayState replayState = Reward.replayStateFor(new RewardOptions());
+        BukkitScheduler scheduler = plugin.getBukkitScheduler();
+        ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
 
         try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class);
                 MockedStatic<Reward> replay = mockStatic(Reward.class)) {
@@ -182,6 +184,10 @@ public class RewardExecutorTest {
             when(child.getRewardName()).thenReturn("child");
             CompletionStage<Void> result = executor.giveRewardAsync(user, child, options);
 
+            verify(scheduler).runTaskAsynchronously(eq(plugin), task.capture());
+            verify(child, never()).giveRewardAsync(eq(user), any(RewardOptions.class));
+            assertFalse(result.toCompletableFuture().isDone());
+            task.getValue().run();
             verify(child).giveRewardAsync(eq(user), any(RewardOptions.class));
             assertSame(replayState, options.getAsyncReplayState());
             assertEquals("parent/child", options.getAsyncReplayKey());

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -130,6 +130,22 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void queuedOccurrenceIsForwardedBeforeAnyAsyncInjectorRuns() {
+		String occurrence = UUID.randomUUID().toString();
+		ArrayList<String> rewards = new ArrayList<>();
+		rewards.add("VoteReward%asyncoccurrence%" + occurrence + "%placeholders%Server%pair%server-a");
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT)).thenReturn(rewards);
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+
+		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkOfflineRewards();
+
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class), options.capture());
+		assertEquals(occurrence, options.getValue().getAsyncReplayOccurrenceId());
+	}
+
+	@Test
 	void setOfflineRewards_emptyList() {
 		ArrayList<String> rewards = new ArrayList<>();
 		user.setOfflineRewards(rewards);
@@ -350,6 +366,41 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void timedAsyncCheckpointPersistsAndRestoresItsRegistryFingerprint() throws Exception {
+		long due = System.currentTimeMillis() - 1_000;
+		ArrayList<String> persisted = new ArrayList<>();
+		persisted.add("VoteReward%placeholders%Server%pair%server-a%ExecutionTime/%" + due);
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(persisted));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			persisted.clear();
+			persisted.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("TimedRewards"), any(), eq(false));
+		CompletableFuture<Void> pending = new CompletableFuture<>();
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(pending);
+
+		ArgumentCaptor<RewardOptions> firstOptions = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkDelayedTimedRewards();
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class), firstOptions.capture());
+		firstOptions.getValue().getAsyncReplayCheckpointConsumer().accept(replayCheckpoint(Map.of("VoteReward", 1),
+				Map.of("VoteReward", "fingerprint", "VoteReward/0", "parent-fingerprint"),
+				new HashMap<>(Map.of("Server", "server-a"))));
+		assertTrue(persisted.get(0).contains("%asyncprogress%v3-"));
+
+		AdvancedCoreUser restarted = new AdvancedCoreUser(plugin, UUID.randomUUID(), "Test");
+		restarted.setData(data);
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(restarted), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+		ArgumentCaptor<RewardOptions> resumed = ArgumentCaptor.forClass(RewardOptions.class);
+		restarted.checkDelayedTimedRewards();
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(restarted), any(PersistedQueueReference.class), resumed.capture());
+		assertEquals("fingerprint", resumed.getValue().getAsyncReplayRegistryFingerprints().get("VoteReward"));
+		assertEquals("parent-fingerprint", resumed.getValue().getAsyncReplayRegistryFingerprints().get("VoteReward/0"));
+	}
+
+	@Test
 	void timedRetryParsesProgressAfterTheExecutionMarkerWasConsumed() {
 		long due = System.currentTimeMillis() - 1_000;
 		ArrayList<String> timed = new ArrayList<>();
@@ -373,5 +424,13 @@ public class AdvancedCoreUserTest {
 				.getDeclaredConstructor(Map.class, HashMap.class);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progress, placeholders);
+	}
+
+	private Reward.ReplayCheckpoint replayCheckpoint(Map<String, Integer> progress, Map<String, String> fingerprints,
+			HashMap<String, String> placeholders) throws Exception {
+		java.lang.reflect.Constructor<Reward.ReplayCheckpoint> constructor = Reward.ReplayCheckpoint.class
+				.getDeclaredConstructor(Map.class, Map.class, HashMap.class);
+		constructor.setAccessible(true);
+		return constructor.newInstance(progress, fingerprints, placeholders);
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.tests.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,15 +13,18 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import org.bukkit.Bukkit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
 import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
 import com.bencodez.advancedcore.AdvancedCorePlugin;
@@ -249,6 +253,23 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void pendingOfflineReplayClaimIsSharedAcrossWrappersForTheSameUuid() {
+		ArrayList<String> rewards = new ArrayList<>(List.of("VoteReward"));
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT)).thenReturn(rewards);
+		CompletableFuture<Void> pending = new CompletableFuture<>();
+		when(rewardHandler.givePersistedQueueRewardAsync(any(AdvancedCoreUser.class),
+				any(PersistedQueueReference.class), any(RewardOptions.class))).thenReturn(pending);
+		AdvancedCoreUser second = new AdvancedCoreUser(plugin, UUID.fromString(user.getUUID()), "Test");
+		second.setData(data);
+
+		user.checkOfflineRewards();
+		second.checkOfflineRewards();
+
+		verify(rewardHandler, org.mockito.Mockito.times(1)).givePersistedQueueRewardAsync(
+				any(AdvancedCoreUser.class), any(PersistedQueueReference.class), any(RewardOptions.class));
+	}
+
+	@Test
 	void offlineCheckpointMigratesOnlyItsOwnDuplicateInFlightClaim() throws Exception {
 		String entry = "VoteReward%placeholders%Server%pair%server-a";
 		ArrayList<String> persisted = new ArrayList<>();
@@ -330,6 +351,38 @@ public class AdvancedCoreUserTest {
 		user.checkDelayedTimedRewards();
 		verify(rewardHandler, org.mockito.Mockito.times(1)).givePersistedQueueRewardAsync(eq(user),
 				any(PersistedQueueReference.class), any(RewardOptions.class));
+	}
+
+	@Test
+	void pendingTimedReplayClaimIsSharedAcrossWrappersForTheSameUuid() {
+		long due = System.currentTimeMillis() - 1_000;
+		ArrayList<String> timed = new ArrayList<>(List.of("VoteReward%ExecutionTime/%" + due));
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT)).thenReturn(timed);
+		CompletableFuture<Void> pending = new CompletableFuture<>();
+		when(rewardHandler.givePersistedQueueRewardAsync(any(AdvancedCoreUser.class),
+				any(PersistedQueueReference.class), any(RewardOptions.class))).thenReturn(pending);
+		AdvancedCoreUser second = new AdvancedCoreUser(plugin, UUID.fromString(user.getUUID()), "Test");
+		second.setData(data);
+
+		user.checkDelayedTimedRewards();
+		second.checkDelayedTimedRewards();
+
+		verify(rewardHandler, org.mockito.Mockito.times(1)).givePersistedQueueRewardAsync(
+				any(AdvancedCoreUser.class), any(PersistedQueueReference.class), any(RewardOptions.class));
+	}
+
+	@Test
+	void unavailablePlayerFailsAsyncCommandDispatch() {
+		AdvancedCorePlugin.setInstance(plugin);
+		try (MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer(UUID.fromString(user.getUUID()))).thenReturn(null);
+
+			assertThrows(java.util.concurrent.CompletionException.class,
+					() -> user.preformCommandAsync(new ArrayList<>(List.of("say hello")), new HashMap<>())
+							.toCompletableFuture().join());
+		} finally {
+			AdvancedCorePlugin.setInstance(null);
+		}
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -2,6 +2,7 @@ package com.bencodez.advancedcore.tests.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
@@ -150,6 +152,76 @@ public class AdvancedCoreUserTest {
 
 		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class), options.capture());
 		assertEquals(occurrence, options.getValue().getAsyncReplayOccurrenceId());
+	}
+
+	@Test
+	void deferredReplayRetainsOccurrenceAndCheckpoint() {
+		ArrayList<String> persisted = new ArrayList<>();
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(persisted));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			persisted.clear();
+			persisted.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("offlineRewardsPath"), any());
+		Reward reward = mock(Reward.class);
+		when(reward.getRewardName()).thenReturn("VoteReward");
+		RewardOptions options = new RewardOptions().addPlaceholder("Server", "server-a");
+		String occurrence = UUID.randomUUID().toString();
+		options.setAsyncReplayOccurrenceId(occurrence);
+		options.setAsyncReplayProgress(Map.of("root/Grant:0", 1));
+		options.setAsyncReplayRegistryFingerprints(Map.of("root/Grant:0", "fingerprint"));
+
+		user.addOfflineRewards(reward, options.getPlaceholders(), options);
+
+		assertEquals(1, persisted.size());
+		assertTrue(persisted.get(0).contains("%asyncoccurrence%" + occurrence));
+		assertTrue(persisted.get(0).contains("%asyncprogress%v3-"));
+		assertTrue(persisted.get(0).contains("Server%pair%server-a"));
+	}
+
+	@Test
+	void replayClaimCleanupRechecksSharedStateUnderItsLock() throws Exception {
+		java.lang.reflect.Method replayClaims = AdvancedCoreUser.class.getDeclaredMethod("replayClaims");
+		replayClaims.setAccessible(true);
+		Object claims = replayClaims.invoke(user);
+		java.lang.reflect.Field lockField = AdvancedCoreUser.class.getDeclaredField("REPLAY_CLAIMS_LOCK");
+		lockField.setAccessible(true);
+		Object lock = lockField.get(null);
+		java.lang.reflect.Field offlineField = claims.getClass().getDeclaredField("offline");
+		offlineField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<String, Integer> offline = (Map<String, Integer>) offlineField.get(claims);
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		Thread cleanup;
+		synchronized (lock) {
+			cleanup = new Thread(() -> {
+				try {
+					java.lang.reflect.Method release = AdvancedCoreUser.class
+							.getDeclaredMethod("releaseReplayClaimsIfEmpty", claims.getClass());
+					release.setAccessible(true);
+					release.invoke(user, claims);
+				} catch (Throwable error) {
+					failure.set(error);
+				}
+			}, "replay-claim-cleanup-test");
+			cleanup.start();
+			long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+			while (cleanup.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+				Thread.yield();
+			}
+			assertEquals(Thread.State.BLOCKED, cleanup.getState());
+			offline.put("new-claim", 1);
+		}
+		cleanup.join(TimeUnit.SECONDS.toMillis(5));
+		assertFalse(cleanup.isAlive());
+		assertTrue(failure.get() == null, () -> "cleanup failed: " + failure.get());
+		assertSame(claims, replayClaims.invoke(user));
+		offline.clear();
+		java.lang.reflect.Method release = AdvancedCoreUser.class
+				.getDeclaredMethod("releaseReplayClaimsIfEmpty", claims.getClass());
+		release.setAccessible(true);
+		release.invoke(user, claims);
 	}
 
 	@Test

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +56,7 @@ public class AdvancedCoreUserTest {
 		when(plugin.getUserManager()).thenReturn(userManager);
 		when(plugin.getRewardHandler()).thenReturn(rewardHandler);
 		when(plugin.getStorageType()).thenReturn(UserStorage.MYSQL);
+		when(plugin.getLogger()).thenReturn(mock(Logger.class));
 		when(userManager.getOfflineRewardsPath()).thenReturn("offlineRewardsPath");
 		when(configOptions.isProcessRewards()).thenReturn(true);
 
@@ -66,11 +70,12 @@ public class AdvancedCoreUserTest {
 		rewards.add("VoteReward%placeholders%Server%pair%server-a");
 		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT)).thenReturn(rewards);
 
-		user.checkOfflineRewards();
-
 		ArgumentCaptor<PersistedQueueReference> referenceCaptor = ArgumentCaptor.forClass(PersistedQueueReference.class);
 		ArgumentCaptor<RewardOptions> optionsCaptor = ArgumentCaptor.forClass(RewardOptions.class);
-		verify(rewardHandler).givePersistedQueueReward(eq(user), referenceCaptor.capture(), optionsCaptor.capture());
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+		user.checkOfflineRewards();
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), referenceCaptor.capture(), optionsCaptor.capture());
 		assertEquals("VoteReward", referenceCaptor.getValue().getReference());
 		RewardOptions options = optionsCaptor.getValue();
 		assertFalse(options.isForceOffline());
@@ -85,11 +90,12 @@ public class AdvancedCoreUserTest {
 		rewards.add("VoteReward%placeholders%Server%pair%server-a");
 		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT)).thenReturn(rewards);
 
-		user.forceRunOfflineRewards();
-
 		ArgumentCaptor<PersistedQueueReference> referenceCaptor = ArgumentCaptor.forClass(PersistedQueueReference.class);
 		ArgumentCaptor<RewardOptions> optionsCaptor = ArgumentCaptor.forClass(RewardOptions.class);
-		verify(rewardHandler).givePersistedQueueReward(eq(user), referenceCaptor.capture(), optionsCaptor.capture());
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+		user.forceRunOfflineRewards();
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), referenceCaptor.capture(), optionsCaptor.capture());
 		assertEquals("VoteReward", referenceCaptor.getValue().getReference());
 		RewardOptions options = optionsCaptor.getValue();
 		assertTrue(options.isForceOffline());
@@ -142,5 +148,40 @@ public class AdvancedCoreUserTest {
 		rewards.add("reward2");
 		user.setOfflineRewards(rewards);
 		verify(data).setStringList("offlineRewardsPath", rewards);
+	}
+
+	@Test
+	void failedAsyncOfflineReplayIsRestoredForRetry() {
+		ArrayList<String> initial = new ArrayList<>();
+		initial.add("VoteReward%placeholders%Server%pair%server-a");
+		initial.add("VoteReward%placeholders%Server%pair%server-a");
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT))
+				.thenReturn(new ArrayList<>(initial)).thenReturn(new ArrayList<>());
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")));
+
+		user.checkOfflineRewards();
+
+		ArgumentCaptor<ArrayList<String>> saved = ArgumentCaptor.forClass(ArrayList.class);
+		verify(data, org.mockito.Mockito.times(3)).setStringList(eq("offlineRewardsPath"), saved.capture());
+		assertEquals(initial, saved.getAllValues().get(2));
+	}
+
+	@Test
+	void failedAsyncTimedReplayIsRestoredAfterDueEntriesAreSaved() {
+		long due = System.currentTimeMillis() - 1_000;
+		String entry = "VoteReward%extime%1%placeholders%Server%pair%server-a";
+		ArrayList<String> timed = new ArrayList<>();
+		timed.add(entry + "%ExecutionTime/%" + due);
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT))
+				.thenReturn(new ArrayList<>(timed)).thenReturn(new ArrayList<>());
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")));
+
+		user.checkDelayedTimedRewards();
+
+		ArgumentCaptor<ArrayList<String>> saved = ArgumentCaptor.forClass(ArrayList.class);
+		verify(data, org.mockito.Mockito.times(2)).setStringList(eq("TimedRewards"), saved.capture());
+		assertEquals(timed, saved.getAllValues().get(1));
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -119,6 +119,26 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void legacyChoiceAdditionPreservesModernOccurrenceIdentity() {
+		AtomicReference<ArrayList<String>> stored = new AtomicReference<>(new ArrayList<>());
+		when(data.getStringList("UnClaimedChoices", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(stored.get()));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			stored.set(new ArrayList<>(invocation.getArgument(1)));
+			return null;
+		}).when(data).setStringList(eq("UnClaimedChoices"), any());
+
+		user.addUnClaimedChoiceReward("Modern", "occurrence-one");
+		String encodedModern = stored.get().get(0);
+		user.addUnClaimedChoiceReward("Legacy");
+		user.addUnClaimedChoiceReward("Modern", "occurrence-one");
+
+		assertEquals(List.of("Modern", "Legacy"), user.getUnClaimedChoices());
+		assertEquals(encodedModern, stored.get().get(0));
+		assertEquals(2, stored.get().size());
+	}
+
+	@Test
 	void checkOfflineRewards_preservesServerRequirementForNormalReplay() {
 		ArrayList<String> rewards = new ArrayList<>();
 		rewards.add("VoteReward%placeholders%Server%pair%server-a");

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -261,6 +261,31 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void deferredReplayAtomicallyReplacesItsExistingOccurrence() {
+		String occurrence = UUID.randomUUID().toString();
+		ArrayList<String> persisted = new ArrayList<>(List.of(
+				"old%asyncoccurrence%" + occurrence + "%placeholders%Server%pair%old",
+				"duplicate%asyncoccurrence%" + occurrence + "%placeholders%Server%pair%stale"));
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(persisted));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			persisted.clear();
+			persisted.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("offlineRewardsPath"), any());
+		Reward reward = mock(Reward.class);
+		when(reward.getRewardName()).thenReturn("VoteReward");
+		RewardOptions options = new RewardOptions().addPlaceholder("Server", "server-a");
+		options.setAsyncReplayOccurrenceId(occurrence);
+
+		user.addOfflineRewards(reward, options.getPlaceholders(), options);
+
+		assertEquals(1, persisted.size());
+		assertTrue(persisted.get(0).contains("%asyncoccurrence%" + occurrence));
+		assertTrue(persisted.get(0).contains("Server%pair%server-a"));
+	}
+
+	@Test
 	void replayClaimCleanupRechecksSharedStateUnderItsLock() throws Exception {
 		java.lang.reflect.Method replayClaims = AdvancedCoreUser.class.getDeclaredMethod("replayClaims");
 		replayClaims.setAccessible(true);

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -16,6 +16,9 @@ import java.util.Map;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -372,6 +375,53 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void timedRewardMutationsAreSharedAcrossUserWrappers() throws Exception {
+		java.util.concurrent.atomic.AtomicReference<ArrayList<String>> stored =
+				new java.util.concurrent.atomic.AtomicReference<>(new ArrayList<>());
+		java.util.concurrent.atomic.AtomicInteger reads = new java.util.concurrent.atomic.AtomicInteger();
+		CountDownLatch firstRead = new CountDownLatch(1);
+		CountDownLatch releaseFirstRead = new CountDownLatch(1);
+		CountDownLatch secondRead = new CountDownLatch(1);
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> {
+					if (reads.getAndIncrement() == 0) {
+						firstRead.countDown();
+						await(releaseFirstRead);
+					} else {
+						secondRead.countDown();
+					}
+					return new ArrayList<>(stored.get());
+				});
+		org.mockito.Mockito.doAnswer(invocation -> {
+			stored.set(new ArrayList<>(invocation.getArgument(1)));
+			return null;
+		}).when(data).setStringList(eq("TimedRewards"), any());
+		AdvancedCoreUser second = new AdvancedCoreUser(plugin, UUID.fromString(user.getUUID()), "Test");
+		second.setData(data);
+		Reward firstReward = mock(Reward.class);
+		Reward secondReward = mock(Reward.class);
+		when(firstReward.getRewardName()).thenReturn("First");
+		when(secondReward.getRewardName()).thenReturn("Second");
+		ExecutorService workers = Executors.newFixedThreadPool(2);
+		try {
+			java.util.concurrent.Future<?> first = workers.submit(
+					() -> user.addTimedReward(firstReward, new HashMap<>(), 1));
+			assertTrue(firstRead.await(5, TimeUnit.SECONDS));
+			java.util.concurrent.Future<?> secondTask = workers.submit(
+					() -> second.addTimedReward(secondReward, new HashMap<>(), 2));
+			assertFalse(secondRead.await(100, TimeUnit.MILLISECONDS));
+			releaseFirstRead.countDown();
+			first.get(10, TimeUnit.SECONDS);
+			secondTask.get(10, TimeUnit.SECONDS);
+		} finally {
+			releaseFirstRead.countDown();
+			workers.shutdownNow();
+		}
+
+		assertEquals(2, stored.get().size());
+	}
+
+	@Test
 	void unavailablePlayerFailsAsyncCommandDispatch() {
 		AdvancedCorePlugin.setInstance(plugin);
 		try (MockedStatic<Bukkit> bukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
@@ -477,6 +527,15 @@ public class AdvancedCoreUserTest {
 				.getDeclaredConstructor(Map.class, HashMap.class);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progress, placeholders);
+	}
+
+	private static void await(CountDownLatch latch) {
+		try {
+			latch.await();
+		} catch (InterruptedException failure) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(failure);
+		}
 	}
 
 	private Reward.ReplayCheckpoint replayCheckpoint(Map<String, Integer> progress, Map<String, String> fingerprints,

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -82,6 +82,43 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void unclaimedChoiceOccurrenceIsIdempotentButDistinctOccurrencesRemainClaimable() {
+		AtomicReference<ArrayList<String>> stored = new AtomicReference<>(new ArrayList<>());
+		when(data.getStringList("UnClaimedChoices", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(stored.get()));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			stored.set(new ArrayList<>(invocation.getArgument(1)));
+			return null;
+		}).when(data).setStringList(eq("UnClaimedChoices"), any());
+
+		user.addUnClaimedChoiceReward("ChoiceReward", "occurrence-one");
+		user.addUnClaimedChoiceReward("ChoiceReward", "occurrence-one");
+		user.addUnClaimedChoiceReward("ChoiceReward", "occurrence-two");
+
+		assertEquals(List.of("ChoiceReward", "ChoiceReward"), user.getUnClaimedChoices());
+		assertEquals(2, stored.get().size());
+		assertTrue(stored.get().stream().noneMatch("ChoiceReward"::equals));
+	}
+
+	@Test
+	void claimingOneOccurrencePreservesAnotherIdenticalChoiceReward() {
+		AtomicReference<ArrayList<String>> stored = new AtomicReference<>(new ArrayList<>());
+		when(data.getStringList("UnClaimedChoices", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(stored.get()));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			stored.set(new ArrayList<>(invocation.getArgument(1)));
+			return null;
+		}).when(data).setStringList(eq("UnClaimedChoices"), any());
+		user.addUnClaimedChoiceReward("ChoiceReward", "occurrence-one");
+		user.addUnClaimedChoiceReward("ChoiceReward", "occurrence-two");
+
+		user.removeUnClaimedChoiceReward("ChoiceReward");
+
+		assertEquals(List.of("ChoiceReward"), user.getUnClaimedChoices());
+		assertEquals(1, stored.get().size());
+	}
+
+	@Test
 	void checkOfflineRewards_preservesServerRequirementForNormalReplay() {
 		ArrayList<String> rewards = new ArrayList<>();
 		rewards.add("VoteReward%placeholders%Server%pair%server-a");

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -212,6 +212,29 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void legacyQueuedOccurrenceIsPersistedBeforeAnyAsyncInjectorRuns() {
+		ArrayList<String> persisted = new ArrayList<>(
+				List.of("VoteReward%placeholders%Server%pair%server-a"));
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(persisted));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			persisted.clear();
+			persisted.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("offlineRewardsPath"), any(), eq(false));
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(new CompletableFuture<>());
+
+		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkOfflineRewards();
+
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class), options.capture());
+		String occurrence = options.getValue().getAsyncReplayOccurrenceId();
+		assertTrue(occurrence != null && !occurrence.isEmpty());
+		assertTrue(persisted.get(0).contains("%asyncoccurrence%" + occurrence));
+	}
+
+	@Test
 	void deferredReplayRetainsOccurrenceAndCheckpoint() {
 		ArrayList<String> persisted = new ArrayList<>();
 		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT))
@@ -363,7 +386,13 @@ public class AdvancedCoreUserTest {
 		String entry = "VoteReward%extime%1%placeholders%Server%pair%server-a";
 		ArrayList<String> timed = new ArrayList<>();
 		timed.add(entry + "%ExecutionTime/%" + due);
-		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT)).thenReturn(new ArrayList<>(timed));
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(timed));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			timed.clear();
+			timed.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("TimedRewards"), any(), eq(false));
 		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
 				any(RewardOptions.class))).thenReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")));
 
@@ -441,11 +470,11 @@ public class AdvancedCoreUserTest {
 
 		assertEquals(2, persisted.size());
 		assertTrue(persisted.stream().anyMatch(value -> value.contains("%asyncprogress%v2-")));
-			assertTrue(persisted.stream().anyMatch(value -> value.equals(entry)));
+			assertTrue(persisted.stream().allMatch(value -> value.contains("%asyncoccurrence%")));
 			user.checkOfflineRewards();
 			verify(rewardHandler).givePersistedQueueRewardAsync(eq(user),
 					any(PersistedQueueReference.class), any(RewardOptions.class));
-			verify(data).setStringList(eq("offlineRewardsPath"), any(), eq(false));
+				verify(data, org.mockito.Mockito.atLeastOnce()).setStringList(eq("offlineRewardsPath"), any(), eq(false));
 
 			pending.complete(null);
 			verify(rewardHandler, org.mockito.Mockito.times(2)).givePersistedQueueRewardAsync(eq(user),
@@ -494,9 +523,10 @@ public class AdvancedCoreUserTest {
 				new HashMap<>(Map.of("Server", "server-a"))));
 
 		assertEquals(1, persisted.size());
-		assertTrue(persisted.get(0).startsWith("VoteReward%extime%12345%asyncprogress%v2-"));
+		assertTrue(persisted.get(0).startsWith("VoteReward%extime%12345%asyncoccurrence%"));
+		assertTrue(persisted.get(0).contains("%asyncprogress%v2-"));
 		assertTrue(persisted.get(0).endsWith("%ExecutionTime/%" + due));
-		verify(data).setStringList(eq("TimedRewards"), any(), eq(false));
+		verify(data, org.mockito.Mockito.atLeastOnce()).setStringList(eq("TimedRewards"), any(), eq(false));
 		// The key has migrated, but its in-flight claim must migrate with it too.
 		user.checkDelayedTimedRewards();
 		verify(rewardHandler, org.mockito.Mockito.times(1)).givePersistedQueueRewardAsync(eq(user),

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -271,6 +271,20 @@ public class AdvancedCoreUserTest {
 	}
 
 	@Test
+	void durableCheckpointTrimmingPreservesTheActiveEntry() throws Exception {
+		String active = "active-" + "a".repeat(70_000);
+		ArrayList<String> rewards = new ArrayList<>(List.of(active, "old-reward"));
+		java.lang.reflect.Method write = AdvancedCoreUser.class.getDeclaredMethod(
+				"setOfflineRewards", ArrayList.class, boolean.class, String.class);
+		write.setAccessible(true);
+
+		write.invoke(user, rewards, false, active);
+
+		assertEquals(List.of(active), rewards);
+		verify(data).setStringList("offlineRewardsPath", rewards, false);
+	}
+
+	@Test
 	void failedAsyncOfflineReplayIsRestoredForRetry() {
 		ArrayList<String> initial = new ArrayList<>();
 		initial.add("VoteReward%placeholders%Server%pair%server-a");

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -289,21 +289,25 @@ public class AdvancedCoreUserTest {
 		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
 				any(RewardOptions.class))).thenReturn(pending);
 
-		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
-		user.checkOfflineRewards();
-		verify(rewardHandler, org.mockito.Mockito.times(2)).givePersistedQueueRewardAsync(eq(user),
-				any(PersistedQueueReference.class), options.capture());
-		options.getAllValues().get(0).getAsyncReplayCheckpointConsumer().accept(replayCheckpoint(Map.of("VoteReward", 1),
-				new HashMap<>(Map.of("Server", "server-a"))));
+			ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+			user.checkOfflineRewards();
+			verify(rewardHandler).givePersistedQueueRewardAsync(eq(user),
+					any(PersistedQueueReference.class), options.capture());
+			options.getValue().getAsyncReplayCheckpointConsumer().accept(replayCheckpoint(Map.of("VoteReward", 1),
+					new HashMap<>(Map.of("Server", "server-a"))));
 
 		assertEquals(2, persisted.size());
 		assertTrue(persisted.stream().anyMatch(value -> value.contains("%asyncprogress%v2-")));
-		assertTrue(persisted.stream().anyMatch(value -> value.equals(entry)));
-		user.checkOfflineRewards();
-		verify(rewardHandler, org.mockito.Mockito.times(2)).givePersistedQueueRewardAsync(eq(user),
-				any(PersistedQueueReference.class), any(RewardOptions.class));
-		verify(data).setStringList(eq("offlineRewardsPath"), any(), eq(false));
-	}
+			assertTrue(persisted.stream().anyMatch(value -> value.equals(entry)));
+			user.checkOfflineRewards();
+			verify(rewardHandler).givePersistedQueueRewardAsync(eq(user),
+					any(PersistedQueueReference.class), any(RewardOptions.class));
+			verify(data).setStringList(eq("offlineRewardsPath"), any(), eq(false));
+
+			pending.complete(null);
+			verify(rewardHandler, org.mockito.Mockito.times(2)).givePersistedQueueRewardAsync(eq(user),
+					any(PersistedQueueReference.class), any(RewardOptions.class));
+		}
 
 	@Test
 	void timedAsyncReplayPreservesItsStoredCheckpointAfterExecutionMarker() {

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/AdvancedCoreUserTest.java
@@ -10,8 +10,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 
 import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
 import com.bencodez.advancedcore.AdvancedCorePlugin;
+import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.rewards.RewardHandler;
 import com.bencodez.advancedcore.api.rewards.RewardOptions;
 import com.bencodez.advancedcore.api.user.AdvancedCoreUser;
@@ -37,6 +42,7 @@ public class AdvancedCoreUserTest {
 	private UserDataManager dataManager;
 	private UserData data;
 	private RewardHandler rewardHandler;
+	private ScheduledExecutorService delayedTimer;
 	private AdvancedCoreUser user;
 
 	@BeforeEach
@@ -46,6 +52,7 @@ public class AdvancedCoreUserTest {
 		dataManager = mock(UserDataManager.class);
 		data = mock(UserData.class);
 		rewardHandler = mock(RewardHandler.class);
+		delayedTimer = mock(ScheduledExecutorService.class);
 		MySQL mysql = mock(MySQL.class);
 
 		AdvancedCoreConfigOptions configOptions = mock(AdvancedCoreConfigOptions.class);
@@ -55,6 +62,7 @@ public class AdvancedCoreUserTest {
 		when(userManager.getDataManager()).thenReturn(dataManager);
 		when(plugin.getUserManager()).thenReturn(userManager);
 		when(plugin.getRewardHandler()).thenReturn(rewardHandler);
+		when(rewardHandler.getDelayedTimer()).thenReturn(delayedTimer);
 		when(plugin.getStorageType()).thenReturn(UserStorage.MYSQL);
 		when(plugin.getLogger()).thenReturn(mock(Logger.class));
 		when(userManager.getOfflineRewardsPath()).thenReturn("offlineRewardsPath");
@@ -102,6 +110,23 @@ public class AdvancedCoreUserTest {
 		assertFalse(options.isGiveOffline());
 		assertFalse(options.isCheckTimed());
 		assertEquals("server-a", options.getPlaceholders().get("Server"));
+	}
+
+	@Test
+	void queuedAsyncReplayResumesAtItsStoredCheckpoint() {
+		ArrayList<String> rewards = new ArrayList<>();
+		rewards.add("VoteReward%asyncprogress%2%placeholders%Server%pair%server-a");
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT)).thenReturn(rewards);
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+
+		ArgumentCaptor<PersistedQueueReference> reference = ArgumentCaptor.forClass(PersistedQueueReference.class);
+		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkOfflineRewards();
+
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), reference.capture(), options.capture());
+		assertEquals("VoteReward", reference.getValue().getReference());
+		assertEquals(2, options.getValue().getCompletedAsyncInjections());
 	}
 
 	@Test
@@ -155,16 +180,15 @@ public class AdvancedCoreUserTest {
 		ArrayList<String> initial = new ArrayList<>();
 		initial.add("VoteReward%placeholders%Server%pair%server-a");
 		initial.add("VoteReward%placeholders%Server%pair%server-a");
-		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT))
-				.thenReturn(new ArrayList<>(initial)).thenReturn(new ArrayList<>());
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT)).thenReturn(new ArrayList<>(initial));
 		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
 				any(RewardOptions.class))).thenReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")));
 
 		user.checkOfflineRewards();
 
 		ArgumentCaptor<ArrayList<String>> saved = ArgumentCaptor.forClass(ArrayList.class);
-		verify(data, org.mockito.Mockito.times(3)).setStringList(eq("offlineRewardsPath"), saved.capture());
-		assertEquals(initial, saved.getAllValues().get(2));
+		verify(data, org.mockito.Mockito.atLeastOnce()).setStringList(eq("offlineRewardsPath"), saved.capture());
+		assertTrue(saved.getAllValues().stream().allMatch(value -> value.size() == initial.size()));
 	}
 
 	@Test
@@ -173,15 +197,181 @@ public class AdvancedCoreUserTest {
 		String entry = "VoteReward%extime%1%placeholders%Server%pair%server-a";
 		ArrayList<String> timed = new ArrayList<>();
 		timed.add(entry + "%ExecutionTime/%" + due);
-		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT))
-				.thenReturn(new ArrayList<>(timed)).thenReturn(new ArrayList<>());
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT)).thenReturn(new ArrayList<>(timed));
 		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
 				any(RewardOptions.class))).thenReturn(CompletableFuture.failedFuture(new IllegalStateException("temporary")));
 
 		user.checkDelayedTimedRewards();
 
 		ArgumentCaptor<ArrayList<String>> saved = ArgumentCaptor.forClass(ArrayList.class);
-		verify(data, org.mockito.Mockito.times(2)).setStringList(eq("TimedRewards"), saved.capture());
-		assertEquals(timed, saved.getAllValues().get(1));
+		verify(data).setStringList(eq("TimedRewards"), saved.capture());
+		String restored = saved.getValue().get(0);
+		assertTrue(restored.contains("%asyncretry%1%"));
+		assertTrue(restored.contains("VoteReward%extime%1"));
+		verify(delayedTimer).schedule(any(Runnable.class), org.mockito.ArgumentMatchers.anyLong(),
+				eq(TimeUnit.MILLISECONDS));
+	}
+
+	@Test
+	void pendingAsyncOfflineReplayRemainsDurableAndIsNotDispatchedTwice() {
+		ArrayList<String> rewards = new ArrayList<>();
+		rewards.add("VoteReward%placeholders%Server%pair%server-a");
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT)).thenReturn(rewards);
+		CompletableFuture<Void> pending = new CompletableFuture<>();
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(pending);
+
+		user.checkOfflineRewards();
+		user.checkOfflineRewards();
+
+		verify(rewardHandler, org.mockito.Mockito.times(1)).givePersistedQueueRewardAsync(eq(user),
+				any(PersistedQueueReference.class), any(RewardOptions.class));
+		verify(data, org.mockito.Mockito.never()).setStringList(eq("offlineRewardsPath"), any());
+		pending.complete(null);
+		assertTrue(rewards.isEmpty());
+		verify(data).setStringList(eq("offlineRewardsPath"), any());
+	}
+
+	@Test
+	void offlineCheckpointMigratesOnlyItsOwnDuplicateInFlightClaim() throws Exception {
+		String entry = "VoteReward%placeholders%Server%pair%server-a";
+		ArrayList<String> persisted = new ArrayList<>();
+		persisted.add(entry);
+		persisted.add(entry);
+		when(data.getStringList("offlineRewardsPath", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(persisted));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			persisted.clear();
+			persisted.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("offlineRewardsPath"), any(), eq(false));
+		CompletableFuture<Void> pending = new CompletableFuture<>();
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(pending);
+
+		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkOfflineRewards();
+		verify(rewardHandler, org.mockito.Mockito.times(2)).givePersistedQueueRewardAsync(eq(user),
+				any(PersistedQueueReference.class), options.capture());
+		options.getAllValues().get(0).getAsyncReplayCheckpointConsumer().accept(replayCheckpoint(Map.of("VoteReward", 1),
+				new HashMap<>(Map.of("Server", "server-a"))));
+
+		assertEquals(2, persisted.size());
+		assertTrue(persisted.stream().anyMatch(value -> value.contains("%asyncprogress%v2-")));
+		assertTrue(persisted.stream().anyMatch(value -> value.equals(entry)));
+		user.checkOfflineRewards();
+		verify(rewardHandler, org.mockito.Mockito.times(2)).givePersistedQueueRewardAsync(eq(user),
+				any(PersistedQueueReference.class), any(RewardOptions.class));
+		verify(data).setStringList(eq("offlineRewardsPath"), any(), eq(false));
+	}
+
+	@Test
+	void timedAsyncReplayPreservesItsStoredCheckpointAfterExecutionMarker() {
+		long due = System.currentTimeMillis() - 1_000;
+		ArrayList<String> timed = new ArrayList<>();
+		timed.add("VoteReward%extime%1%asyncprogress%2%placeholders%Server%pair%server-a%ExecutionTime/%" + due);
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT)).thenReturn(timed);
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+
+		ArgumentCaptor<PersistedQueueReference> reference = ArgumentCaptor.forClass(PersistedQueueReference.class);
+		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkDelayedTimedRewards();
+
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), reference.capture(), options.capture());
+		assertEquals("VoteReward", reference.getValue().getReference());
+		assertEquals(2, options.getValue().getCompletedAsyncInjections());
+	}
+
+	@Test
+	void timedAsyncCheckpointIsDurableAndMigratesTheExactEntryWhileInFlight() throws Exception {
+		long due = System.currentTimeMillis() - 1_000;
+		String original = "VoteReward%extime%12345%placeholders%Server%pair%server-a";
+		ArrayList<String> persisted = new ArrayList<>();
+		persisted.add(original + "%ExecutionTime/%" + due);
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(persisted));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			persisted.clear();
+			persisted.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("TimedRewards"), any(), eq(false));
+		CompletableFuture<Void> pending = new CompletableFuture<>();
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(pending);
+
+		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkDelayedTimedRewards();
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class), options.capture());
+		options.getValue().getAsyncReplayCheckpointConsumer().accept(replayCheckpoint(Map.of("VoteReward", 1),
+				new HashMap<>(Map.of("Server", "server-a"))));
+
+		assertEquals(1, persisted.size());
+		assertTrue(persisted.get(0).startsWith("VoteReward%extime%12345%asyncprogress%v2-"));
+		assertTrue(persisted.get(0).endsWith("%ExecutionTime/%" + due));
+		verify(data).setStringList(eq("TimedRewards"), any(), eq(false));
+		// The key has migrated, but its in-flight claim must migrate with it too.
+		user.checkDelayedTimedRewards();
+		verify(rewardHandler, org.mockito.Mockito.times(1)).givePersistedQueueRewardAsync(eq(user),
+				any(PersistedQueueReference.class), any(RewardOptions.class));
+	}
+
+	@Test
+	void timedAsyncCheckpointSurvivesRestartBeforeTheInFlightCompletion() throws Exception {
+		long due = System.currentTimeMillis() - 1_000;
+		ArrayList<String> persisted = new ArrayList<>();
+		persisted.add("VoteReward%extime%12345%placeholders%Server%pair%server-a%ExecutionTime/%" + due);
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT))
+				.thenAnswer(ignored -> new ArrayList<>(persisted));
+		org.mockito.Mockito.doAnswer(invocation -> {
+			persisted.clear();
+			persisted.addAll(invocation.getArgument(1));
+			return null;
+		}).when(data).setStringList(eq("TimedRewards"), any(), eq(false));
+		CompletableFuture<Void> pending = new CompletableFuture<>();
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(pending);
+
+		ArgumentCaptor<RewardOptions> firstOptions = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkDelayedTimedRewards();
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class), firstOptions.capture());
+		firstOptions.getValue().getAsyncReplayCheckpointConsumer().accept(replayCheckpoint(Map.of("root/Grant:0", 1),
+				new HashMap<>(Map.of("Server", "server-a"))));
+
+		AdvancedCoreUser restarted = new AdvancedCoreUser(plugin, UUID.randomUUID(), "Test");
+		restarted.setData(data);
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(restarted), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+		ArgumentCaptor<RewardOptions> resumed = ArgumentCaptor.forClass(RewardOptions.class);
+		restarted.checkDelayedTimedRewards();
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(restarted), any(PersistedQueueReference.class), resumed.capture());
+		assertEquals(1, resumed.getValue().getAsyncReplayProgress().get("root/Grant:0"));
+		assertEquals("server-a", resumed.getValue().getPlaceholders().get("Server"));
+	}
+
+	@Test
+	void timedRetryParsesProgressAfterTheExecutionMarkerWasConsumed() {
+		long due = System.currentTimeMillis() - 1_000;
+		ArrayList<String> timed = new ArrayList<>();
+		timed.add("VoteReward%asyncprogress%2%asyncretry%1%placeholders%Server%pair%server-a%ExecutionTime/%" + due);
+		when(data.getStringList("TimedRewards", UserDataFetchMode.DEFAULT)).thenReturn(timed);
+		when(rewardHandler.givePersistedQueueRewardAsync(eq(user), any(PersistedQueueReference.class),
+				any(RewardOptions.class))).thenReturn(CompletableFuture.completedFuture(null));
+
+		ArgumentCaptor<PersistedQueueReference> reference = ArgumentCaptor.forClass(PersistedQueueReference.class);
+		ArgumentCaptor<RewardOptions> options = ArgumentCaptor.forClass(RewardOptions.class);
+		user.checkDelayedTimedRewards();
+
+		verify(rewardHandler).givePersistedQueueRewardAsync(eq(user), reference.capture(), options.capture());
+		assertEquals("VoteReward", reference.getValue().getReference());
+		assertEquals(2, options.getValue().getCompletedAsyncInjections());
+	}
+
+	private Reward.ReplayCheckpoint replayCheckpoint(Map<String, Integer> progress,
+			HashMap<String, String> placeholders) throws Exception {
+		java.lang.reflect.Constructor<Reward.ReplayCheckpoint> constructor = Reward.ReplayCheckpoint.class
+				.getDeclaredConstructor(Map.class, HashMap.class);
+		constructor.setAccessible(true);
+		return constructor.newInstance(progress, placeholders);
 	}
 }

--- a/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
+++ b/AdvancedCore/src/test/java/com/bencodez/advancedcore/tests/user/UserDataCacheSchedulingTest.java
@@ -195,4 +195,35 @@ public class UserDataCacheSchedulingTest {
 
 		assertTrue(cache.isCached("PlayerName"));
 	}
+
+	@Test
+	public void flushChangesAndRunPersistsQueuedWritesBeforeTheSynchronousAction() {
+		AdvancedCorePlugin plugin = mock(AdvancedCorePlugin.class);
+		UserManager userManager = mock(UserManager.class);
+		AdvancedCoreUser user = mock(AdvancedCoreUser.class);
+		UserData userData = mock(UserData.class);
+		UserDataManager manager = mock(UserDataManager.class);
+		ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
+		ScheduledFuture future = mock(ScheduledFuture.class);
+		UUID uuid = UUID.randomUUID();
+
+		when(manager.getPlugin()).thenReturn(plugin);
+		when(manager.getTimer()).thenReturn(timer);
+		when(plugin.getUserManager()).thenReturn(userManager);
+		when(userManager.getUser(uuid, false)).thenReturn(user);
+		when(user.getUserData()).thenReturn(userData);
+		doReturn(future).when(timer).schedule(any(Runnable.class), eq(3L), eq(TimeUnit.SECONDS));
+
+		java.util.concurrent.atomic.AtomicBoolean flushed = new java.util.concurrent.atomic.AtomicBoolean();
+		doAnswer(ignored -> {
+			flushed.set(true);
+			return null;
+		}).when(userData).setValues(any(HashMap.class));
+		UserDataCache cache = new UserDataCache(manager, uuid);
+		cache.addChange(new UserDataChangeString("TimedRewards", "old-value"), true);
+
+		cache.flushChangesAndRun(() -> assertTrue(flushed.get(),
+				"the durable replay checkpoint must follow the queued cache flush"));
+		assertFalse(cache.hasChangesToProcess());
+	}
 }


### PR DESCRIPTION
## Summary
- add opt-in asynchronous reward injection hooks while preserving synchronous implementations
- execute injections in registration order, wait for durable asynchronous completion, and stop dependent rewards on failure
- serialize synchronized async injections through completion and resume Bukkit/Folia work through the server scheduler
- bound scheduler handoff during shutdown without timing out the underlying storage operation
- enable modern Surefire so the existing JUnit 5 suite and new regressions run under normal Maven commands

## Compatibility
Existing injection APIs and synchronous behavior remain available. Only injections that override `supportsAsyncRequest()` enter the async path. This PR is the dependency for the VotingPlugin #1600 durable shared-points reward fix and should merge/release before that consumer update.

## Validation
- `mvn test -Dtest=RewardAsyncInjectionTest` — 7 passed
- `mvn clean package` — 291 passed
- `git diff --check`
- JAR: `AdvancedCore/target/AdvancedCore.jar` SHA-256 `846a3fbc16fe9ca354d124b203655651ee146a6bf94672201e24be9fed5fe460`
- fresh independent read-only local review: no findings

AI assistance: Codex assisted with implementation, tests, and review.